### PR TITLE
Add a manual /subs switch command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ pi install git:github.com/hjanuschka/pi-multi-pass
 ```
 /subs add              Pick a provider, add a subscription
 /login                 Authenticate the new subscription
+/subs switch           Manually switch to another subscription/provider
 /subs limits           Check built-in quota support (Codex + Google)
 /pool create           Group subs into a rotation pool
 /pool chain create     Build an ordered fallback chain across pools
@@ -47,6 +48,7 @@ When one account hits a rate limit during an assistant turn, multi-pass automati
 /subs remove       Remove a subscription
 /subs login        Login to a subscription
 /subs logout       Logout from a subscription
+/subs switch       Manually switch to a subscription/provider now
 /subs list         List subscriptions with auth status; select one for quick actions
 /subs status       Detailed status (token expiry, pool membership)
 /subs limits       Check built-in quota/usage support (Codex + Google)

--- a/extensions/multi-sub.ts
+++ b/extensions/multi-sub.ts
@@ -2198,6 +2198,127 @@ function formatSubscriptionListLine(
 	return `${subDisplayName(entry)} -- ${formatSubscriptionMeta(entry, config, authStorage)}`;
 }
 
+function normalizeSwitchAllowedProviderNames(cwd: string): string[] | undefined {
+	const project = loadProjectConfig(cwd);
+	if (!project?.allowedSubs || project.allowedSubs.length === 0) return undefined;
+	const normalized = [...new Set(project.allowedSubs.map((value) => value.trim()).filter(Boolean))];
+	return normalized.length > 0 ? normalized : undefined;
+}
+
+function getSwitchableProviderOptions(
+	ctx: ExtensionContext | ExtensionCommandContext,
+): Array<{ providerName: string; label: string; description: string }> {
+	const config = loadGlobalConfig();
+	const envEntries = parseEnvConfig();
+	const allSubs = normalizeEntries(mergeConfigs(config, envEntries));
+	const allowedProviderNames = normalizeSwitchAllowedProviderNames(ctx.cwd);
+	const allowed = allowedProviderNames ? new Set(allowedProviderNames) : undefined;
+	const options: Array<{ providerName: string; label: string; description: string }> = [];
+	const seen = new Set<string>();
+	const push = (providerName: string, label: string, description: string) => {
+		if (allowed && !allowed.has(providerName)) return;
+		if (!ctx.modelRegistry.authStorage.hasAuth(providerName)) return;
+		if (seen.has(providerName)) return;
+		seen.add(providerName);
+		options.push({ providerName, label, description });
+	};
+
+	for (const providerName of SUPPORTED_PROVIDERS) {
+		push(
+			providerName,
+			PROVIDER_TEMPLATES[providerName]?.displayName || providerName,
+			"base provider",
+		);
+	}
+	for (const entry of allSubs) {
+		push(subProviderName(entry), subDisplayName(entry), "extra subscription");
+	}
+	return options;
+}
+
+function resolveSwitchTargetModel(
+	ctx: ExtensionContext | ExtensionCommandContext,
+	providerName: string,
+	preferredModelId?: string,
+): Model<Api> | undefined {
+	if (!ctx.modelRegistry.authStorage.hasAuth(providerName)) {
+		return undefined;
+	}
+	if (preferredModelId) {
+		const preferred = ctx.modelRegistry.find(providerName, preferredModelId);
+		if (preferred) {
+			return preferred as Model<Api>;
+		}
+	}
+	const baseProvider = getBaseProvider(providerName);
+	if (!baseProvider) {
+		return undefined;
+	}
+	for (const baseModel of getModels(baseProvider as any) as Model<Api>[]) {
+		const candidate = ctx.modelRegistry.find(providerName, baseModel.id);
+		if (candidate) {
+			return candidate as Model<Api>;
+		}
+	}
+	return undefined;
+}
+
+async function handleSubsSwitch(
+	pi: ExtensionAPI,
+	ctx: ExtensionCommandContext,
+	requestedProviderName?: string,
+): Promise<void> {
+	const options = getSwitchableProviderOptions(ctx);
+	if (options.length === 0) {
+		const allowedProviderNames = normalizeSwitchAllowedProviderNames(ctx.cwd);
+		const suffix = allowedProviderNames && allowedProviderNames.length > 0
+			? ` for this project restriction (${allowedProviderNames.join(", ")})`
+			: "";
+		ctx.ui.notify(`No authenticated subscriptions are available to switch${suffix}.`, "info");
+		return;
+	}
+
+	let providerName = requestedProviderName?.trim();
+	if (!providerName) {
+		providerName = await showWrappedSelect(ctx, {
+			title: "Switch Subscription",
+			subtitle: "Select the subscription/provider to use now.",
+			items: options.map((option) => ({
+				value: option.providerName,
+				label: option.label,
+				description: option.description,
+			})),
+			initialValue: ctx.model?.provider,
+			confirmHint: "switch",
+			cancelHint: "back",
+		});
+		if (!providerName) return;
+	}
+
+	const selected = options.find((option) => option.providerName === providerName);
+	if (!selected) {
+		ctx.ui.notify(`Subscription not available for switching: ${providerName}`, "error");
+		return;
+	}
+
+	const nextModel = resolveSwitchTargetModel(ctx, selected.providerName, ctx.model?.id);
+	if (!nextModel) {
+		ctx.ui.notify(`No selectable models found for ${selected.label}.`, "error");
+		return;
+	}
+	if (ctx.model?.provider === nextModel.provider && ctx.model?.id === nextModel.id) {
+		ctx.ui.notify(`Already using ${selected.label} (${nextModel.id}).`, "info");
+		return;
+	}
+
+	const success = await pi.setModel(nextModel);
+	if (!success) {
+		ctx.ui.notify(`Failed to switch to ${selected.label}.`, "error");
+		return;
+	}
+	ctx.ui.notify(`Switched to ${selected.label} (${nextModel.id}).`, "info");
+}
+
 async function renameSubscriptionLabel(
 	ctx: ExtensionCommandContext,
 	config: MultiPassConfig,
@@ -4075,6 +4196,7 @@ async function handleSubsMenu(
 		{ value: "remove", label: "remove", description: "Remove a subscription" },
 		{ value: "login", label: "login", description: "Login to a subscription" },
 		{ value: "logout", label: "logout", description: "Logout from a subscription" },
+		{ value: "switch", label: "switch", description: "Switch to a different subscription/provider now" },
 		{ value: "status", label: "status", description: "Show auth status and token info" },
 		{ value: "limits", label: "limits", description: "Check built-in quota support (Codex + Google)" },
 	];
@@ -4107,6 +4229,9 @@ async function handleSubsMenu(
 				break;
 			case "logout":
 				await handleSubsLogout(ctx);
+				break;
+			case "switch":
+				await handleSubsSwitch(pi, ctx);
 				break;
 			case "status":
 				await handleSubsStatus(ctx);
@@ -4223,7 +4348,7 @@ export default function multiSub(pi: ExtensionAPI) {
 	pi.registerCommand("subs", {
 		description: "Manage extra OAuth subscriptions",
 		getArgumentCompletions: (prefix: string) => {
-			const subcommands = ["list", "add", "remove", "login", "logout", "status", "limits"];
+			const subcommands = ["list", "add", "remove", "login", "logout", "switch", "status", "limits"];
 			const filtered = subcommands.filter((s) => s.startsWith(prefix));
 			return filtered.length > 0
 				? filtered.map((s) => ({ value: s, label: s }))
@@ -4231,7 +4356,9 @@ export default function multiSub(pi: ExtensionAPI) {
 		},
 		handler: async (args: string, ctx: ExtensionCommandContext) => {
 			const config = loadGlobalConfig();
-			const subcommand = args.trim().toLowerCase();
+			const parts = args.trim().split(/\s+/).filter(Boolean);
+			const subcommand = (parts[0] || "").toLowerCase();
+			const rest = parts.slice(1).join(" ");
 			switch (subcommand) {
 				case "list":
 				case "ls":
@@ -4247,6 +4374,8 @@ export default function multiSub(pi: ExtensionAPI) {
 					return handleSubsLogin(ctx);
 				case "logout":
 					return handleSubsLogout(ctx);
+				case "switch":
+					return handleSubsSwitch(pi, ctx, rest || undefined);
 				case "status":
 				case "info":
 					return handleSubsStatus(ctx);

--- a/tests/subs-switch-check.mjs
+++ b/tests/subs-switch-check.mjs
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+
+function subProviderName(entry) {
+  return `${entry.provider}-${entry.index}`;
+}
+
+function normalizeEntries(entries) {
+  const byProvider = new Map();
+  for (const entry of entries) {
+    if (!byProvider.has(entry.provider)) byProvider.set(entry.provider, []);
+    byProvider.get(entry.provider).push(entry);
+  }
+
+  const normalized = [];
+  for (const [provider, list] of byProvider.entries()) {
+    const usedIndices = new Set(list.filter((e) => e.index > 0).map((e) => e.index));
+    if (list.some((e) => e.index === 0)) {
+      let nextIndex = 2;
+      while (usedIndices.has(nextIndex)) nextIndex += 1;
+      normalized.push({ provider, index: nextIndex });
+      usedIndices.add(nextIndex);
+    }
+    for (const entry of list.filter((e) => e.index > 0).sort((a, b) => a.index - b.index)) {
+      normalized.push(entry);
+    }
+  }
+  return normalized;
+}
+
+function mergeConfigs(fileConfig, envEntries) {
+  const merged = [...fileConfig.subscriptions];
+  for (const envEntry of envEntries) {
+    const existingCount = merged.filter((s) => s.provider === envEntry.provider).length;
+    const envCountForProvider = envEntries.filter((e) => e.provider === envEntry.provider).length;
+    if (existingCount < envCountForProvider) {
+      const usedIndices = merged
+        .filter((s) => s.provider === envEntry.provider)
+        .map((s) => s.index);
+      let nextIndex = 2;
+      while (usedIndices.includes(nextIndex)) nextIndex += 1;
+      merged.push({ provider: envEntry.provider, index: nextIndex });
+    }
+  }
+  return merged;
+}
+
+function normalizeSwitchAllowedProviderNames(projectConfig) {
+  if (!projectConfig?.allowedSubs || projectConfig.allowedSubs.length === 0) return undefined;
+  const normalized = [...new Set(projectConfig.allowedSubs.map((value) => value.trim()).filter(Boolean))];
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function getSwitchableProviderNames({ baseProviders, subscriptions, hasAuth, allowedProviderNames }) {
+  const allSubs = normalizeEntries(mergeConfigs({ subscriptions }, []));
+  const allowed = allowedProviderNames ? new Set(allowedProviderNames) : undefined;
+  const names = [];
+  const seen = new Set();
+
+  const push = (providerName) => {
+    if (allowed && !allowed.has(providerName)) return;
+    if (!hasAuth(providerName)) return;
+    if (seen.has(providerName)) return;
+    seen.add(providerName);
+    names.push(providerName);
+  };
+
+  for (const providerName of baseProviders) {
+    push(providerName);
+  }
+  for (const entry of allSubs) {
+    push(subProviderName(entry));
+  }
+  return names;
+}
+
+function resolveSwitchTargetModel({ providerName, preferredModelId, hasAuth, providerModels, baseProviderLookup }) {
+  if (!hasAuth(providerName)) return undefined;
+  const models = providerModels[providerName] || [];
+  if (preferredModelId && models.some((model) => model.id === preferredModelId)) {
+    return models.find((model) => model.id === preferredModelId);
+  }
+  const baseProvider = baseProviderLookup(providerName);
+  if (!baseProvider) return undefined;
+  const baseModels = providerModels[baseProvider] || [];
+  for (const baseModel of baseModels) {
+    const candidate = models.find((model) => model.id === baseModel.id);
+    if (candidate) return candidate;
+  }
+  return undefined;
+}
+
+function runAllowedProviderFilteringCheck() {
+  const providerNames = getSwitchableProviderNames({
+    baseProviders: ["openai-codex"],
+    subscriptions: [{ provider: "openai-codex", index: 2 }],
+    hasAuth: (providerName) => providerName === "openai-codex" || providerName === "openai-codex-2",
+    allowedProviderNames: normalizeSwitchAllowedProviderNames({ allowedSubs: ["openai-codex-2"] }),
+  });
+
+  assert.deepEqual(providerNames, ["openai-codex-2"]);
+}
+
+function runPreferredModelCheck() {
+  const model = resolveSwitchTargetModel({
+    providerName: "openai-codex-2",
+    preferredModelId: "gpt-5.4",
+    hasAuth: () => true,
+    providerModels: {
+      "openai-codex": [{ id: "gpt-5.4" }, { id: "gpt-5.3-codex" }],
+      "openai-codex-2": [{ id: "gpt-5.4" }, { id: "gpt-5.3-codex" }],
+    },
+    baseProviderLookup: (providerName) => providerName.replace(/-\d+$/, ""),
+  });
+
+  assert.equal(model?.id, "gpt-5.4");
+}
+
+function runFallbackModelCheck() {
+  const model = resolveSwitchTargetModel({
+    providerName: "openai-codex-2",
+    preferredModelId: "gpt-5.4",
+    hasAuth: () => true,
+    providerModels: {
+      "openai-codex": [{ id: "gpt-5.4" }, { id: "gpt-5.3-codex" }],
+      "openai-codex-2": [{ id: "gpt-5.3-codex" }],
+    },
+    baseProviderLookup: (providerName) => providerName.replace(/-\d+$/, ""),
+  });
+
+  assert.equal(model?.id, "gpt-5.3-codex");
+}
+
+runAllowedProviderFilteringCheck();
+runPreferredModelCheck();
+runFallbackModelCheck();
+console.log("subs switch checks passed");


### PR DESCRIPTION
## Summary
- add `/subs switch` for manual provider/subscription switching
- reuse the current model when the target provider supports it, with fallback to the first compatible model
- respect project allow-lists when offering switch targets
- document the new command and add focused regression coverage

## Testing
- node tests/pool-edit-check.mjs
- node tests/runtime-failover-check.mjs
- node tests/subs-switch-check.mjs
- node tests/subscription-limits-check.mjs