### PR TITLE
Scope subscription limits to project allow-lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ Google quota is not a single flat subscription bucket, so the details view shows
 
 `/subs limits` is an on-demand snapshot. It helps you see which account looks healthiest right now, but it does not proactively switch models by itself. Automatic switching still happens when the active provider returns a rate-limit-style runtime error and that provider belongs to an enabled pool or chain.
 
+When a project defines `.pi/multi-pass.json` with `allowedSubs`, `/subs limits` only shows accounts allowed in that project.
+
 Future providers can add another checker without changing the `/subs` command surface.
 
 ## Environment variable (optional)

--- a/extensions/multi-sub.ts
+++ b/extensions/multi-sub.ts
@@ -1192,13 +1192,23 @@ async function checkGoogleQuotaAccount(
 	}
 }
 
+function normalizeQuotaAllowedProviderNames(cwd: string): string[] | undefined {
+	const project = loadProjectConfig(cwd);
+	if (!project?.allowedSubs || project.allowedSubs.length === 0) return undefined;
+	const normalized = [...new Set(project.allowedSubs.map((value) => value.trim()).filter(Boolean))];
+	return normalized.length > 0 ? normalized : undefined;
+}
+
 function collectQuotaAccounts(ctx: ExtensionContext): QuotaAccount[] {
 	const config = loadGlobalConfig();
 	const envEntries = parseEnvConfig();
 	const allSubs = normalizeEntries(mergeConfigs(config, envEntries));
+	const allowedProviderNames = normalizeQuotaAllowedProviderNames(ctx.cwd);
+	const allowed = allowedProviderNames ? new Set(allowedProviderNames) : undefined;
 	const seen = new Set<string>();
 	const accounts: QuotaAccount[] = [];
 	const pushAccount = (providerName: string, displayName: string) => {
+		if (allowed && !allowed.has(providerName)) return;
 		if (seen.has(providerName)) return;
 		seen.add(providerName);
 		accounts.push({
@@ -1368,10 +1378,14 @@ async function showQuotaDetails(
 }
 
 async function handleSubsLimits(ctx: ExtensionCommandContext): Promise<void> {
+	const allowedProviderNames = normalizeQuotaAllowedProviderNames(ctx.cwd);
 	const accounts = collectQuotaAccounts(ctx);
 	if (accounts.length === 0) {
+		const suffix = allowedProviderNames && allowedProviderNames.length > 0
+			? ` for this project restriction (${allowedProviderNames.join(", ")})`
+			: "";
 		ctx.ui.notify(
-			"No supported subscription limits are available yet. Login to a supported provider first.",
+			`No supported subscription limits are available yet${suffix}. Login to a supported provider first.`,
 			"info",
 		);
 		return;

--- a/tests/project-aware-limits-check.mjs
+++ b/tests/project-aware-limits-check.mjs
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+
+function subProviderName(entry) {
+  return `${entry.provider}-${entry.index}`;
+}
+
+function normalizeEntries(entries) {
+  const byProvider = new Map();
+  for (const entry of entries) {
+    if (!byProvider.has(entry.provider)) byProvider.set(entry.provider, []);
+    byProvider.get(entry.provider).push(entry);
+  }
+
+  const normalized = [];
+  for (const [provider, list] of byProvider.entries()) {
+    const usedIndices = new Set(list.filter((e) => e.index > 0).map((e) => e.index));
+    if (list.some((e) => e.index === 0)) {
+      let nextIndex = 2;
+      while (usedIndices.has(nextIndex)) nextIndex += 1;
+      normalized.push({ provider, index: nextIndex });
+      usedIndices.add(nextIndex);
+    }
+    for (const entry of list.filter((e) => e.index > 0).sort((a, b) => a.index - b.index)) {
+      normalized.push(entry);
+    }
+  }
+  return normalized;
+}
+
+function mergeConfigs(fileConfig, envEntries) {
+  const merged = [...fileConfig.subscriptions];
+  for (const envEntry of envEntries) {
+    const existingCount = merged.filter((s) => s.provider === envEntry.provider).length;
+    const envCountForProvider = envEntries.filter((e) => e.provider === envEntry.provider).length;
+    if (existingCount < envCountForProvider) {
+      const usedIndices = merged
+        .filter((s) => s.provider === envEntry.provider)
+        .map((s) => s.index);
+      let nextIndex = 2;
+      while (usedIndices.includes(nextIndex)) nextIndex += 1;
+      merged.push({ provider: envEntry.provider, index: nextIndex });
+    }
+  }
+  return merged;
+}
+
+function normalizeQuotaAllowedProviderNames(projectConfig) {
+  if (!projectConfig?.allowedSubs || projectConfig.allowedSubs.length === 0) return undefined;
+  const normalized = [...new Set(projectConfig.allowedSubs.map((value) => value.trim()).filter(Boolean))];
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function collectQuotaProviderNames({ checkers, subscriptions, hasAuth, allowedProviderNames }) {
+  const allSubs = normalizeEntries(mergeConfigs({ subscriptions }, []));
+  const allowed = allowedProviderNames ? new Set(allowedProviderNames) : undefined;
+  const seen = new Set();
+  const providerNames = [];
+
+  const push = (providerName) => {
+    if (allowed && !allowed.has(providerName)) return;
+    if (seen.has(providerName)) return;
+    seen.add(providerName);
+    providerNames.push(providerName);
+  };
+
+  for (const checker of checkers) {
+    if (hasAuth(checker.baseProvider)) {
+      push(checker.baseProvider);
+    }
+    for (const entry of allSubs) {
+      if (entry.provider !== checker.baseProvider) continue;
+      push(subProviderName(entry));
+    }
+  }
+
+  return providerNames;
+}
+
+function runRestrictedExtraSubscriptionCheck() {
+  const providerNames = collectQuotaProviderNames({
+    checkers: [{ baseProvider: "openai-codex" }],
+    subscriptions: [{ provider: "openai-codex", index: 2, label: "mw" }],
+    hasAuth: (providerName) => providerName === "openai-codex" || providerName === "openai-codex-2",
+    allowedProviderNames: normalizeQuotaAllowedProviderNames({ allowedSubs: ["openai-codex-2"] }),
+  });
+
+  assert.deepEqual(providerNames, ["openai-codex-2"]);
+}
+
+function runRestrictedBaseProviderCheck() {
+  const providerNames = collectQuotaProviderNames({
+    checkers: [{ baseProvider: "openai-codex" }],
+    subscriptions: [{ provider: "openai-codex", index: 2 }],
+    hasAuth: (providerName) => providerName === "openai-codex" || providerName === "openai-codex-2",
+    allowedProviderNames: normalizeQuotaAllowedProviderNames({ allowedSubs: ["openai-codex"] }),
+  });
+
+  assert.deepEqual(providerNames, ["openai-codex"]);
+}
+
+function runUnrestrictedCheck() {
+  const providerNames = collectQuotaProviderNames({
+    checkers: [{ baseProvider: "openai-codex" }],
+    subscriptions: [{ provider: "openai-codex", index: 2 }],
+    hasAuth: (providerName) => providerName === "openai-codex" || providerName === "openai-codex-2",
+    allowedProviderNames: undefined,
+  });
+
+  assert.deepEqual(providerNames, ["openai-codex", "openai-codex-2"]);
+}
+
+runRestrictedExtraSubscriptionCheck();
+runRestrictedBaseProviderCheck();
+runUnrestrictedCheck();
+console.log("project-aware limits checks passed");


### PR DESCRIPTION
## Summary
- make `/subs limits` respect project-level `allowedSubs` filters
- keep quota snapshots aligned with the providers allowed in the current project
- document the project-aware limits behavior and add regression coverage

## Testing
- node tests/pool-edit-check.mjs
- node tests/project-aware-limits-check.mjs
- node tests/runtime-failover-check.mjs
- node tests/subscription-limits-check.mjs