### PR TITLE
Enforce project subscription restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ When one account hits a rate limit during an assistant turn, multi-pass automati
 
 Use `/pool project` to configure per-project subscription affinity. This creates `.pi/multi-pass.json` in your project directory.
 
+When `allowedSubs` is set, multi-pass now treats it as an exact allow-list for this project: active routing, pool membership, and chain traversal are all constrained to those provider names.
+
 ### Use case: separate work and personal accounts
 
 ```
@@ -100,7 +102,7 @@ cd ~/side-project
 
 | Feature | Description |
 |---|---|
-| **Restrict subs** | Only allow specific subscriptions in this project |
+| **Restrict subs** | Only allow specific provider names in this project (for example `openai-codex-2` or `openai-codex`) |
 | **Override pools** | Use different pools than global (or disable some) |
 | **Override chains** | Use different fallback chains than global |
 | **Clear** | Remove project config, fall back to global |
@@ -133,7 +135,7 @@ cd ~/side-project
 }
 ```
 
-- `allowedSubs`: whitelist of provider names. If set, only these (plus originals) are available. Omit to allow all.
+- `allowedSubs`: whitelist of exact provider names. If set, only those exact providers are available in this project. Omit to allow all.
 - `pools`: if set, replaces global pools for this project. Omit to inherit global pools.
 - `chains`: if set, replaces global chains for this project. Omit to inherit global chains.
 

--- a/extensions/multi-sub.ts
+++ b/extensions/multi-sub.ts
@@ -1448,9 +1448,9 @@ interface ProjectConfig {
 	pools?: PoolConfig[];
 	/** Override chains for this project. If set, replaces global chains. */
 	chains?: ChainConfig[];
-	/** Restrict which subscriptions can be used. Provider names (e.g. "openai-codex-2").
-	 *  If set, only these subs (plus the originals) are available in this project.
-	 *  If not set, all global subs are available. */
+	/** Restrict which provider names can be used in this project (for example
+	 *  "openai-codex" or "openai-codex-2"). If set, only these exact providers
+	 *  are available in this project. If not set, all global providers are available. */
 	allowedSubs?: string[];
 }
 
@@ -1459,6 +1459,8 @@ interface EffectiveConfig {
 	subscriptions: SubEntry[];
 	pools: PoolConfig[];
 	chains: ChainConfig[];
+	/** Exact provider names allowed in this project, if restricted. */
+	allowedProviderNames?: string[];
 	/** Which project config was loaded from, if any */
 	projectConfigPath?: string;
 }
@@ -1514,33 +1516,71 @@ function loadProjectConfig(cwd: string): ProjectConfig | undefined {
 	}
 }
 
+function normalizeAllowedProviderNames(allowedSubs: string[] | undefined): string[] | undefined {
+	if (!allowedSubs || allowedSubs.length === 0) return undefined;
+	const normalized = [...new Set(allowedSubs.map((value) => value.trim()).filter(Boolean))];
+	return normalized.length > 0 ? normalized : undefined;
+}
+
+function filterPoolsByAllowedProviders(
+	pools: PoolConfig[],
+	allowedProviderNames: string[] | undefined,
+): PoolConfig[] {
+	if (!allowedProviderNames || allowedProviderNames.length === 0) {
+		return pools;
+	}
+	const allowed = new Set(allowedProviderNames);
+	return pools
+		.map((pool) => ({
+			...pool,
+			members: pool.members.filter((member) => allowed.has(member)),
+		}))
+		.filter((pool) => pool.members.length > 0);
+}
+
+function filterChainsByAvailablePools(chains: ChainConfig[], pools: PoolConfig[]): ChainConfig[] {
+	const poolNames = new Set(pools.map((pool) => pool.name));
+	return chains
+		.map((chain) => ({
+			...chain,
+			entries: chain.entries.filter((entry) => poolNames.has(entry.pool)),
+		}))
+		.filter((chain) => chain.entries.length > 0);
+}
+
 function loadEffectiveConfig(cwd: string): EffectiveConfig {
 	const global = loadGlobalConfig();
+	const envEntries = parseEnvConfig();
+	const mergedSubscriptions = normalizeEntries(mergeConfigs(global, envEntries));
 	const project = loadProjectConfig(cwd);
 
 	if (!project) {
 		return {
-			subscriptions: global.subscriptions,
+			subscriptions: mergedSubscriptions,
 			pools: global.pools,
 			chains: global.chains,
 		};
 	}
 
-	// Subscriptions are always global, but filter if allowedSubs is set
-	let subs = global.subscriptions;
-	if (project.allowedSubs && project.allowedSubs.length > 0) {
-		const allowed = new Set(project.allowedSubs);
-		subs = global.subscriptions.filter((s) => allowed.has(subProviderName(s)));
+	const allowedProviderNames = normalizeAllowedProviderNames(project.allowedSubs);
+	let subs = mergedSubscriptions;
+	if (allowedProviderNames) {
+		const allowed = new Set(allowedProviderNames);
+		subs = mergedSubscriptions.filter((s) => allowed.has(subProviderName(s)));
 	}
 
-	// Pools/chains: project overrides global if defined
-	const pools = project.pools !== undefined ? project.pools : global.pools;
-	const chains = project.chains !== undefined ? project.chains : global.chains;
+	let pools = project.pools !== undefined ? project.pools : global.pools;
+	let chains = project.chains !== undefined ? project.chains : global.chains;
+	if (allowedProviderNames) {
+		pools = filterPoolsByAllowedProviders(pools, allowedProviderNames);
+		chains = filterChainsByAvailablePools(chains, pools);
+	}
 
 	return {
 		subscriptions: subs,
 		pools,
 		chains,
+		allowedProviderNames,
 		projectConfigPath: projectConfigPath(cwd),
 	};
 }
@@ -1557,6 +1597,82 @@ function saveProjectConfig(cwd: string, config: ProjectConfig): void {
 	const dir = dirname(path);
 	if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
 	writeFileSync(path, JSON.stringify(config, null, 2), "utf-8");
+}
+
+function getProviderDisplayName(providerName: string, subscriptions: SubEntry[]): string {
+	const subEntry = subscriptions.find((entry) => subProviderName(entry) === providerName);
+	if (subEntry) {
+		return subDisplayName(subEntry);
+	}
+	return PROVIDER_TEMPLATES[providerName]?.displayName || providerName;
+}
+
+function getProjectScopedProviderNames(
+	ctx: ExtensionContext | ExtensionCommandContext,
+	effective: EffectiveConfig,
+): string[] {
+	const seen = new Set<string>();
+	const providerNames: string[] = [];
+	const push = (providerName: string) => {
+		if (!providerName || seen.has(providerName)) return;
+		seen.add(providerName);
+		providerNames.push(providerName);
+	};
+
+	if (effective.allowedProviderNames && effective.allowedProviderNames.length > 0) {
+		for (const providerName of effective.allowedProviderNames) {
+			const isExtraSubscription = effective.subscriptions.some(
+				(entry) => subProviderName(entry) === providerName,
+			);
+			const isSupportedBaseProvider = SUPPORTED_PROVIDERS.includes(providerName);
+			if (!isExtraSubscription && !isSupportedBaseProvider) continue;
+			push(providerName);
+		}
+		return providerNames;
+	}
+
+	for (const providerName of SUPPORTED_PROVIDERS) {
+		if (ctx.modelRegistry.authStorage.hasAuth(providerName)) {
+			push(providerName);
+		}
+	}
+	for (const entry of effective.subscriptions) {
+		push(subProviderName(entry));
+	}
+	return providerNames;
+}
+
+function findSelectableModelForProvider(
+	ctx: ExtensionContext | ExtensionCommandContext,
+	providerName: string,
+	preferredModelId?: string,
+): Model<Api> | undefined {
+	if (!ctx.modelRegistry.authStorage.hasAuth(providerName)) {
+		return undefined;
+	}
+	if (preferredModelId) {
+		const preferred = ctx.modelRegistry.find(providerName, preferredModelId);
+		if (preferred) {
+			return preferred as Model<Api>;
+		}
+	}
+	const baseProvider = getBaseProvider(providerName);
+	if (!baseProvider) {
+		return undefined;
+	}
+	for (const baseModel of getModels(baseProvider as any) as Model<Api>[]) {
+		const candidate = ctx.modelRegistry.find(providerName, baseModel.id);
+		if (candidate) {
+			return candidate as Model<Api>;
+		}
+	}
+	return undefined;
+}
+
+function formatAllowedProviderSummary(effective: EffectiveConfig): string | undefined {
+	return effective.allowedProviderNames && effective.allowedProviderNames.length > 0
+		? effective.allowedProviderNames.join(", ")
+		: undefined;
 }
 
 // ==========================================================================
@@ -4136,35 +4252,88 @@ export default function multiSub(pi: ExtensionAPI) {
 	const poolManager = new PoolManager(pi);
 	poolManager.loadPools(config.pools);
 
+	let projectRestrictionSwitchInFlight = false;
+	const enforceProjectRestriction = async (
+		ctx: ExtensionContext | ExtensionCommandContext,
+		reason: "session" | "model" | "input",
+	): Promise<boolean> => {
+		if (projectRestrictionSwitchInFlight) return true;
+		const effective = loadEffectiveConfig(ctx.cwd);
+		const allowedSummary = formatAllowedProviderSummary(effective);
+		if (!allowedSummary) {
+			return true;
+		}
+		if (ctx.model && effective.allowedProviderNames?.includes(ctx.model.provider)) {
+			return true;
+		}
+
+		for (const providerName of getProjectScopedProviderNames(ctx, effective)) {
+			const model = findSelectableModelForProvider(ctx, providerName, ctx.model?.id);
+			if (!model) continue;
+
+			projectRestrictionSwitchInFlight = true;
+			try {
+				const success = await pi.setModel(model);
+				if (!success) continue;
+				const displayName = getProviderDisplayName(providerName, effective.subscriptions);
+				ctx.ui.notify(
+					`multi-pass: project restricted to ${allowedSummary}; switched to ${displayName} (${model.id}).`,
+					"info",
+				);
+				return true;
+			} finally {
+				projectRestrictionSwitchInFlight = false;
+			}
+		}
+
+		const currentModel = ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : "the current model";
+		ctx.ui.notify(
+			`multi-pass: project restricted to ${allowedSummary}, but no authenticated allowed provider can serve ${currentModel}.`,
+			"warning",
+		);
+		return false;
+	};
+
 	// On session start, reload pools with project-level config
 	pi.on("session_start", async (_event, ctx) => {
 		const effective = loadEffectiveConfig(ctx.cwd);
 		poolManager.loadPools(effective.pools);
 
+		const statusParts: string[] = [];
 		const enabledChains = effective.chains.filter((chain) => chain.enabled);
 		const activeChain = enabledChains[0];
 		if (activeChain) {
 			const firstEnabledEntry = activeChain.entries.find((entry) => entry.enabled);
 			if (firstEnabledEntry) {
-				ctx.ui.setStatus(
-					"multi-pass",
-					`chain:${activeChain.name} | starts ${firstEnabledEntry.pool} -> ${firstEnabledEntry.model}`,
-				);
-				return;
+				statusParts.push(`chain:${activeChain.name} | starts ${firstEnabledEntry.pool} -> ${firstEnabledEntry.model}`);
 			}
+		}
+		const allowedSummary = formatAllowedProviderSummary(effective);
+		if (allowedSummary) {
+			statusParts.push(`allowed ${allowedSummary}`);
+		} else {
+			const poolCount = effective.pools.filter((p) => p.enabled).length;
+			if (poolCount > 0 && !activeChain) {
+				statusParts.push(`${poolCount} pool(s)`);
+			}
+		}
+		if (statusParts.length > 0) {
+			ctx.ui.setStatus("multi-pass", statusParts.join(" | "));
 		}
 
-		const projectConf = loadProjectConfig(ctx.cwd);
-		if (projectConf) {
-			const poolCount = effective.pools.filter((p) => p.enabled).length;
-			const restricted = projectConf.allowedSubs && projectConf.allowedSubs.length > 0;
-			const parts: string[] = [];
-			if (poolCount > 0) parts.push(`${poolCount} pool(s)`);
-			if (restricted) parts.push(`restricted to ${projectConf.allowedSubs!.length} sub(s)`);
-			if (parts.length > 0) {
-				ctx.ui.setStatus("multi-pass", `project: ${parts.join(", ")}`);
-			}
+		await enforceProjectRestriction(ctx, "session");
+	});
+
+	pi.on("model_select", async (_event, ctx) => {
+		await enforceProjectRestriction(ctx, "model");
+	});
+
+	pi.on("input", async (event, ctx) => {
+		if (event.text.trimStart().startsWith("/")) {
+			return { action: "continue" as const };
 		}
+		const ok = await enforceProjectRestriction(ctx, "input");
+		return ok ? { action: "continue" as const } : { action: "handled" as const };
 	});
 
 	// Track last user prompt for retry on rotation

--- a/tests/project-restriction-check.mjs
+++ b/tests/project-restriction-check.mjs
@@ -1,0 +1,190 @@
+import assert from "node:assert/strict";
+
+function subProviderName(entry) {
+  return `${entry.provider}-${entry.index}`;
+}
+
+function normalizeEntries(entries) {
+  const byProvider = new Map();
+  for (const entry of entries) {
+    if (!byProvider.has(entry.provider)) byProvider.set(entry.provider, []);
+    byProvider.get(entry.provider).push(entry);
+  }
+
+  const normalized = [];
+  for (const [provider, list] of byProvider.entries()) {
+    const usedIndices = new Set(list.filter((e) => e.index > 0).map((e) => e.index));
+    if (list.some((e) => e.index === 0)) {
+      let nextIndex = 2;
+      while (usedIndices.has(nextIndex)) nextIndex += 1;
+      normalized.push({ provider, index: nextIndex });
+      usedIndices.add(nextIndex);
+    }
+    for (const entry of list.filter((e) => e.index > 0).sort((a, b) => a.index - b.index)) {
+      normalized.push(entry);
+    }
+  }
+  return normalized;
+}
+
+function mergeConfigs(fileConfig, envEntries) {
+  const merged = [...fileConfig.subscriptions];
+  for (const envEntry of envEntries) {
+    const existingCount = merged.filter((s) => s.provider === envEntry.provider).length;
+    const envCountForProvider = envEntries.filter((e) => e.provider === envEntry.provider).length;
+    if (existingCount < envCountForProvider) {
+      const usedIndices = merged
+        .filter((s) => s.provider === envEntry.provider)
+        .map((s) => s.index);
+      let nextIndex = 2;
+      while (usedIndices.includes(nextIndex)) nextIndex += 1;
+      merged.push({ provider: envEntry.provider, index: nextIndex });
+    }
+  }
+  return merged;
+}
+
+function normalizeAllowedProviderNames(allowedSubs) {
+  if (!allowedSubs || allowedSubs.length === 0) return undefined;
+  const normalized = [...new Set(allowedSubs.map((value) => value.trim()).filter(Boolean))];
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function filterPoolsByAllowedProviders(pools, allowedProviderNames) {
+  if (!allowedProviderNames || allowedProviderNames.length === 0) {
+    return pools;
+  }
+  const allowed = new Set(allowedProviderNames);
+  return pools
+    .map((pool) => ({
+      ...pool,
+      members: pool.members.filter((member) => allowed.has(member)),
+    }))
+    .filter((pool) => pool.members.length > 0);
+}
+
+function filterChainsByAvailablePools(chains, pools) {
+  const poolNames = new Set(pools.map((pool) => pool.name));
+  return chains
+    .map((chain) => ({
+      ...chain,
+      entries: chain.entries.filter((entry) => poolNames.has(entry.pool)),
+    }))
+    .filter((chain) => chain.entries.length > 0);
+}
+
+function buildEffectiveConfig(globalConfig, projectConfig, envEntries = []) {
+  const mergedSubscriptions = normalizeEntries(mergeConfigs(globalConfig, envEntries));
+  if (!projectConfig) {
+    return {
+      subscriptions: mergedSubscriptions,
+      pools: globalConfig.pools,
+      chains: globalConfig.chains,
+      allowedProviderNames: undefined,
+    };
+  }
+
+  const allowedProviderNames = normalizeAllowedProviderNames(projectConfig.allowedSubs);
+  let subscriptions = mergedSubscriptions;
+  if (allowedProviderNames) {
+    const allowed = new Set(allowedProviderNames);
+    subscriptions = mergedSubscriptions.filter((entry) => allowed.has(subProviderName(entry)));
+  }
+
+  let pools = projectConfig.pools !== undefined ? projectConfig.pools : globalConfig.pools;
+  let chains = projectConfig.chains !== undefined ? projectConfig.chains : globalConfig.chains;
+  if (allowedProviderNames) {
+    pools = filterPoolsByAllowedProviders(pools, allowedProviderNames);
+    chains = filterChainsByAvailablePools(chains, pools);
+  }
+
+  return { subscriptions, pools, chains, allowedProviderNames };
+}
+
+function runExactProviderRestrictionCheck() {
+  const globalConfig = {
+    subscriptions: [{ provider: "openai-codex", index: 2, label: "mw" }],
+    pools: [
+      {
+        name: "codex-work",
+        baseProvider: "openai-codex",
+        members: ["openai-codex", "openai-codex-2"],
+        enabled: true,
+      },
+      {
+        name: "copilot-backup",
+        baseProvider: "github-copilot",
+        members: ["github-copilot"],
+        enabled: true,
+      },
+    ],
+    chains: [
+      {
+        name: "primary",
+        enabled: true,
+        entries: [
+          { pool: "codex-work", model: "gpt-5", enabled: true },
+          { pool: "copilot-backup", model: "gpt-5", enabled: true },
+        ],
+      },
+    ],
+  };
+
+  const effective = buildEffectiveConfig(globalConfig, { allowedSubs: ["openai-codex-2"] });
+
+  assert.deepEqual(effective.allowedProviderNames, ["openai-codex-2"]);
+  assert.deepEqual(effective.subscriptions.map(subProviderName), ["openai-codex-2"]);
+  assert.deepEqual(effective.pools, [
+    {
+      name: "codex-work",
+      baseProvider: "openai-codex",
+      members: ["openai-codex-2"],
+      enabled: true,
+    },
+  ]);
+  assert.deepEqual(effective.chains, [
+    {
+      name: "primary",
+      enabled: true,
+      entries: [{ pool: "codex-work", model: "gpt-5", enabled: true }],
+    },
+  ]);
+}
+
+function runBaseProviderAllowedCheck() {
+  const globalConfig = {
+    subscriptions: [{ provider: "openai-codex", index: 2 }],
+    pools: [
+      {
+        name: "codex-base",
+        baseProvider: "openai-codex",
+        members: ["openai-codex"],
+        enabled: true,
+      },
+    ],
+    chains: [],
+  };
+
+  const effective = buildEffectiveConfig(globalConfig, { allowedSubs: ["openai-codex"] });
+  assert.deepEqual(effective.allowedProviderNames, ["openai-codex"]);
+  assert.deepEqual(effective.subscriptions.map(subProviderName), []);
+  assert.deepEqual(effective.pools[0].members, ["openai-codex"]);
+}
+
+function runUnrestrictedEnvMergeCheck() {
+  const globalConfig = {
+    subscriptions: [],
+    pools: [],
+    chains: [],
+  };
+  const envEntries = [{ provider: "openai-codex", index: 0 }];
+
+  const effective = buildEffectiveConfig(globalConfig, undefined, envEntries);
+  assert.deepEqual(effective.subscriptions.map(subProviderName), ["openai-codex-2"]);
+  assert.equal(effective.allowedProviderNames, undefined);
+}
+
+runExactProviderRestrictionCheck();
+runBaseProviderAllowedCheck();
+runUnrestrictedEnvMergeCheck();
+console.log("project restriction checks passed");


### PR DESCRIPTION
## Summary
- treat `allowedSubs` as an exact project allow-list for provider names
- constrain effective pools/chains to allowed providers
- auto-switch away from disallowed active providers on session start and before prompts
- update project-affinity docs and add focused regression coverage

## Testing
- node tests/pool-edit-check.mjs
- node tests/project-restriction-check.mjs
- node tests/runtime-failover-check.mjs
- node tests/subscription-limits-check.mjs