### PR TITLE
feat: leeloo.js -- OpenAI-compatible proxy (Phase 1 of #10)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ Multi-subscription extension for [pi](https://github.com/badlogic/pi-mono) -- us
   - [How routing works](#how-routing-works)
   - [Chat UI](#chat-ui)
   - [Persistent data files](#persistent-data-files)
+  - [Routing v2: modes, rules, intent routing](#routing-v2-modes-rules-intent-routing)
+    - [Why v2](#why-v2)
+    - [Concepts](#concepts)
+    - [Built-in routing rule types](#built-in-routing-rule-types)
+    - [JSON config example](#json-config-example)
+    - [JS config (multi-pass.config.js)](#js-config-multi-passconfigjs)
+    - [Routing tab in admin](#routing-tab-in-admin)
+    - [CLI commands](#cli-commands)
   - [Integration guides](#integration-guides)
     - [pi coding agent](#pi-coding-agent)
     - [Cursor](#cursor)
@@ -593,6 +601,217 @@ Chat completion responses include extra fields:
 | `~/.pi/agent/leeloo-audit.jsonl` | Audit log (rule violations, persisted) |
 | `~/.pi/agent/leeloo-usage.jsonl` | Usage log (per-user request tracking) |
 | `~/.pi/agent/auth.json` | OAuth credentials |
+
+### Routing v2: modes, rules, intent routing
+
+The original pool/chain/preset model is great at same-provider failover. v2 adds **cross-provider intent routing** -- pick a provider per request based on time, quota, cost, or your own JS rules.
+
+#### Why v2
+
+Old model: `pool` = group of accounts of the same provider, with one strategy. `chain` = static fallover order. `preset` = ordered list of provider/model entries.
+
+New model: `mode` = a list of candidates (any mix of accounts, pools, or other modes) plus a pipeline of `rules` that filter and rank candidates per request. The router applies all rules, sorts by score, then tries the top candidate -- with `re-evaluate` on error so rules see the new context.
+
+You can mix:
+- 10 OpenAI keys (round-robin via a pool)
+- 1 Anthropic Pro account
+- 1 OpenRouter API key
+- 1 Copilot subscription
+
+...all in one `coding-premium` mode that prefers Anthropic during evening hours, burns expiring quotas first, and falls back to OpenRouter for cheap simple tasks.
+
+#### Concepts
+
+| Concept | Purpose |
+|---|---|
+| `accounts` | Unified primitive: any access point (subscription or apiKey) |
+| `pools` | Same-provider rotation (still useful) |
+| `routingRules` | Reusable decision functions: filter, score, or both |
+| `modes` | Cross-provider routing pipeline: candidates + rules + onError |
+| `presets` | Client-facing virtual model: maps to a mode + preferred/fallback models |
+
+Routing pipeline:
+
+```
+preset -> mode -> expand candidates (accounts/pools/nested modes)
+       -> filter exhausted -> apply rules in order (filter + score)
+       -> sort by total score -> try top candidate
+       -> on error: re-evaluate (rules see the error context)
+```
+
+Mode candidates can include other modes (composition, max depth 5, cycles detected at load time).
+
+Rules return `{ candidates, scores }` -- they can shrink the array (filter) and/or contribute to per-candidate scores. Total score is summed across all rules. Sort descending.
+
+#### Built-in routing rule types
+
+| Type | What it does | Key params |
+|---|---|---|
+| `time-window` | Score boost during specified hours/days | targets, windows, boost |
+| `quota-burn` | Boost candidates whose quota expires soonest | -- |
+| `cost-tier` | Boost cheap/free targets | targets, boost |
+| `model-fit` | Filter by required context size, tools, vision | minContext, requireTools, requireVision |
+| `error-blacklist` | Filter recently errored candidates | windowMinutes |
+| `cooldown` | Filter exhausted candidates (always-on) | -- |
+| `custom` | Run inline JS function (JS config) or file path (JSON) | fn or code |
+
+#### JSON config example
+
+Add to `~/.pi/agent/multi-pass.json`:
+
+```json
+{
+  "subscriptions": [...],
+  "pools": [
+    { "name": "codex-shared", "baseProvider": "openai-codex", "members": ["openai-codex", "openai-codex-2"], "strategy": "round-robin", "enabled": true }
+  ],
+  "routingRules": [
+    {
+      "id": "prefer-anthropic-evening",
+      "type": "time-window",
+      "params": {
+        "targets": ["anthropic"],
+        "windows": [{ "days": ["mon", "tue", "wed", "thu", "fri"], "hours": [18, 23] }],
+        "boost": 100
+      }
+    },
+    {
+      "id": "burn-expiring-first",
+      "type": "quota-burn"
+    }
+  ],
+  "modes": [
+    {
+      "id": "coding-premium",
+      "description": "Best quality coding mode",
+      "candidates": ["anthropic", "pool:codex-shared"],
+      "rules": ["prefer-anthropic-evening", "burn-expiring-first"],
+      "onError": "re-evaluate"
+    }
+  ],
+  "presets": [
+    {
+      "name": "coding-premium-v2",
+      "mode": "coding-premium",
+      "preferredModels": ["claude-sonnet-4-20250514", "gpt-5.1"],
+      "fallbackModels": ["claude-haiku", "gpt-5.0-mini"],
+      "enabled": true
+    }
+  ]
+}
+```
+
+When a client sends `model: "coding-premium-v2"`:
+1. Resolve preset -> mode `coding-premium`
+2. Expand candidates: `anthropic` + members of `codex-shared` pool
+3. Filter exhausted (always applied)
+4. Run `prefer-anthropic-evening` -- boosts anthropic +100 if it's a weekday evening
+5. Run `burn-expiring-first` -- boosts whichever account's quota expires soonest
+6. Sort by total score, try the top candidate with `claude-sonnet-4-20250514`
+7. On error: re-evaluate (rules re-run with the failed candidate in `ctx.history`)
+
+#### JS config (multi-pass.config.js)
+
+For power users who want IntelliSense, env vars, imports, and inline custom rules. Place at `~/.pi/agent/multi-pass.config.js`:
+
+```js
+import { defineConfig, account, pool, mode, preset, rule } from
+  "/path/to/pi-multi-pass/config.js";
+
+export default defineConfig({
+  accounts: [
+    account("anthropic", { provider: "anthropic", kind: "subscription" }),
+    account("openai-codex", { provider: "openai-codex", kind: "subscription" }),
+    account("openrouter", {
+      provider: "openrouter",
+      kind: "apiKey",
+      key: process.env.OPENROUTER_KEY,
+    }),
+  ],
+
+  pools: [
+    pool("codex-shared", {
+      baseProvider: "openai-codex",
+      members: ["openai-codex", "openai-codex-2"],
+      strategy: "round-robin",
+    }),
+  ],
+
+  rules: [
+    rule.timeWindow("prefer-anthropic-evening", {
+      targets: ["anthropic"],
+      windows: [{ days: ["mon", "tue", "wed", "thu", "fri"], hours: [18, 23] }],
+      boost: 100,
+    }),
+
+    rule.quotaBurn("burn-expiring-first"),
+
+    rule.costTier("prefer-cheap", {
+      targets: ["openrouter"],
+      boost: 30,
+    }),
+
+    // Inline custom rule -- no separate file
+    rule.custom("avoid-personal-models", async (candidates, ctx) => {
+      return {
+        candidates: candidates.filter((c) => !c.id.includes("personal")),
+      };
+    }),
+  ],
+
+  modes: [
+    mode("coding-premium", {
+      candidates: ["anthropic", "codex-shared"],
+      rules: ["prefer-anthropic-evening", "burn-expiring-first", "avoid-personal-models"],
+      onError: "re-evaluate",
+    }),
+
+    mode("coding-budget", {
+      candidates: ["openrouter", "codex-shared"],
+      rules: ["prefer-cheap"],
+      onError: "next-in-order",
+    }),
+  ],
+
+  presets: [
+    preset("coding-premium", {
+      mode: "coding-premium",
+      preferredModels: ["claude-sonnet-4-20250514", "gpt-5.1"],
+    }),
+    preset("coding-budget", {
+      mode: "coding-budget",
+      preferredModels: ["gpt-5.1-mini"],
+    }),
+  ],
+});
+```
+
+When `multi-pass.config.js` exists, the JSON config is ignored and the admin UI becomes read-only (banner shown). Edit the JS file directly. Hot-reloads on file change.
+
+#### Routing tab in admin
+
+`/admin` -> **Routing** tab provides:
+
+- **Routing rules** editor: form per rule type, drag-to-reorder
+- **Modes** editor: candidate picker (drag-to-reorder), rule list (drag-to-reorder), onError dropdown
+- **Presets** editor: type selector (v2 with mode + preferred models | v1 legacy entries)
+
+When JS config is detected, the tab shows a read-only banner and all edit buttons are hidden.
+
+#### CLI commands
+
+```bash
+# Initial setup wizard
+node leeloo.js init
+
+# Migrate v1 JSON config to v2 shape
+# (creates a backup, generates accounts/modes from existing data)
+node leeloo.js migrate
+
+# Export JSON config to multi-pass.config.js template
+node leeloo.js export-js
+# Then update the import path and move to ~/.pi/agent/multi-pass.config.js
+```
 
 ### Integration guides
 

--- a/README.md
+++ b/README.md
@@ -602,7 +602,7 @@ All routing, failover, DLP rules, and budget enforcement happen transparently --
 
 ### pi coding agent
 
-pi can use Leeloo as its provider backend. Create a custom provider config:
+[pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) can use Leeloo as its provider backend. Create a custom provider config:
 
 `~/.pi/agent/providers.json`:
 ```json

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ pi install git:github.com/hjanuschka/pi-multi-pass
 - **Smart pool strategies**: `round-robin`, `quota-first`, `scheduled` (time windows), `custom` (JS script hook)
 - **Fallback chains**: Define ordered cross-pool/model failover via `/pool chain`
 - **Model presets**: Named routing shortcuts across providers (`/mp-preset coding-premium`)
+- **Leeloo proxy**: OpenAI-compatible local proxy with full pool/chain/preset routing, chat UI, and quota dashboard (`npx pi-multi-pass`)
 - **Built-in limits checks**: Inspect subscription headroom across accounts with `/subs limits`
 - **Smarter retries**: Preserve failover progress across internal replay retries
 - **Project affinity**: Restrict which subs/pools/chains are used per project
@@ -345,6 +346,147 @@ Presets are stored in `~/.pi/agent/multi-pass.json`:
 
 Presets work with pools: if an entry's provider belongs to a pool, rate-limit failover still rotates within that pool before trying the next preset entry.
 
+## Leeloo -- OpenAI-compatible proxy
+
+Leeloo is a standalone local proxy that exposes all of multi-pass's routing intelligence as a standard OpenAI-compatible API. Point any tool, editor, or script at it and get automatic pool rotation, chain failover, preset routing, and quota-aware selection -- no pi integration required.
+
+### Quick start
+
+```bash
+# Run directly (installs deps automatically)
+npx pi-multi-pass
+
+# Or with a custom port
+npx pi-multi-pass --port 8080
+
+# Then point your tools at it
+export OPENAI_BASE_URL=http://localhost:4000/v1
+```
+
+Open `http://localhost:4000/ui` for the built-in chat UI with streaming markdown, model/pool/preset picker, and live quota dashboard.
+
+### Endpoints
+
+| Endpoint | Description |
+|---|---|
+| `POST /v1/chat/completions` | Chat completions (streaming + non-streaming, tools, images) |
+| `GET /v1/models` | List all available models + presets |
+| `GET /v1/routing` | Models grouped by presets, pools, providers (used by chat UI) |
+| `GET /v1/quota` | Detailed quota per provider (windows, reset times, model-level) |
+| `GET /v1/stats` | Usage stats: per-provider aggregates + recent request log |
+| `GET /health` | Provider status, pools, chains, presets, exhausted state |
+| `GET /ui` | Chat UI |
+
+### How routing works
+
+The `model` field in a chat completion request can be:
+
+| Format | Example | Behavior |
+|---|---|---|
+| Preset name | `coding-premium` | Tries preset entries in order. If an entry's provider is in a pool, all pool members are tried (with strategy) before moving to the next entry. |
+| Pool + model | `pool:codex-pool/gpt-5.1` | Routes through the pool's members using its strategy (quota-first, scheduled, custom, round-robin). |
+| Pool only | `pool:codex-pool` | Same as above, auto-picks the default model for the pool's base provider. |
+| Provider + model | `provider:anthropic/claude-sonnet-4-20250514` | Routes to that specific provider. |
+| Raw model ID | `claude-sonnet-4-20250514` | Finds any provider that serves this model, prefers pool members. |
+
+### Failover
+
+On rate limit errors, Leeloo automatically:
+
+1. Marks the provider as exhausted (5-minute cooldown, same as the extension)
+2. Tries the next candidate in the ordered list (up to 5 attempts)
+3. Pool strategies (quota-first, scheduled, custom) are applied when ordering candidates
+4. Chain entries are traversed in order, each chain pool's strategy is applied
+5. Preset entries expand to full pool membership before trying the next preset entry
+
+### Pool strategy support
+
+All four strategies work in the proxy, same as the extension:
+
+| Strategy | Proxy behavior |
+|---|---|
+| `round-robin` | Sequential pool member order |
+| `quota-first` | Queries Codex usage API (5h/7d windows) and Google quota APIs, sorts by remaining headroom |
+| `scheduled` | Evaluates time windows, roles (preferred/default/overflow), shortest-remaining-first |
+| `custom` | Loads and runs JS selector scripts with same `PoolSelectorContext` interface |
+
+### Quota endpoints
+
+`GET /v1/quota` returns detailed per-provider quota data:
+
+```json
+{
+  "providers": [
+    {
+      "provider": "openai-codex",
+      "label": "ChatGPT Plus/Pro (Codex)",
+      "score": 85,
+      "status": "ready",
+      "plan": "plus",
+      "email": "user@example.com",
+      "windows": [
+        { "name": "5-hour", "used": 15, "remaining": 85, "resetAt": "2025-06-01T14:00:00Z" },
+        { "name": "7-day", "used": 5, "remaining": 95, "resetAt": "2025-06-07T09:00:00Z" }
+      ]
+    },
+    {
+      "provider": "google-gemini-cli",
+      "label": "Google Cloud Code Assist",
+      "score": 100,
+      "status": "ready",
+      "models": [
+        { "model": "Pro", "remaining": 100, "resetAt": "2025-06-01T12:00:00Z" },
+        { "model": "Flash", "remaining": 100, "resetAt": "2025-06-01T12:00:00Z" }
+      ]
+    }
+  ]
+}
+```
+
+`GET /v1/stats` returns usage tracking:
+
+```json
+{
+  "session": {
+    "total_requests": 42,
+    "total_tokens_in": 12500,
+    "total_tokens_out": 8300,
+    "total_errors": 1
+  },
+  "providers": [
+    { "provider": "anthropic", "label": "Anthropic (Claude Pro/Max)", "requests": 30, "tokens_in": 9000, "tokens_out": 6000, "errors": 0, "last_used": "..." }
+  ],
+  "recent": [
+    { "timestamp": "...", "provider": "anthropic", "model": "claude-sonnet-4-20250514", "tokens_in": 300, "tokens_out": 200, "duration_ms": 1200, "error": null }
+  ]
+}
+```
+
+### Chat UI
+
+The built-in chat UI at `/ui` includes:
+
+- **Model picker**: grouped by Presets, Pools (with strategy labels), and Providers
+- **Streaming markdown**: live rendering via [streaming-markdown](https://github.com/thetarnav/streaming-markdown)
+- **Thinking indicator**: animated spinner while waiting for first token
+- **Response footer**: shows preset/pool name, actual provider label, model ID, token counts, response time
+- **Config strip**: always-visible top bar showing pools (with strategy), presets, and per-provider quota bars with color coding (green >50%, yellow 20-50%, red <20%)
+- **Quota auto-refresh**: bars update after each response
+
+### Response metadata
+
+Chat completion responses include extra fields showing the actual routing:
+
+```json
+{
+  "x_provider": "openai-codex",
+  "x_model": "gpt-5.1",
+  "x_label": "ChatGPT Plus/Pro (Codex)"
+}
+```
+
+For streaming, these fields appear in the final chunk (alongside `usage`).
+
 ## Supported providers
 
 | Provider key | Service |
@@ -387,7 +529,8 @@ Env entries merge with saved config.
 
 | File | Scope | Contains |
 |---|---|---|
-| `~/.pi/agent/multi-pass.json` | Global | Subscriptions + pools + chains |
+| `~/.pi/agent/multi-pass.json` | Global | Subscriptions + pools + chains + presets |
+| `~/.pi/agent/auth.json` | Global | OAuth credentials (used by extension + Leeloo) |
 | `.pi/multi-pass.json` | Project | Pool/chain overrides + sub restrictions |
 
 ## License

--- a/README.md
+++ b/README.md
@@ -346,9 +346,9 @@ Presets are stored in `~/.pi/agent/multi-pass.json`:
 
 Presets work with pools: if an entry's provider belongs to a pool, rate-limit failover still rotates within that pool before trying the next preset entry.
 
-## Leeloo -- OpenAI-compatible proxy
+## Leeloo -- OpenAI-compatible proxy & admin
 
-Leeloo is a standalone local proxy that exposes all of multi-pass's routing intelligence as a standard OpenAI-compatible API. Point any tool, editor, or script at it and get automatic pool rotation, chain failover, preset routing, and quota-aware selection -- no pi integration required.
+Leeloo is a standalone local proxy that exposes all of multi-pass's routing intelligence as a standard OpenAI-compatible API. It includes a full admin dashboard for managing configuration, users, DLP rules, and observability -- plus a chat UI for testing. Point any tool, editor, or script at it and get automatic pool rotation, chain failover, preset routing, and quota-aware selection.
 
 ### Quick start
 
@@ -359,27 +359,149 @@ npx pi-multi-pass
 # Or with a custom port
 npx pi-multi-pass --port 8080
 
-# Local dev mode with auto-restart on leeloo/web changes
-# (run from repo root)
+# Set a persistent admin token (random if not set)
+LEELOO_KEY=my-secret-token npx pi-multi-pass
+
+# Local dev mode with auto-restart on file changes
 yarn web-dev
 
 # Then point your tools at it
 export OPENAI_BASE_URL=http://localhost:4000/v1
+export OPENAI_API_KEY=<admin-token-or-user-key>
 ```
 
-Open `http://localhost:4000/ui` for the built-in chat UI with streaming markdown, model/pool/preset picker, and live quota dashboard.
+On startup, Leeloo prints an admin token to the console. Use this token for `/admin` access and API authentication.
 
-### Endpoints
+### Web interfaces
 
-| Endpoint | Description |
+| URL | Description |
 |---|---|
-| `POST /v1/chat/completions` | Chat completions (streaming + non-streaming, tools, images) |
-| `GET /v1/models` | List all available models + presets |
-| `GET /v1/routing` | Models grouped by presets, pools, providers (used by chat UI) |
-| `GET /v1/quota` | Detailed quota per provider (windows, reset times, model-level) |
-| `GET /v1/stats` | Usage stats: per-provider aggregates + recent request log |
-| `GET /health` | Provider status, pools, chains, presets, exhausted state |
-| `GET /ui` | Chat UI |
+| `http://localhost:4000/admin` | Admin dashboard (requires admin token) |
+| `http://localhost:4000/ui` | Chat UI (accepts admin or user token) |
+
+Both require token login on first visit.
+
+### API endpoints
+
+All `/v1/*` endpoints require `Authorization: Bearer <token>` header.
+
+| Endpoint | Auth | Description |
+|---|---|---|
+| `POST /v1/chat/completions` | any token | Chat completions (streaming + non-streaming, tools, images) |
+| `GET /v1/models` | any token | List all available models + presets |
+| `GET /v1/routing` | any token | Models grouped by presets, pools, providers |
+| `GET /v1/quota` | admin | Detailed quota per provider |
+| `GET /v1/stats` | admin | Usage stats + per-user + recent request log |
+| `GET/POST /v1/rules` | admin | Policy rules CRUD |
+| `GET /v1/audit` | admin | Rule violation audit log |
+| `GET/POST /v1/users` | admin | User management CRUD |
+| `GET/PUT /v1/config` | admin | Multi-pass config editor |
+| `POST /v1/auth/login/:provider` | admin | Start OAuth login flow |
+| `POST /v1/auth/verify` | public | Verify a token (for login screens) |
+| `GET /health` | public | Provider status, pools, exhausted state |
+
+### Authentication & users
+
+Leeloo uses token-based authentication at two levels:
+
+**Admin token** -- full access to all endpoints, config, rules, users:
+```bash
+# Set via environment (persists across restarts)
+LEELOO_KEY=my-admin-token npx pi-multi-pass
+
+# Or let Leeloo generate a random one (shown in startup banner)
+npx pi-multi-pass
+```
+
+**User tokens** -- scoped access for sharing with team members:
+```bash
+# Create a user via API
+curl -X POST http://localhost:4000/v1/users \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"username":"alice","allowedPresets":["coding-premium","fastest"]}'
+
+# Response includes the API key
+# {"user":{"username":"alice","key":"abc123...","allowedPresets":["coding-premium","fastest"]}}
+
+# Alice can now use the proxy
+export OPENAI_API_KEY=abc123...
+```
+
+User access restrictions:
+
+| Field | Effect |
+|---|---|
+| `allowedPresets` | Whitelist of preset names (empty = all) |
+| `allowedPools` | Whitelist of pool names, matched as `pool:name` (empty = all) |
+| `enabled` | Toggle user on/off without deleting |
+
+Users are stored in `~/.pi/agent/multi-pass-users.json`.
+
+### Admin dashboard
+
+The admin UI (`/admin`) provides a full control plane:
+
+**Dashboard tab:**
+- Session stats (requests, tokens, errors)
+- Provider health with quota bars and status badges
+- Per-user usage table (requests, tokens, errors per user)
+- Recent chats with expandable request/response previews + user column
+
+**Config tab:**
+- OAuth accounts: login/logout/re-login, add extra accounts per provider
+- Pools: create/edit with drag-to-reorder members, strategy picker, schedule editor
+- Chains: create/edit with drag-to-reorder failover steps
+- Presets: create/edit with drag-to-reorder entries
+- All changes saved to `~/.pi/agent/multi-pass.json` immediately
+
+**Users tab:**
+- Create users with auto-generated API keys
+- Edit allowed presets/pools via chip picker dropdowns
+- Enable/disable, reveal/copy keys, delete
+- Per-user stats shown on each card
+
+**Rules tab:**
+- Create/edit DLP policy rules (block, redact, warn, model, limit)
+- Toggle rules on/off, persisted to `~/.pi/agent/multi-pass-rules.json`
+
+**Audit tab:**
+- Filterable audit log of all rule violations
+- Inline character-level diffs for redaction events (red strikethrough = removed, green = replacement)
+- Persisted to `~/.pi/agent/leeloo-audit.jsonl` (survives restarts)
+
+### DLP / policy rules
+
+Leeloo can intercept and enforce policies on both requests and responses:
+
+| Rule type | What it does |
+|---|---|
+| `block` | Reject if regex pattern matches (AWS keys, private keys, connection strings) |
+| `redact` | Replace pattern matches with placeholder before sending to LLM (`[EMAIL]`, `[REDACTED]`) |
+| `warn` | Log to audit trail but allow through |
+| `model` | Allow/deny model lists with glob patterns |
+| `limit` | Rate limiting (max N requests per M seconds) |
+
+Rules apply to `request`, `response`, or `both` scopes. Examples:
+
+```bash
+# Block AWS access keys in prompts
+curl -X POST http://localhost:4000/v1/rules \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"block-aws-keys","type":"block","scope":"request",
+       "patterns":["AKIA[0-9A-Z]{16}"],"message":"Blocked: AWS key detected"}'
+
+# Redact email addresses in both directions
+curl -X POST http://localhost:4000/v1/rules \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"redact-emails","type":"redact","scope":"both",
+       "patterns":["[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}"],
+       "replacement":"[EMAIL]"}'
+```
+
+Rules are stored in `~/.pi/agent/multi-pass-rules.json` (separate from main config).
 
 ### How routing works
 
@@ -387,99 +509,37 @@ The `model` field in a chat completion request can be:
 
 | Format | Example | Behavior |
 |---|---|---|
-| Preset name | `coding-premium` | Tries preset entries in order. If an entry's provider is in a pool, all pool members are tried (with strategy) before moving to the next entry. |
-| Pool + model | `pool:codex-pool/gpt-5.1` | Routes through the pool's members using its strategy (quota-first, scheduled, custom, round-robin). |
-| Pool only | `pool:codex-pool` | Same as above, auto-picks the default model for the pool's base provider. |
-| Provider + model | `provider:anthropic/claude-sonnet-4-20250514` | Routes to that specific provider. |
-| Raw model ID | `claude-sonnet-4-20250514` | Finds any provider that serves this model, prefers pool members. |
+| Preset name | `coding-premium` | Tries preset entries in order with pool failover |
+| Pool + model | `pool:codex-pool/gpt-5.1` | Routes through pool members using strategy |
+| Pool only | `pool:codex-pool` | Auto-picks the default model |
+| Provider + model | `provider:anthropic/claude-sonnet-4-20250514` | Direct provider routing |
+| Raw model ID | `claude-sonnet-4-20250514` | Finds any provider that serves this model |
 
 ### Failover
 
 On rate limit errors, Leeloo automatically:
 
-1. Marks the provider as exhausted (5-minute cooldown, same as the extension)
-2. Tries the next candidate in the ordered list (up to 5 attempts)
-3. Pool strategies (quota-first, scheduled, custom) are applied when ordering candidates
-4. Chain entries are traversed in order, each chain pool's strategy is applied
-5. Preset entries expand to full pool membership before trying the next preset entry
-
-### Pool strategy support
-
-All four strategies work in the proxy, same as the extension:
-
-| Strategy | Proxy behavior |
-|---|---|
-| `round-robin` | Sequential pool member order |
-| `quota-first` | Queries Codex usage API (5h/7d windows) and Google quota APIs, sorts by remaining headroom |
-| `scheduled` | Evaluates time windows, roles (preferred/default/overflow), shortest-remaining-first |
-| `custom` | Loads and runs JS selector scripts with same `PoolSelectorContext` interface |
-
-### Quota endpoints
-
-`GET /v1/quota` returns detailed per-provider quota data:
-
-```json
-{
-  "providers": [
-    {
-      "provider": "openai-codex",
-      "label": "ChatGPT Plus/Pro (Codex)",
-      "score": 85,
-      "status": "ready",
-      "plan": "plus",
-      "email": "user@example.com",
-      "windows": [
-        { "name": "5-hour", "used": 15, "remaining": 85, "resetAt": "2025-06-01T14:00:00Z" },
-        { "name": "7-day", "used": 5, "remaining": 95, "resetAt": "2025-06-07T09:00:00Z" }
-      ]
-    },
-    {
-      "provider": "google-gemini-cli",
-      "label": "Google Cloud Code Assist",
-      "score": 100,
-      "status": "ready",
-      "models": [
-        { "model": "Pro", "remaining": 100, "resetAt": "2025-06-01T12:00:00Z" },
-        { "model": "Flash", "remaining": 100, "resetAt": "2025-06-01T12:00:00Z" }
-      ]
-    }
-  ]
-}
-```
-
-`GET /v1/stats` returns usage tracking:
-
-```json
-{
-  "session": {
-    "total_requests": 42,
-    "total_tokens_in": 12500,
-    "total_tokens_out": 8300,
-    "total_errors": 1
-  },
-  "providers": [
-    { "provider": "anthropic", "label": "Anthropic (Claude Pro/Max)", "requests": 30, "tokens_in": 9000, "tokens_out": 6000, "errors": 0, "last_used": "..." }
-  ],
-  "recent": [
-    { "timestamp": "...", "provider": "anthropic", "model": "claude-sonnet-4-20250514", "tokens_in": 300, "tokens_out": 200, "duration_ms": 1200, "error": null }
-  ]
-}
-```
+1. Marks the provider as exhausted (5-minute cooldown)
+2. Tries the next candidate (up to 5 attempts)
+3. Pool strategies are applied when ordering candidates
+4. Chain entries are traversed in order
+5. Preset entries expand to full pool membership
 
 ### Chat UI
 
 The built-in chat UI at `/ui` includes:
 
-- **Model picker**: grouped by Presets, Pools (with strategy labels), and Providers
-- **Streaming markdown**: live rendering via [streaming-markdown](https://github.com/thetarnav/streaming-markdown)
-- **Thinking indicator**: animated spinner while waiting for first token
-- **Response footer**: shows preset/pool name, actual provider label, model ID, token counts, response time
-- **Config strip**: always-visible top bar showing pools (with strategy), presets, and per-provider quota bars with color coding (green >50%, yellow 20-50%, red <20%)
-- **Quota auto-refresh**: bars update after each response
+- **Markdown rendering** with syntax highlighting (JS, Python, Bash, Rust, C++, etc.)
+- **Copy button** on code blocks
+- **Model picker** grouped by Presets, Pools, Providers
+- **Streaming** with animated thinking indicator
+- **Response metadata** (route, provider, model, tokens, duration)
+- **Quota bars** with color coding (green >50%, yellow 20-50%, red <20%)
+- **Token login** with localStorage persistence
 
 ### Response metadata
 
-Chat completion responses include extra fields showing the actual routing:
+Chat completion responses include extra fields:
 
 ```json
 {
@@ -489,7 +549,16 @@ Chat completion responses include extra fields showing the actual routing:
 }
 ```
 
-For streaming, these fields appear in the final chunk (alongside `usage`).
+### Persistent data files
+
+| File | Contents |
+|---|---|
+| `~/.pi/agent/multi-pass.json` | Config (subscriptions, pools, chains, presets) |
+| `~/.pi/agent/multi-pass-rules.json` | DLP policy rules |
+| `~/.pi/agent/multi-pass-users.json` | User accounts and permissions |
+| `~/.pi/agent/leeloo-audit.jsonl` | Audit log (rule violations, persisted) |
+| `~/.pi/agent/leeloo-usage.jsonl` | Usage log (per-user request tracking) |
+| `~/.pi/agent/auth.json` | OAuth credentials |
 
 ## Supported providers
 
@@ -534,7 +603,11 @@ Env entries merge with saved config.
 | File | Scope | Contains |
 |---|---|---|
 | `~/.pi/agent/multi-pass.json` | Global | Subscriptions + pools + chains + presets |
+| `~/.pi/agent/multi-pass-rules.json` | Global | DLP policy rules (Leeloo) |
+| `~/.pi/agent/multi-pass-users.json` | Global | User accounts + permissions (Leeloo) |
 | `~/.pi/agent/auth.json` | Global | OAuth credentials (used by extension + Leeloo) |
+| `~/.pi/agent/leeloo-audit.jsonl` | Global | Audit log -- rule violations (persistent) |
+| `~/.pi/agent/leeloo-usage.jsonl` | Global | Usage log -- per-user request tracking |
 | `.pi/multi-pass.json` | Project | Pool/chain overrides + sub restrictions |
 
 ## License

--- a/README.md
+++ b/README.md
@@ -22,16 +22,16 @@ Multi-subscription extension for [pi](https://github.com/badlogic/pi-mono) -- us
   - [How routing works](#how-routing-works)
   - [Chat UI](#chat-ui)
   - [Persistent data files](#persistent-data-files)
-- [Integration guides](#integration-guides)
-  - [pi coding agent](#pi-coding-agent)
-  - [Cursor](#cursor)
-  - [Windsurf / Codeium](#windsurf--codeium)
-  - [Continue (VS Code / JetBrains)](#continue-vs-code--jetbrains)
-  - [Cline (VS Code)](#cline-vs-code)
-  - [aider](#aider)
-  - [OpenAI Python SDK](#openai-python-sdk)
-  - [OpenAI Node SDK](#openai-node-sdk)
-  - [curl](#curl)
+  - [Integration guides](#integration-guides)
+    - [pi coding agent](#pi-coding-agent)
+    - [Cursor](#cursor)
+    - [Windsurf / Codeium](#windsurf--codeium)
+    - [Continue (VS Code / JetBrains)](#continue-vs-code--jetbrains)
+    - [Cline (VS Code)](#cline-vs-code)
+    - [aider](#aider)
+    - [OpenAI Python SDK](#openai-python-sdk)
+    - [OpenAI Node SDK](#openai-node-sdk)
+    - [curl](#curl)
 - [Supported providers](#supported-providers)
 - [Built-in limits support](#built-in-limits-support)
 - [Config files](#config-files)
@@ -594,13 +594,13 @@ Chat completion responses include extra fields:
 | `~/.pi/agent/leeloo-usage.jsonl` | Usage log (per-user request tracking) |
 | `~/.pi/agent/auth.json` | OAuth credentials |
 
-## Integration guides
+### Integration guides
 
 Leeloo is a standard OpenAI-compatible proxy. Any tool that supports a custom `base_url` / `api_base` works out of the box. Set the model to any preset name (`coding-premium`, `fastest`), pool (`pool:codex-pool`), or raw model ID.
 
 All routing, failover, DLP rules, and budget enforcement happen transparently -- the tool thinks it's talking to OpenAI.
 
-### pi coding agent
+#### pi coding agent
 
 [pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) can use Leeloo as its provider backend. Create a custom provider config:
 
@@ -628,7 +628,7 @@ pi
 
 Then select `coding-premium` or any preset/pool as your model in pi.
 
-### Cursor
+#### Cursor
 
 Add to your Cursor settings (`.cursor/settings.json` or via Settings UI):
 
@@ -643,14 +643,14 @@ Then pick `coding-premium` (or any preset name) from Cursor's model dropdown.
 
 For team setups: each developer gets their own user token from `/admin` -> Users, with budget limits and preset restrictions.
 
-### Windsurf / Codeium
+#### Windsurf / Codeium
 
 Settings -> Custom Model Provider:
 - **Base URL**: `http://localhost:4000/v1`
 - **API Key**: `<token>`
 - **Model**: `coding-premium`
 
-### Continue (VS Code / JetBrains)
+#### Continue (VS Code / JetBrains)
 
 `.continue/config.yaml`:
 ```yaml
@@ -676,7 +676,7 @@ models:
 
 Each model entry shows up as a separate option in Continue's model picker.
 
-### Cline (VS Code)
+#### Cline (VS Code)
 
 In VS Code settings (`settings.json`):
 ```json
@@ -688,7 +688,7 @@ In VS Code settings (`settings.json`):
 }
 ```
 
-### aider
+#### aider
 
 ```bash
 export OPENAI_API_BASE=http://localhost:4000/v1
@@ -696,7 +696,7 @@ export OPENAI_API_KEY=<token>
 aider --model coding-premium
 ```
 
-### OpenAI Python SDK
+#### OpenAI Python SDK
 
 ```python
 from openai import OpenAI
@@ -723,7 +723,7 @@ for chunk in stream:
         print(chunk.choices[0].delta.content, end="")
 ```
 
-### OpenAI Node SDK
+#### OpenAI Node SDK
 
 ```javascript
 import OpenAI from "openai";
@@ -740,7 +740,7 @@ const response = await client.chat.completions.create({
 console.log(response.choices[0].message.content);
 ```
 
-### curl
+#### curl
 
 ```bash
 curl http://localhost:4000/v1/chat/completions \
@@ -752,7 +752,7 @@ curl http://localhost:4000/v1/chat/completions \
   }'
 ```
 
-### Tips for team deployments
+#### Tips for team deployments
 
 - Run Leeloo on an internal server (not just localhost)
 - Set `LEELOO_KEY` to a persistent admin token via `.env`

--- a/README.md
+++ b/README.md
@@ -2,6 +2,40 @@
 
 Multi-subscription extension for [pi](https://github.com/badlogic/pi-mono) -- use multiple OAuth accounts per provider with automatic rate-limit rotation and project-level affinity.
 
+## Table of contents
+
+- [Install](#install)
+- [Features](#features)
+- [Quick start](#quick-start)
+- [Commands](#commands)
+- [Project-level configuration](#project-level-configuration)
+- [How pools work](#how-pools-work)
+- [How chains work](#how-chains-work)
+- [Model presets](#model-presets)
+- [Leeloo -- OpenAI-compatible proxy & admin](#leeloo----openai-compatible-proxy--admin)
+  - [Quick start](#quick-start-1)
+  - [Web interfaces](#web-interfaces)
+  - [API endpoints](#api-endpoints)
+  - [Authentication & users](#authentication--users)
+  - [Admin dashboard](#admin-dashboard)
+  - [DLP / policy rules](#dlp--policy-rules)
+  - [How routing works](#how-routing-works)
+  - [Chat UI](#chat-ui)
+  - [Persistent data files](#persistent-data-files)
+- [Integration guides](#integration-guides)
+  - [pi coding agent](#pi-coding-agent)
+  - [Cursor](#cursor)
+  - [Windsurf / Codeium](#windsurf--codeium)
+  - [Continue (VS Code / JetBrains)](#continue-vs-code--jetbrains)
+  - [Cline (VS Code)](#cline-vs-code)
+  - [aider](#aider)
+  - [OpenAI Python SDK](#openai-python-sdk)
+  - [OpenAI Node SDK](#openai-node-sdk)
+  - [curl](#curl)
+- [Supported providers](#supported-providers)
+- [Built-in limits support](#built-in-limits-support)
+- [Config files](#config-files)
+
 ## Install
 
 ```bash
@@ -559,6 +593,174 @@ Chat completion responses include extra fields:
 | `~/.pi/agent/leeloo-audit.jsonl` | Audit log (rule violations, persisted) |
 | `~/.pi/agent/leeloo-usage.jsonl` | Usage log (per-user request tracking) |
 | `~/.pi/agent/auth.json` | OAuth credentials |
+
+## Integration guides
+
+Leeloo is a standard OpenAI-compatible proxy. Any tool that supports a custom `base_url` / `api_base` works out of the box. Set the model to any preset name (`coding-premium`, `fastest`), pool (`pool:codex-pool`), or raw model ID.
+
+All routing, failover, DLP rules, and budget enforcement happen transparently -- the tool thinks it's talking to OpenAI.
+
+### pi coding agent
+
+pi can use Leeloo as its provider backend. Create a custom provider config:
+
+`~/.pi/agent/providers.json`:
+```json
+{
+  "providers": [
+    {
+      "name": "leeloo",
+      "type": "openai",
+      "baseUrl": "http://localhost:4000/v1",
+      "apiKey": "<admin-or-user-token>",
+      "models": ["coding-premium", "coding-budget", "fastest"]
+    }
+  ]
+}
+```
+
+Or set environment variables before running pi:
+```bash
+export OPENAI_BASE_URL=http://localhost:4000/v1
+export OPENAI_API_KEY=<token>
+pi
+```
+
+Then select `coding-premium` or any preset/pool as your model in pi.
+
+### Cursor
+
+Add to your Cursor settings (`.cursor/settings.json` or via Settings UI):
+
+```json
+{
+  "openai.baseUrl": "http://localhost:4000/v1",
+  "openai.apiKey": "<token>"
+}
+```
+
+Then pick `coding-premium` (or any preset name) from Cursor's model dropdown.
+
+For team setups: each developer gets their own user token from `/admin` -> Users, with budget limits and preset restrictions.
+
+### Windsurf / Codeium
+
+Settings -> Custom Model Provider:
+- **Base URL**: `http://localhost:4000/v1`
+- **API Key**: `<token>`
+- **Model**: `coding-premium`
+
+### Continue (VS Code / JetBrains)
+
+`.continue/config.yaml`:
+```yaml
+models:
+  - model: coding-premium
+    title: Leeloo Premium
+    provider: openai
+    apiBase: http://localhost:4000/v1
+    apiKey: <token>
+
+  - model: fastest
+    title: Leeloo Fast
+    provider: openai
+    apiBase: http://localhost:4000/v1
+    apiKey: <token>
+
+  - model: coding-budget
+    title: Leeloo Budget
+    provider: openai
+    apiBase: http://localhost:4000/v1
+    apiKey: <token>
+```
+
+Each model entry shows up as a separate option in Continue's model picker.
+
+### Cline (VS Code)
+
+In VS Code settings (`settings.json`):
+```json
+{
+  "cline.provider": "openai",
+  "cline.openai.baseUrl": "http://localhost:4000/v1",
+  "cline.openai.apiKey": "<token>",
+  "cline.openai.model": "coding-premium"
+}
+```
+
+### aider
+
+```bash
+export OPENAI_API_BASE=http://localhost:4000/v1
+export OPENAI_API_KEY=<token>
+aider --model coding-premium
+```
+
+### OpenAI Python SDK
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:4000/v1",
+    api_key="<token>",
+)
+
+response = client.chat.completions.create(
+    model="coding-premium",
+    messages=[{"role": "user", "content": "Hello!"}],
+)
+print(response.choices[0].message.content)
+
+# Streaming
+stream = client.chat.completions.create(
+    model="fastest",
+    messages=[{"role": "user", "content": "Write a haiku"}],
+    stream=True,
+)
+for chunk in stream:
+    if chunk.choices[0].delta.content:
+        print(chunk.choices[0].delta.content, end="")
+```
+
+### OpenAI Node SDK
+
+```javascript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:4000/v1",
+  apiKey: "<token>",
+});
+
+const response = await client.chat.completions.create({
+  model: "coding-premium",
+  messages: [{ role: "user", content: "Hello!" }],
+});
+console.log(response.choices[0].message.content);
+```
+
+### curl
+
+```bash
+curl http://localhost:4000/v1/chat/completions \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "coding-premium",
+    "messages": [{"role": "user", "content": "Hello!"}]
+  }'
+```
+
+### Tips for team deployments
+
+- Run Leeloo on an internal server (not just localhost)
+- Set `LEELOO_KEY` to a persistent admin token via `.env`
+- Create user accounts in `/admin` -> Users with per-person budgets
+- Restrict users to specific presets (e.g. `coding-budget` only for interns)
+- Monitor usage in `/admin` -> Dashboard (per-user stats, provider health)
+- Set up DLP rules to block secrets before they reach the LLM
+- All tools above work identically -- just swap `localhost:4000` for your server address
 
 ## Supported providers
 

--- a/README.md
+++ b/README.md
@@ -359,6 +359,10 @@ npx pi-multi-pass
 # Or with a custom port
 npx pi-multi-pass --port 8080
 
+# Local dev mode with auto-restart on leeloo/web changes
+# (run from repo root)
+yarn web-dev
+
 # Then point your tools at it
 export OPENAI_BASE_URL=http://localhost:4000/v1
 ```

--- a/config.js
+++ b/config.js
@@ -1,0 +1,127 @@
+/**
+ * pi-multi-pass / leeloo config helpers.
+ *
+ * Use these in `~/.pi/agent/multi-pass.config.js` to define your routing
+ * setup with full IntelliSense, env vars, imports, and inline custom rules.
+ *
+ * Example:
+ *
+ *   import { defineConfig, account, pool, rule, mode, preset } from "pi-multi-pass/config";
+ *
+ *   export default defineConfig({
+ *     accounts: [
+ *       account("openai-main", { provider: "openai-codex", kind: "subscription" }),
+ *       account("openrouter", { provider: "openrouter", kind: "apiKey", key: process.env.OPENROUTER_KEY }),
+ *     ],
+ *     pools: [pool("openai-shared", { members: ["openai-main", "openai-alt"], strategy: "round-robin" })],
+ *     rules: [
+ *       rule.timeWindow("prefer-anthropic-evening", { targets: ["anthropic-shared"], windows: [{ days: ["mon-fri"], hours: [18, 23] }], boost: 100 }),
+ *       rule.quotaBurn("burn-expiring-first"),
+ *       rule.custom("avoid-third-party", async (candidates, ctx) => candidates.filter(c => !c.id.includes("personal"))),
+ *     ],
+ *     modes: [
+ *       mode("coding-premium", {
+ *         candidates: ["openai-shared", "anthropic-shared", "copilot-main"],
+ *         rules: ["prefer-anthropic-evening", "burn-expiring-first"],
+ *         onError: "re-evaluate",
+ *       }),
+ *     ],
+ *     presets: [
+ *       preset("coding-premium", {
+ *         mode: "coding-premium",
+ *         preferredModels: ["claude-opus", "gpt-5.4"],
+ *       }),
+ *     ],
+ *   });
+ */
+
+export function defineConfig(config) {
+	return {
+		subscriptions: config.subscriptions || [],
+		apiKeys: config.apiKeys || [],
+		accounts: config.accounts || [],
+		pools: config.pools || [],
+		chains: config.chains || [],
+		modes: config.modes || [],
+		routingRules: config.rules || config.routingRules || [],
+		presets: config.presets || [],
+	};
+}
+
+export function account(id, opts = {}) {
+	return {
+		id,
+		provider: opts.provider,
+		kind: opts.kind || "subscription",
+		key: opts.key,
+		baseUrl: opts.baseUrl,
+		label: opts.label || "",
+		enabled: opts.enabled !== false,
+	};
+}
+
+export function pool(id, opts = {}) {
+	return {
+		name: id,
+		id,
+		baseProvider: opts.baseProvider || opts.provider,
+		members: opts.members || [],
+		strategy: opts.strategy || "round-robin",
+		memberSchedule: opts.memberSchedule,
+		selectorScript: opts.selectorScript,
+		enabled: opts.enabled !== false,
+	};
+}
+
+export function mode(id, opts = {}) {
+	return {
+		id,
+		description: opts.description || "",
+		candidates: opts.candidates || [],
+		rules: opts.rules || [],
+		onError: opts.onError || "re-evaluate",
+		enabled: opts.enabled !== false,
+	};
+}
+
+export function preset(id, opts = {}) {
+	return {
+		id,
+		name: id,
+		mode: opts.mode,
+		preferredModels: opts.preferredModels || [],
+		fallbackModels: opts.fallbackModels || [],
+		entries: opts.entries || [], // legacy v1 support
+		enabled: opts.enabled !== false,
+	};
+}
+
+export const rule = {
+	timeWindow(id, params) {
+		return { id, type: "time-window", params, description: params.description };
+	},
+	quotaBurn(id, params = {}) {
+		return { id, type: "quota-burn", params, description: params.description };
+	},
+	costTier(id, params) {
+		return { id, type: "cost-tier", params, description: params.description };
+	},
+	modelFit(id, params) {
+		return { id, type: "model-fit", params, description: params.description };
+	},
+	errorBlacklist(id, params = {}) {
+		return { id, type: "error-blacklist", params, description: params.description };
+	},
+	cooldown(id, params = {}) {
+		return { id, type: "cooldown", params, description: params.description };
+	},
+	custom(id, fnOrPath, params = {}) {
+		const isFn = typeof fnOrPath === "function";
+		return {
+			id,
+			type: "custom",
+			params: { ...params, ...(isFn ? { fn: fnOrPath } : { code: fnOrPath }) },
+			description: params.description,
+		};
+	},
+};

--- a/leeloo.js
+++ b/leeloo.js
@@ -425,14 +425,20 @@ const auditLog = [];
 const AUDIT_LOG_MAX = 1000;
 const rateLimitCounters = {}; // { ruleName: { count, windowStart } }
 
-function auditEvent(rule, action, detail, content) {
+function auditEvent(rule, action, detail, matchedText, fullMessage, source) {
+	const matched = typeof matchedText === "string" ? matchedText : null;
+	const full = typeof fullMessage === "string" ? fullMessage : null;
+	const base = full || matched;
 	const entry = {
 		timestamp: new Date().toISOString(),
 		rule: rule.name,
 		type: rule.type,
 		action,
 		detail,
-		snippet: content ? content.slice(0, 200) : null,
+		source: source || null,
+		snippet: base ? base.slice(0, 200) : null,
+		matched_text: matched,
+		full_message: full,
 	};
 	auditLog.push(entry);
 	if (auditLog.length > AUDIT_LOG_MAX) auditLog.shift();
@@ -484,12 +490,13 @@ function evaluateContentRules(rules, messages, scope) {
 
 		for (const re of patterns) {
 			if (re.test(text)) {
+				const matched = text.match(re)?.[0] || null;
 				if (rule.type === "block") {
 					blocked = true;
 					blockMessage = rule.message || `Blocked by rule: ${rule.name}`;
-					auditEvent(rule, "blocked", blockMessage, text.match(re)?.[0]);
+					auditEvent(rule, "blocked", blockMessage, matched, text, scope);
 				} else if (rule.type === "warn") {
-					auditEvent(rule, "warned", `Pattern matched: ${re.source}`, text.match(re)?.[0]);
+					auditEvent(rule, "warned", `Pattern matched: ${re.source}`, matched, text, scope);
 				} else if (rule.type === "redact") {
 					const replacement = rule.replacement || "[REDACTED]";
 					// Redact in all message contents
@@ -505,7 +512,7 @@ function evaluateContentRules(rules, messages, scope) {
 						return m;
 					});
 					modified = true;
-					auditEvent(rule, "redacted", `Pattern replaced: ${re.source}`, replacement);
+					auditEvent(rule, "redacted", `Pattern replaced: ${re.source}`, matched, text, scope);
 				}
 			}
 			re.lastIndex = 0; // reset global regex
@@ -528,7 +535,7 @@ function evaluateModelRules(rules, modelId) {
 			for (const pattern of denyList) {
 				const re = new RegExp("^" + pattern.replace(/\*/g, ".*") + "$", "i");
 				if (re.test(modelId)) {
-					auditEvent(rule, "denied", `Model ${modelId} denied by ${pattern}`);
+					auditEvent(rule, "denied", `Model ${modelId} denied by ${pattern}`, modelId, null, "model");
 					return { allowed: false, message: rule.message || `Model "${modelId}" is not allowed by policy "${rule.name}"` };
 				}
 			}
@@ -539,7 +546,7 @@ function evaluateModelRules(rules, modelId) {
 				return re.test(modelId);
 			});
 			if (!matched) {
-				auditEvent(rule, "denied", `Model ${modelId} not in allow list`);
+				auditEvent(rule, "denied", `Model ${modelId} not in allow list`, modelId, null, "model");
 				return { allowed: false, message: rule.message || `Model "${modelId}" is not in the allowed list for policy "${rule.name}"` };
 			}
 		}
@@ -568,7 +575,7 @@ function evaluateRateLimitRules(rules) {
 		counter.count++;
 		if (counter.count > maxRequests) {
 			const retryAfter = Math.ceil((counter.windowStart + windowMs - now) / 1000);
-			auditEvent(rule, "rate-limited", `${counter.count}/${maxRequests} in ${rule.windowSeconds || 60}s window`);
+			auditEvent(rule, "rate-limited", `${counter.count}/${maxRequests} in ${rule.windowSeconds || 60}s window`, `${counter.count}/${maxRequests}`, null, "limit");
 			return { allowed: false, message: rule.message || `Rate limit exceeded: ${maxRequests} requests per ${rule.windowSeconds || 60}s`, retryAfter };
 		}
 	}
@@ -588,7 +595,8 @@ function redactResponse(rules, text) {
 			try {
 				const re = new RegExp(p, "gi");
 				if (re.test(text)) {
-					auditEvent(rule, "redacted-response", `Pattern replaced: ${re.source}`);
+					const matched = text.match(re)?.[0] || null;
+					auditEvent(rule, "redacted-response", `Pattern replaced: ${re.source}`, matched, text, "response");
 					re.lastIndex = 0;
 					text = text.replace(re, replacement);
 				}
@@ -610,7 +618,8 @@ function checkResponseBlock(rules, text) {
 			try {
 				const re = new RegExp(p, "gi");
 				if (re.test(text)) {
-					auditEvent(rule, "blocked-response", `Pattern matched: ${re.source}`, text.match(re)?.[0]);
+					const matched = text.match(re)?.[0] || null;
+					auditEvent(rule, "blocked-response", `Pattern matched: ${re.source}`, matched, text, "response");
 					return { blocked: true, message: rule.message || `Response blocked by rule: ${rule.name}` };
 				}
 			} catch {}
@@ -1749,12 +1758,16 @@ const loaders = {
     const data = await fetch(BASE+"/v1/audit").then(r=>r.json());
     let h = '<h2>Audit Log</h2>';
     if(!data.entries?.length){h+='<div class="empty">No audit events yet. Events appear when rules match requests or responses.</div>';}
-    else{h+='<table><tr><th>Time</th><th>Rule</th><th>Type</th><th>Action</th><th>Detail</th><th>Snippet</th></tr>';
+    else{h+='<table><tr><th>Time</th><th>Rule</th><th>Type</th><th>Action</th><th>Source</th><th>Detail</th><th>Matched</th><th>Full message</th></tr>';
     for(const e of data.entries){
+      const fullMsg = e.full_message
+        ? '<details><summary>view ('+e.full_message.length+' chars)</summary><pre style="white-space:pre-wrap;word-break:break-word;max-height:280px;overflow:auto;background:#0a0a0a;border:1px solid #222;border-radius:6px;padding:8px;margin-top:6px">'+esc(e.full_message)+'</pre></details>'
+        : '--';
       h+='<tr><td>'+ago(e.timestamp)+'</td><td>'+esc(e.rule)+'</td>';
       h+='<td><span class="badge '+esc(e.type)+'">'+esc(e.type)+'</span></td>';
-      h+='<td>'+esc(e.action)+'</td><td>'+esc(e.detail)+'</td>';
-      h+='<td>'+(e.snippet?esc(e.snippet):'--')+'</td></tr>';
+      h+='<td>'+esc(e.action)+'</td><td>'+esc(e.source||'--')+'</td><td>'+esc(e.detail)+'</td>';
+      h+='<td>'+(e.matched_text?esc(e.matched_text):'--')+'</td>';
+      h+='<td>'+fullMsg+'</td></tr>';
     }h+='</table>';}
     document.getElementById("audit").innerHTML = h;
   },

--- a/leeloo.js
+++ b/leeloo.js
@@ -1012,6 +1012,17 @@ function handleRouting(req, res) {
 	res.end(JSON.stringify({ groups }));
 }
 
+/** Returns live quota scores for all providers that support it. */
+async function handleQuota(req, res) {
+	const providers = getAllProviders();
+	const results = await Promise.all(providers.map(async (prov) => {
+		const score = await checkQuota(prov);
+		return { provider: prov, quota: score, exhausted: isExhausted(prov) };
+	}));
+	res.writeHead(200, json());
+	res.end(JSON.stringify({ providers: results }));
+}
+
 function handleHealth(req, res) {
 	const config = loadConfig();
 	const providers = getAllProviders();
@@ -1079,14 +1090,19 @@ body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;b
 #status-text{font-size:11px;color:#555}
 
 /* ── Info strip ── */
-#info-strip{display:none;padding:6px 20px;background:#0d0d0d;border-bottom:1px solid #1a1a1a;font-size:11px;color:#555;overflow-x:auto;white-space:nowrap}
-#info-strip .tag{display:inline-block;padding:2px 8px;margin-right:6px;border-radius:4px;border:1px solid #222;background:#111}
-#info-strip .tag b{color:#888;font-weight:600}
-#info-strip .tag .val{color:#aaa}
+#info-strip{padding:5px 20px;background:#0d0d0d;border-bottom:1px solid #1a1a1a;font-size:11px;color:#555;overflow-x:auto;white-space:nowrap;display:flex;gap:6px;align-items:center;flex-wrap:wrap}
+#info-strip .section{display:flex;gap:4px;align-items:center;margin-right:8px}
+#info-strip .section-label{color:#444;font-weight:700;text-transform:uppercase;font-size:9px;letter-spacing:.5px;margin-right:2px}
+#info-strip .tag{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:4px;border:1px solid #222;background:#111}
+#info-strip .tag b{color:#999;font-weight:600}
+#info-strip .tag .val{color:#777}
+#info-strip .tag .bar{display:inline-block;width:40px;height:6px;background:#222;border-radius:3px;overflow:hidden;vertical-align:middle}
+#info-strip .tag .bar-fill{height:100%;border-radius:3px;transition:width .3s}
 #info-strip .tag.pool{border-color:#2a2a3a}
 #info-strip .tag.preset{border-color:#3a2a1a}
 #info-strip .tag.provider{border-color:#1a2a1a}
-#info-strip .tag.exhausted{border-color:#4a1a1a;color:#a66}
+#info-strip .tag.exhausted{border-color:#4a1a1a;opacity:.5}
+#info-strip .sep{color:#222;margin:0 2px}
 
 /* ── Chat ── */
 #chat{flex:1;overflow-y:auto;padding:20px;display:flex;flex-direction:column;gap:14px}
@@ -1140,7 +1156,6 @@ body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;b
     <select id="model-select"><option>Loading...</option></select>
     <div class="bar-actions">
       <button class="bar-btn" onclick="clearChat()">Clear</button>
-      <button class="bar-btn" onclick="toggleInfo()">Config</button>
       <span class="dot" id="dot"></span>
       <span id="status-text">loading...</span>
     </div>
@@ -1173,7 +1188,6 @@ const dotEl = document.getElementById("dot");
 const infoStrip = document.getElementById("info-strip");
 let messages = [];
 let streaming = false;
-let infoVisible = false;
 
 input.addEventListener("input", () => { input.style.height = "auto"; input.style.height = Math.min(input.scrollHeight, 140) + "px"; });
 input.addEventListener("keydown", (e) => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); sendMessage(); } });
@@ -1183,29 +1197,59 @@ function setStatus(state, text) {
   dotEl.className = "dot " + (state === "ready" ? "ok" : state === "busy" ? "busy" : "");
 }
 
-// ── Load config info ──
-async function loadInfo() {
-  try {
-    const h = await (await fetch(BASE + "/health")).json();
-    const tags = [];
-    for (const p of (h.pools || [])) {
-      tags.push('<span class="tag pool"><b>' + esc(p.name) + '</b> <span class="val">' + esc(p.strategy) + ' (' + p.members.length + ')</span></span>');
-    }
-    for (const p of (h.presets || [])) {
-      tags.push('<span class="tag preset"><b>' + esc(p.name) + '</b> <span class="val">' + esc(p.entries.join(" > ")) + '</span></span>');
-    }
-    for (const p of (h.providers || [])) {
-      const exh = (h.exhausted || []).includes(p);
-      tags.push('<span class="tag provider' + (exh ? " exhausted" : "") + '"><b>' + esc(p) + '</b>' + (exh ? ' <span class="val">exhausted</span>' : ' <span class="val">ok</span>') + '</span>');
-    }
-    infoStrip.innerHTML = tags.join("");
-  } catch {}
+// ── Load config + quota info strip ──
+function quotaColor(pct) {
+  if (pct === null || pct === undefined) return "#555";
+  if (pct > 50) return "#4a4";
+  if (pct > 20) return "#ca0";
+  return "#e44";
+}
+function quotaBar(pct) {
+  if (pct === null || pct === undefined) return '<span class="val">--</span>';
+  return '<span class="bar"><span class="bar-fill" style="width:' + pct + '%;background:' + quotaColor(pct) + '"></span></span> <span class="val">' + pct + '%</span>';
 }
 
-function toggleInfo() {
-  infoVisible = !infoVisible;
-  infoStrip.style.display = infoVisible ? "block" : "none";
-  if (infoVisible) loadInfo();
+async function loadInfo() {
+  try {
+    const [h, q] = await Promise.all([
+      fetch(BASE + "/health").then(r => r.json()),
+      fetch(BASE + "/v1/quota").then(r => r.json()).catch(() => ({ providers: [] })),
+    ]);
+    const quotaMap = {};
+    for (const p of (q.providers || [])) quotaMap[p.provider] = p;
+
+    let html = "";
+
+    // Pools
+    if (h.pools?.length) {
+      html += '<span class="section"><span class="section-label">pools</span>';
+      for (const p of h.pools) {
+        html += '<span class="tag pool"><b>' + esc(p.name) + '</b> <span class="val">' + esc(p.strategy) + '</span></span>';
+      }
+      html += '</span><span class="sep">|</span>';
+    }
+
+    // Presets
+    if (h.presets?.length) {
+      html += '<span class="section"><span class="section-label">presets</span>';
+      for (const p of h.presets) {
+        html += '<span class="tag preset" title="' + esc(p.entries.join(" > ")) + '"><b>' + esc(p.name) + '</b></span>';
+      }
+      html += '</span><span class="sep">|</span>';
+    }
+
+    // Providers with quota bars
+    html += '<span class="section"><span class="section-label">providers</span>';
+    for (const prov of (h.providers || [])) {
+      const qi = quotaMap[prov] || {};
+      const exh = (h.exhausted || []).includes(prov) || qi.exhausted;
+      const cls = "tag provider" + (exh ? " exhausted" : "");
+      html += '<span class="' + cls + '"><b>' + esc(prov) + '</b> ' + quotaBar(qi.quota) + '</span>';
+    }
+    html += '</span>';
+
+    infoStrip.innerHTML = html;
+  } catch {}
 }
 
 // ── Load routing ──
@@ -1360,10 +1404,11 @@ async function sendMessage() {
   streaming = false; sendBtn.disabled = false; input.disabled = false;
   input.focus();
   setStatus("ready", "done");
-  if (infoVisible) loadInfo(); // refresh exhausted state
+  loadInfo(); // refresh quota + exhausted state
 }
 
 loadRouting();
+loadInfo();
 </script>
 </body></html>`;
 
@@ -1381,6 +1426,7 @@ const server = createServer(async (req, res) => {
 		if (path === "/v1/chat/completions" && req.method === "POST") await handleChatCompletions(req, res);
 		else if (path === "/v1/models" && req.method === "GET") handleModels(req, res);
 		else if (path === "/v1/routing" && req.method === "GET") handleRouting(req, res);
+		else if (path === "/v1/quota" && req.method === "GET") await handleQuota(req, res);
 		else if (path === "/health" && req.method === "GET") handleHealth(req, res);
 		else if (path === "/ui" || path === "/") handleUI(req, res);
 		else { res.writeHead(404, json()); res.end(JSON.stringify({ error: { message: "Not found" } })); }

--- a/leeloo.js
+++ b/leeloo.js
@@ -1218,7 +1218,8 @@ body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;b
 </div>
 
 <script type="module">
-import * as smd from "https://cdn.jsdelivr.net/npm/streaming-markdown@latest/smd.min.js";
+let smd = null;
+try { smd = await import("https://cdn.jsdelivr.net/npm/streaming-markdown@latest/smd.min.js"); } catch {}
 const BASE = location.origin;
 const chat = document.getElementById("chat");
 const input = document.getElementById("input");
@@ -1355,7 +1356,8 @@ async function sendMessage() {
   const t0 = Date.now();
   const rawSelection = sel.value;
   // Clean display: "pool:codex-pool/gpt-5.1" -> "codex-pool / gpt-5.1"
-  const selectedModel = rawSelection.replace(/^pool:([^/]+)\/(.+)$/, "$1 / $2").replace(/^provider:([^/]+)\/(.+)$/, "$1 / $2");
+  const selectedModel = rawSelection.includes("/") ? rawSelection.split("/").pop() : rawSelection;
+  const selectedRoute = rawSelection.replace("pool:", "").replace("provider:", "").replace("/", " / ");
 
   try {
     const resp = await fetch(BASE + "/v1/chat/completions", {
@@ -1394,11 +1396,12 @@ async function sendMessage() {
               mdBody.className = "md-body";
               msgDiv.innerHTML = "";
               msgDiv.appendChild(mdBody);
-              smdParser = smd.parser(smd.default_renderer(mdBody));
+              if (smd) smdParser = smd.parser(smd.default_renderer(mdBody));
               setStatus("busy", "receiving...");
             }
             full += d.content;
-            smd.parser_write(smdParser, d.content);
+            if (smdParser) smd.parser_write(smdParser, d.content);
+            else mdBody.textContent = full;
             chat.scrollTop = chat.scrollHeight;
           }
 
@@ -1409,12 +1412,13 @@ async function sendMessage() {
               mdBody.className = "md-body";
               msgDiv.innerHTML = "";
               msgDiv.appendChild(mdBody);
-              smdParser = smd.parser(smd.default_renderer(mdBody));
+              if (smd) smdParser = smd.parser(smd.default_renderer(mdBody));
             }
             const tc = d.tool_calls[0];
             const tcText = "\\n**Tool call:** \`" + (tc?.function?.name || "?") + "\`\\n";
             full += tcText;
-            smd.parser_write(smdParser, tcText);
+            if (smdParser) smd.parser_write(smdParser, tcText);
+            else mdBody.textContent = full;
           }
 
           if (j.usage) usage = j.usage;
@@ -1422,12 +1426,12 @@ async function sendMessage() {
           if (j.x_model) xModel = j.x_model;
 
           if (j.choices?.[0]?.finish_reason) {
-            if (smdParser) smd.parser_end(smdParser);
+            if (smdParser && smd) smd.parser_end(smdParser);
             const ms = Date.now() - t0;
             const meta = document.createElement("div");
             meta.className = "meta";
             const parts = [];
-            parts.push('<span class="provider-tag">' + esc(selectedModel) + '</span>');
+            parts.push('<span class="provider-tag">' + esc(selectedRoute) + '</span>');
             if (xProvider || xModel) {
               parts.push('<span style="color:#8af">' + esc(xProvider) + '</span> / <span style="color:#aaa">' + esc(xModel) + '</span>');
             }

--- a/leeloo.js
+++ b/leeloo.js
@@ -189,6 +189,31 @@ function getBaseProvider(name) {
 	return null;
 }
 
+/**
+ * Get API key for a provider. For base providers, uses authStorage.getApiKey().
+ * For subscriptions (e.g. openai-codex-2), AuthStorage.getApiKey() fails because
+ * it doesn't know the OAuth provider. We fall back to extracting the access token
+ * directly from stored credentials, same as the base provider's getApiKey would.
+ */
+async function getApiKeyForProvider(providerName) {
+	// Try the standard path first (works for base providers)
+	const key = await authStorage.getApiKey(providerName);
+	if (key) return key;
+
+	// For subscriptions: extract directly from stored creds
+	const cred = authStorage.get(providerName);
+	if (!cred || cred.type !== "oauth" || !cred.access) return null;
+
+	const base = getBaseProvider(providerName);
+	if (base === "google-gemini-cli" || base === "google-antigravity") {
+		// Google providers store { access, projectId } serialized
+		return JSON.stringify({ token: cred.access, projectId: cred.projectId });
+	}
+
+	// Anthropic, OpenAI Codex, GitHub Copilot: just the access token
+	return cred.access;
+}
+
 /** Get all provider names (base + extras) that are authenticated. */
 function getAllProviders() {
 	const config = loadConfig();
@@ -325,7 +350,7 @@ async function checkCodexQuotaDetailed(provider) {
 	const cred = authStorage.get(provider);
 	if (!cred || cred.type !== "oauth" || !cred.access) return { score: null, status: "no-auth" };
 
-	const apiKey = await authStorage.getApiKey(provider);
+	const apiKey = await getApiKeyForProvider(provider);
 	if (!apiKey) return { score: null, status: "no-auth" };
 
 	const payload = decodeJwtPayload(apiKey);
@@ -371,7 +396,7 @@ async function checkCodexQuotaDetailed(provider) {
 }
 
 async function checkGeminiQuotaDetailed(provider) {
-	const apiKey = await authStorage.getApiKey(provider);
+	const apiKey = await getApiKeyForProvider(provider);
 	if (!apiKey) return { score: null, status: "no-auth" };
 
 	let token;
@@ -405,7 +430,7 @@ async function checkGeminiQuotaDetailed(provider) {
 }
 
 async function checkAntigravityQuotaDetailed(provider) {
-	const apiKey = await authStorage.getApiKey(provider);
+	const apiKey = await getApiKeyForProvider(provider);
 	if (!apiKey) return { score: null, status: "no-auth" };
 
 	let token;
@@ -1270,8 +1295,9 @@ function tryGetModel(providerName, modelId) {
 	const base = getBaseProvider(providerName);
 	if (!base) return null;
 	try {
-		const m = getModel(base, modelId);
-		return base !== providerName ? { ...m, provider: providerName } : m;
+		// Always use base provider in the model object (pi-ai needs it for API routing).
+		// The subscription name (providerName) is tracked separately for auth lookup.
+		return getModel(base, modelId);
 	} catch { return null; }
 }
 
@@ -1878,7 +1904,7 @@ async function handleChatCompletions(req, res) {
 		const candidate = candidates[attempt];
 
 		try {
-			const apiKey = await authStorage.getApiKey(candidate.provider);
+			const apiKey = await getApiKeyForProvider(candidate.provider);
 			if (!apiKey) {
 				log(`[${candidate.provider}] no API key, skipping`);
 				continue;

--- a/leeloo.js
+++ b/leeloo.js
@@ -657,7 +657,7 @@ function formatUsage(u) {
 
 // ─── Streaming handler ────────────────────────────────────────────────────────
 
-async function handleStreaming(res, model, context, opts, requestModelId) {
+async function handleStreaming(res, model, context, opts, requestModelId, actualProvider) {
 	res.writeHead(200, {
 		"Content-Type": "text/event-stream",
 		"Cache-Control": "no-cache",
@@ -749,7 +749,10 @@ async function handleStreaming(res, model, context, opts, requestModelId) {
 			case "done": {
 				const finish = toolCalls.size > 0 ? "tool_calls" : mapFinishReason(event.reason);
 				const usage = formatUsage(event.message?.usage);
-				write(chunk(id, requestModelId, {}, finish, usage));
+				const finalChunk = chunk(id, requestModelId, {}, finish, usage);
+				finalChunk.x_provider = actualProvider;
+				finalChunk.x_model = model.id;
+				write(finalChunk);
 				res.write("data: [DONE]\n\n");
 				break;
 			}
@@ -775,7 +778,7 @@ async function handleStreaming(res, model, context, opts, requestModelId) {
 
 // ─── Non-streaming handler ────────────────────────────────────────────────────
 
-async function handleNonStreaming(res, model, context, opts, requestModelId) {
+async function handleNonStreaming(res, model, context, opts, requestModelId, actualProvider) {
 	const eventStream = stream(model, context, opts);
 	let fullText = "";
 	const toolCalls = [];
@@ -820,6 +823,8 @@ async function handleNonStreaming(res, model, context, opts, requestModelId) {
 	const id = `chatcmpl-leeloo-${Date.now()}`;
 	const response = completionResponse(id, requestModelId, message, formatUsage(usage));
 	response.choices[0].finish_reason = toolCalls.length > 0 ? "tool_calls" : mapFinishReason(finishReason);
+	response.x_provider = actualProvider;
+	response.x_model = model.id;
 
 	res.writeHead(200, { "Content-Type": "application/json" });
 	res.end(JSON.stringify(response));
@@ -889,9 +894,9 @@ async function handleChatCompletions(req, res) {
 			log(`[${candidate.provider}] ${candidate.modelId} (attempt ${attempt + 1}/${maxAttempts})`);
 
 			if (doStream) {
-				await handleStreaming(res, candidate.model, context, opts, requestModelId);
+				await handleStreaming(res, candidate.model, context, opts, requestModelId, candidate.provider);
 			} else {
-				await handleNonStreaming(res, candidate.model, context, opts, requestModelId);
+				await handleNonStreaming(res, candidate.model, context, opts, requestModelId, candidate.provider);
 			}
 			return;
 
@@ -1286,7 +1291,7 @@ async function sendMessage() {
 
     const reader = resp.body.getReader();
     const dec = new TextDecoder();
-    let buf = "", usage = null, routedProvider = "";
+    let buf = "", usage = null, xProvider = "", xModel = "";
 
     while (true) {
       const { done, value } = await reader.read();
@@ -1333,7 +1338,8 @@ async function sendMessage() {
           }
 
           if (j.usage) usage = j.usage;
-          if (j.model && !routedProvider) routedProvider = j.model;
+          if (j.x_provider) xProvider = j.x_provider;
+          if (j.x_model) xModel = j.x_model;
 
           if (j.choices?.[0]?.finish_reason) {
             if (smdParser) smd.parser_end(smdParser);
@@ -1342,9 +1348,12 @@ async function sendMessage() {
             meta.className = "meta";
             const parts = [];
             parts.push('<span class="provider-tag">' + esc(selectedModel) + '</span>');
+            if (xProvider || xModel) {
+              parts.push('<span style="color:#8af">' + esc(xProvider) + '</span> / <span style="color:#aaa">' + esc(xModel) + '</span>');
+            }
             if (usage) parts.push(usage.prompt_tokens + " in / " + usage.completion_tokens + " out");
             parts.push((ms / 1000).toFixed(1) + "s");
-            meta.innerHTML = parts.join('<span style="color:#333">|</span>');
+            meta.innerHTML = parts.join(' <span style="color:#333">|</span> ');
             msgDiv.appendChild(meta);
           }
         } catch {}

--- a/leeloo.js
+++ b/leeloo.js
@@ -390,12 +390,23 @@ function tryGetModel(providerName, modelId) {
 async function resolveCandidates(modelId) {
 	const config = loadConfig();
 
-	// ── 0. Pool-scoped: "pool:<name>/<model>" ──
-	const poolMatch = modelId.match(/^pool:([^/]+)\/(.+)$/);
+	// ── 0. Pool-scoped: "pool:<name>" or "pool:<name>/<model>" ──
+	const poolMatch = modelId.match(/^pool:([^/]+)(?:\/(.+))?$/);
 	if (poolMatch) {
-		const [, poolName, actualModel] = poolMatch;
+		const poolName = poolMatch[1];
+		let actualModel = poolMatch[2];
 		const pool = config.pools.find((p) => p.name === poolName && p.enabled);
 		if (!pool) return [];
+
+		// Auto-pick default model if none specified
+		if (!actualModel) {
+			try {
+				const models = getModels(pool.baseProvider);
+				if (models.length > 0) actualModel = models[0].id;
+			} catch {}
+			if (!actualModel) return [];
+		}
+
 		const candidates = [];
 		const members = pool.members.filter((m) => isAvailable(m));
 
@@ -1012,7 +1023,7 @@ function handleRouting(req, res) {
 		});
 	}
 
-	// Pools -- each pool as a selectable group with specific models
+	// Pools -- pool-level entry (auto-picks default model) + per-model entries
 	const enabledPools = config.pools.filter((p) => p.enabled);
 	if (enabledPools.length > 0) {
 		const poolItems = [];
@@ -1022,11 +1033,20 @@ function handleRouting(req, res) {
 				const available = pool.members.filter((m) => authStorage.hasAuth(m));
 				if (available.length === 0) continue;
 				const strat = pool.strategy || "round-robin";
-				// Pool-level entries with specific models
+				const defaultModel = models[0]?.id || "?";
+
+				// Pool-level auto entry
+				poolItems.push({
+					id: `pool:${pool.name}`,
+					name: `${pool.name}`,
+					detail: `[${strat}] ${available.length} members, default: ${defaultModel}`,
+				});
+
+				// Per-model entries
 				for (const m of models) {
 					poolItems.push({
 						id: `pool:${pool.name}/${m.id}`,
-						name: `${pool.name} / ${m.id}`,
+						name: `  ${pool.name} / ${m.id}`,
 						detail: `[${strat}] via ${available.join(", ")}`,
 					});
 				}

--- a/leeloo.js
+++ b/leeloo.js
@@ -482,6 +482,29 @@ function tryGetModel(providerName, modelId) {
  * { model, provider, modelId } candidates, respecting pools, chains,
  * presets, strategies, and exhausted state.
  */
+/** Apply a pool's strategy to order its members. Returns reordered array. */
+async function applyPoolStrategy(pool, members, modelId) {
+	if (members.length <= 1) return members;
+	const strategy = pool.strategy || "round-robin";
+	let ordered = members;
+
+	if (strategy === "scheduled" && pool.memberSchedule) {
+		ordered = getScheduledOrder(pool, members);
+		if (ordered.length > 0) log(`[pool:${pool.name}] scheduled: ${ordered[0]} selected`);
+	} else if (strategy === "custom" && pool.selectorScript) {
+		const best = await runCustomSelector(pool, members, "", modelId);
+		if (best) {
+			ordered = [best, ...members.filter((m) => m !== best)];
+			log(`[pool:${pool.name}] custom: selector chose ${best}`);
+		}
+	} else if (strategy === "quota-first") {
+		ordered = await sortByQuota(members);
+		if (ordered.length > 0) log(`[pool:${pool.name}] quota-first: ${ordered[0]} preferred`);
+	}
+
+	return ordered;
+}
+
 async function resolveCandidates(modelId) {
 	const config = loadConfig();
 
@@ -504,18 +527,7 @@ async function resolveCandidates(modelId) {
 
 		const candidates = [];
 		const members = pool.members.filter((m) => isAvailable(m));
-
-		// Apply pool strategy
-		const strategy = pool.strategy || "round-robin";
-		let ordered = members;
-		if (strategy === "scheduled" && pool.memberSchedule) {
-			ordered = getScheduledOrder(pool, members);
-		} else if (strategy === "custom" && pool.selectorScript) {
-			const best = await runCustomSelector(pool, members, "", actualModel);
-			if (best) ordered = [best, ...members.filter((m) => m !== best)];
-		} else if (strategy === "quota-first") {
-			ordered = await sortByQuota(members);
-		}
+		const ordered = await applyPoolStrategy(pool, members, actualModel);
 
 		for (const member of ordered) {
 			const m = tryGetModel(member, actualModel);
@@ -539,11 +551,30 @@ async function resolveCandidates(modelId) {
 	);
 	if (preset) {
 		const candidates = [];
+		const used = new Set();
 		for (const entry of preset.entries) {
 			if (!entry.enabled) continue;
-			if (!isAvailable(entry.provider)) continue;
-			const m = tryGetModel(entry.provider, entry.model);
-			if (m) candidates.push({ model: m, provider: entry.provider, modelId: entry.model });
+
+			// If the entry's provider belongs to a pool, expand to all
+			// pool members (with strategy) so pool rotation happens before
+			// moving to the next preset entry.
+			const pool = config.pools.find(
+				(p) => p.enabled && p.members.includes(entry.provider),
+			);
+			if (pool) {
+				let members = pool.members.filter((m) => isAvailable(m) && !used.has(m));
+				if (members.length > 0) {
+					members = await applyPoolStrategy(pool, members, entry.model);
+					for (const member of members) {
+						const m = tryGetModel(member, entry.model);
+						if (m) { candidates.push({ model: m, provider: member, modelId: entry.model }); used.add(member); }
+					}
+				}
+			} else {
+				if (!isAvailable(entry.provider) || used.has(entry.provider)) continue;
+				const m = tryGetModel(entry.provider, entry.model);
+				if (m) { candidates.push({ model: m, provider: entry.provider, modelId: entry.model }); used.add(entry.provider); }
+			}
 		}
 		return candidates;
 	}
@@ -567,27 +598,7 @@ async function resolveCandidates(modelId) {
 		const poolMembers = pool.members.filter((m) => raw.some((c) => c.provider === m));
 		if (poolMembers.length === 0) continue;
 
-		const strategy = pool.strategy || "round-robin";
-		let memberOrder = poolMembers;
-
-		if (strategy === "scheduled" && pool.memberSchedule) {
-			memberOrder = getScheduledOrder(pool, poolMembers);
-			if (memberOrder.length > 0) {
-				log(`[pool:${pool.name}] scheduled: ${memberOrder[0]} selected by schedule priority`);
-			}
-		} else if (strategy === "custom" && pool.selectorScript) {
-			const best = await runCustomSelector(pool, poolMembers, "", modelId);
-			if (best) {
-				memberOrder = [best, ...poolMembers.filter((m) => m !== best)];
-				log(`[pool:${pool.name}] custom: selector chose ${best}`);
-			}
-		}
-		if (strategy === "quota-first") {
-			memberOrder = await sortByQuota(poolMembers);
-			if (memberOrder.length > 0) {
-				log(`[pool:${pool.name}] quota-first: ${memberOrder[0]} preferred`);
-			}
-		}
+		const memberOrder = await applyPoolStrategy(pool, poolMembers, modelId);
 
 		for (const member of memberOrder) {
 			const match = raw.find((c) => c.provider === member);
@@ -598,15 +609,17 @@ async function resolveCandidates(modelId) {
 		}
 	}
 
-	// ── 4. Chain targets ──
+	// ── 4. Chain targets (with pool strategy) ──
 	for (const chain of config.chains) {
 		if (!chain.enabled) continue;
 		for (const entry of chain.entries) {
 			if (!entry.enabled) continue;
 			const pool = config.pools.find((p) => p.name === entry.pool && p.enabled);
 			if (!pool) continue;
-			for (const member of pool.members) {
-				if (used.has(member) || !isAvailable(member)) continue;
+			let members = pool.members.filter((m) => isAvailable(m) && !used.has(m));
+			if (members.length === 0) continue;
+			members = await applyPoolStrategy(pool, members, entry.model);
+			for (const member of members) {
 				const m = tryGetModel(member, entry.model);
 				if (m) {
 					ordered.push({ model: m, provider: member, modelId: entry.model });

--- a/leeloo.js
+++ b/leeloo.js
@@ -361,8 +361,14 @@ async function checkCodexQuotaDetailed(provider) {
 	const headers = { Authorization: `Bearer ${apiKey}`, Accept: "application/json" };
 	if (accountId) headers["chatgpt-account-id"] = accountId;
 
+	// Check JWT expiry before making the API call
+	if (payload?.exp && payload.exp < Date.now() / 1000) {
+		return { score: null, status: "expired", error: "Token expired - re-login required" };
+	}
+
 	try {
 		const resp = await fetch(`${CODEX_USAGE_URL.replace(/\/+$/, "")}/wham/usage`, { headers });
+		if (resp.status === 401 || resp.status === 403) return { score: null, status: "expired", error: "Token rejected - re-login required" };
 		if (!resp.ok) return { score: null, status: "error", error: `HTTP ${resp.status}` };
 		const data = await resp.json();
 		const rl = data?.rate_limit;
@@ -392,7 +398,10 @@ async function checkCodexQuotaDetailed(provider) {
 			email: profileClaim?.email || data?.email || null,
 			windows,
 		};
-	} catch (e) { return { score: null, status: "error", error: e.message }; }
+	} catch (e) {
+		if (/expired|unauthorized|401/i.test(e.message)) return { score: null, status: "expired", error: e.message };
+		return { score: null, status: "error", error: e.message };
+	}
 }
 
 async function checkGeminiQuotaDetailed(provider) {
@@ -1002,36 +1011,56 @@ function handleSubDelete(req, res, subName) {
 
 const pendingLogins = new Map(); // provider -> { resolve, reject, authUrl, status }
 
-function handleAuthProviders(req, res) {
+async function handleAuthProviders(req, res) {
 	const provs = authStorage.getOAuthProviders();
 	const config = loadConfig();
 	const result = [];
 
+	// Collect all provider IDs to check
+	const allIds = [];
+
 	// Built-in providers
 	for (const p of provs) {
-		result.push({
-			id: p.id,
-			name: p.name,
-			baseProvider: p.id,
-			authenticated: authStorage.hasAuth(p.id),
-			isBuiltin: true,
-		});
+		allIds.push({ id: p.id, name: p.name, baseProvider: p.id, isBuiltin: true });
 	}
 
 	// Extra subscription accounts
 	for (const sub of config.subscriptions) {
 		const subId = `${sub.provider}-${sub.index}`;
-		if (result.some((r) => r.id === subId)) continue;
+		if (allIds.some((r) => r.id === subId)) continue;
 		const baseProv = provs.find((p) => p.id === sub.provider);
-		result.push({
+		allIds.push({
 			id: subId,
 			name: `${baseProv?.name || sub.provider} #${sub.index}${sub.label ? " (" + sub.label + ")" : ""}`,
 			baseProvider: sub.provider,
-			authenticated: authStorage.hasAuth(subId),
 			isBuiltin: false,
 			index: sub.index,
 			label: sub.label,
 		});
+	}
+
+	// Check actual auth status for each (fast: just checks stored creds + JWT expiry)
+	for (const entry of allIds) {
+		const hasAuth = authStorage.hasAuth(entry.id);
+		let tokenStatus = "no-auth";
+		if (hasAuth) {
+			const cred = authStorage.get(entry.id);
+			if (cred?.type === "oauth" && cred.access) {
+				// Quick JWT expiry check (no API call)
+				try {
+					const payload = decodeJwtPayload(cred.access);
+					if (payload?.exp && payload.exp < Date.now() / 1000) {
+						tokenStatus = "expired";
+					} else {
+						tokenStatus = "ok";
+					}
+				} catch {
+					// Non-JWT token (e.g. Google) -- assume ok if cred exists
+					tokenStatus = "ok";
+				}
+			}
+		}
+		result.push({ ...entry, authenticated: hasAuth, tokenStatus });
 	}
 
 	res.writeHead(200, json());

--- a/leeloo.js
+++ b/leeloo.js
@@ -107,32 +107,160 @@ const RATE_LIMIT_RE = [
 ];
 function isRateLimit(msg) { return RATE_LIMIT_RE.some((r) => r.test(msg)); }
 
+// ─── Pool state (exhausted tracking + cooldown) ──────────────────────────────
+
+const COOLDOWN_MS = 5 * 60 * 1000; // 5 min, same as extension
+const exhaustedMembers = new Map(); // provider -> timestamp
+
+function markExhausted(provider) {
+	exhaustedMembers.set(provider, Date.now());
+	log(`[pool] marked ${provider} exhausted (cooldown ${COOLDOWN_MS / 1000}s)`);
+}
+
+function isExhausted(provider) {
+	const ts = exhaustedMembers.get(provider);
+	if (!ts) return false;
+	if (Date.now() - ts >= COOLDOWN_MS) {
+		exhaustedMembers.delete(provider);
+		return false;
+	}
+	return true;
+}
+
+function isAvailable(provider) {
+	return authStorage.hasAuth(provider) && !isExhausted(provider);
+}
+
+// ─── Schedule evaluation (same logic as extension) ────────────────────────────
+
+const JS_DAY_TO_DOW = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"];
+
+function getDayOfWeek(date) { return JS_DAY_TO_DOW[date.getDay()]; }
+
+function isInHourRange(hour, range) {
+	const [start, end] = range;
+	return start <= end ? (hour >= start && hour < end) : (hour >= start || hour < end);
+}
+
+function isInScheduleWindow(window, now) {
+	if (window.days?.length > 0 && !window.days.includes(getDayOfWeek(now))) return false;
+	if (window.hours && !isInHourRange(now.getHours(), window.hours)) return false;
+	if (window.dateRange) {
+		const d = `${now.getFullYear()}-${String(now.getMonth()+1).padStart(2,"0")}-${String(now.getDate()).padStart(2,"0")}`;
+		if (window.dateRange.from && d < window.dateRange.from) return false;
+		if (window.dateRange.to && d > window.dateRange.to) return false;
+	}
+	return true;
+}
+
+function getWindowRemainingMs(window, now) {
+	if (!window.hours) return Infinity;
+	const end = new Date(now);
+	end.setHours(window.hours[1], 0, 0, 0);
+	let remaining = end.getTime() - now.getTime();
+	if (remaining <= 0) remaining += 24 * 60 * 60 * 1000;
+	return remaining;
+}
+
+/** Order members by schedule: preferred (in-window, shortest-remaining first) > default > overflow */
+function getScheduledOrder(pool, available) {
+	const schedule = pool.memberSchedule || {};
+	const now = new Date();
+	const preferred = [], defaults = [], overflow = [];
+
+	for (const prov of available) {
+		const s = schedule[prov];
+		if (!s) { defaults.push({ prov, remaining: Infinity }); continue; }
+		const role = s.role || "default";
+		if (role === "overflow") { overflow.push({ prov, remaining: Infinity }); continue; }
+		if (role === "preferred") {
+			const windows = s.windows || [];
+			if (windows.length === 0) { defaults.push({ prov, remaining: Infinity }); continue; }
+			let active = false, shortest = Infinity;
+			for (const w of windows) {
+				if (isInScheduleWindow(w, now)) {
+					active = true;
+					const r = getWindowRemainingMs(w, now);
+					if (r < shortest) shortest = r;
+				}
+			}
+			if (active) preferred.push({ prov, remaining: shortest });
+			// Preferred but NOT in window -> skip entirely (not even default)
+			continue;
+		}
+		defaults.push({ prov, remaining: Infinity });
+	}
+
+	preferred.sort((a, b) => a.remaining - b.remaining);
+	return [...preferred, ...defaults, ...overflow].map((x) => x.prov);
+}
+
+// ─── Custom selector script loader ────────────────────────────────────────────
+
+const selectorCache = new Map();
+
+async function loadSelector(scriptPath) {
+	let resolved = scriptPath;
+	if (!scriptPath.startsWith("/") && !scriptPath.startsWith("~/")) {
+		resolved = join(AGENT_DIR, scriptPath);
+	} else if (scriptPath.startsWith("~/")) {
+		const home = process.env.HOME || process.env.USERPROFILE || "";
+		resolved = join(home, scriptPath.slice(2));
+	}
+	if (selectorCache.has(resolved)) return selectorCache.get(resolved);
+	if (!existsSync(resolved)) { selectorCache.set(resolved, null); return null; }
+	try {
+		const mod = await import(resolved);
+		const fn = typeof mod.default === "function" ? mod.default : typeof mod === "function" ? mod : null;
+		selectorCache.set(resolved, fn);
+		return fn;
+	} catch { selectorCache.set(resolved, null); return null; }
+}
+
+async function runCustomSelector(pool, available, currentProvider, modelId) {
+	if (!pool.selectorScript) return null;
+	const fn = await loadSelector(pool.selectorScript);
+	if (!fn) return null;
+	const now = new Date();
+	try {
+		const result = await fn({
+			members: [...available],
+			currentProvider: currentProvider || "",
+			modelId,
+			pool: { name: pool.name, baseProvider: pool.baseProvider, members: [...pool.members] },
+			timestamp: now.getTime(),
+			hour: now.getHours(),
+			day: getDayOfWeek(now),
+		});
+		if (typeof result === "string" && available.includes(result)) return result;
+		if (Array.isArray(result)) {
+			const first = result.find((r) => typeof r === "string" && available.includes(r));
+			if (first) return first;
+		}
+	} catch { /* fall through */ }
+	return null;
+}
+
 // ─── Model resolution ─────────────────────────────────────────────────────────
 
-/**
- * Try to get a pi-ai Model for a given provider and modelId.
- * Returns null if the provider doesn't serve that model.
- */
 function tryGetModel(providerName, modelId) {
 	const base = getBaseProvider(providerName);
 	if (!base) return null;
 	try {
 		const m = getModel(base, modelId);
-		// Re-tag with the actual provider name (may be an extra sub)
 		return base !== providerName ? { ...m, provider: providerName } : m;
-	} catch {
-		return null;
-	}
+	} catch { return null; }
 }
 
 /**
  * Resolve a model ID (or preset name) into an ordered list of
- * { model, provider } candidates, respecting pools, chains, and presets.
+ * { model, provider, modelId } candidates, respecting pools, chains,
+ * presets, strategies, and exhausted state.
  */
-function resolveCandidates(modelId) {
+async function resolveCandidates(modelId) {
 	const config = loadConfig();
 
-	// ── 1. Check if modelId is a preset name ──
+	// ── 1. Preset resolution ──
 	const preset = config.presets.find(
 		(p) => p.enabled && p.name.toLowerCase() === modelId.toLowerCase(),
 	);
@@ -140,31 +268,53 @@ function resolveCandidates(modelId) {
 		const candidates = [];
 		for (const entry of preset.entries) {
 			if (!entry.enabled) continue;
-			if (!authStorage.hasAuth(entry.provider)) continue;
+			if (!isAvailable(entry.provider)) continue;
 			const m = tryGetModel(entry.provider, entry.model);
 			if (m) candidates.push({ model: m, provider: entry.provider, modelId: entry.model });
 		}
 		return candidates;
 	}
 
-	// ── 2. Collect all providers that can serve this model ──
+	// ── 2. Collect all providers that serve this model ──
 	const allProviders = getAllProviders();
 	const raw = [];
 	for (const prov of allProviders) {
+		if (!isAvailable(prov)) continue;
 		const m = tryGetModel(prov, modelId);
 		if (m) raw.push({ model: m, provider: prov, modelId });
 	}
 	if (raw.length === 0) return [];
 
-	// ── 3. Order by pool membership ──
-	// Providers in an enabled pool come first (in pool member order),
-	// then non-pool providers.
+	// ── 3. Strategy-aware pool ordering ──
 	const ordered = [];
 	const used = new Set();
 
 	for (const pool of config.pools) {
 		if (!pool.enabled) continue;
-		for (const member of pool.members) {
+		const poolMembers = pool.members.filter((m) => raw.some((c) => c.provider === m));
+		if (poolMembers.length === 0) continue;
+
+		const strategy = pool.strategy || "round-robin";
+		let memberOrder = poolMembers;
+
+		if (strategy === "scheduled" && pool.memberSchedule) {
+			memberOrder = getScheduledOrder(pool, poolMembers);
+			if (memberOrder.length > 0) {
+				log(`[pool:${pool.name}] scheduled: ${memberOrder[0]} selected by schedule priority`);
+			}
+		} else if (strategy === "custom" && pool.selectorScript) {
+			const best = await runCustomSelector(pool, poolMembers, "", modelId);
+			if (best) {
+				memberOrder = [best, ...poolMembers.filter((m) => m !== best)];
+				log(`[pool:${pool.name}] custom: selector chose ${best}`);
+			}
+		}
+		// quota-first: would need provider-specific quota APIs (Codex, Google).
+		// Fall back to pool member order -- the extension's quota checkers
+		// aren't available outside pi's runtime, but rate-limit failover
+		// still rotates through all members.
+
+		for (const member of memberOrder) {
 			const match = raw.find((c) => c.provider === member);
 			if (match && !used.has(member)) {
 				ordered.push(match);
@@ -173,7 +323,7 @@ function resolveCandidates(modelId) {
 		}
 	}
 
-	// ── 4. Append chain targets ──
+	// ── 4. Chain targets ──
 	for (const chain of config.chains) {
 		if (!chain.enabled) continue;
 		for (const entry of chain.entries) {
@@ -181,8 +331,7 @@ function resolveCandidates(modelId) {
 			const pool = config.pools.find((p) => p.name === entry.pool && p.enabled);
 			if (!pool) continue;
 			for (const member of pool.members) {
-				if (used.has(member)) continue;
-				// Chain entries may specify a different model
+				if (used.has(member) || !isAvailable(member)) continue;
 				const m = tryGetModel(member, entry.model);
 				if (m) {
 					ordered.push({ model: m, provider: member, modelId: entry.model });
@@ -192,12 +341,9 @@ function resolveCandidates(modelId) {
 		}
 	}
 
-	// ── 5. Append remaining non-pool providers ──
+	// ── 5. Remaining non-pool providers ──
 	for (const c of raw) {
-		if (!used.has(c.provider)) {
-			ordered.push(c);
-			used.add(c.provider);
-		}
+		if (!used.has(c.provider)) { ordered.push(c); used.add(c.provider); }
 	}
 
 	return ordered;
@@ -572,7 +718,7 @@ async function handleChatCompletions(req, res) {
 		return;
 	}
 
-	const candidates = resolveCandidates(requestModelId);
+	const candidates = await resolveCandidates(requestModelId);
 	if (candidates.length === 0) {
 		res.writeHead(404, json());
 		res.end(JSON.stringify({ error: { message: `No provider found for model "${requestModelId}"` } }));
@@ -616,8 +762,8 @@ async function handleChatCompletions(req, res) {
 			lastError = errMsg;
 
 			if (isRateLimit(errMsg)) {
+				markExhausted(candidate.provider);
 				log(`[${candidate.provider}] rate limited, failover -> next candidate`);
-				// If streaming already started writing, we can't retry
 				if (res.headersSent) return;
 				continue;
 			}
@@ -677,10 +823,12 @@ function handleModels(req, res) {
 function handleHealth(req, res) {
 	const config = loadConfig();
 	const providers = getAllProviders();
+	const exhausted = providers.filter((p) => isExhausted(p));
 	res.writeHead(200, json());
 	res.end(JSON.stringify({
 		status: "ok",
 		providers,
+		exhausted,
 		pools: config.pools.filter((p) => p.enabled).map((p) => ({
 			name: p.name,
 			strategy: p.strategy || "round-robin",

--- a/leeloo.js
+++ b/leeloo.js
@@ -31,7 +31,7 @@
  */
 
 import { createServer } from "node:http";
-import { readFileSync, existsSync, writeFileSync, mkdirSync, appendFileSync, createReadStream } from "node:fs";
+import { readFileSync, existsSync, writeFileSync, mkdirSync, appendFileSync, createReadStream, unlinkSync } from "node:fs";
 import { join, extname, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createInterface } from "node:readline";
@@ -1539,6 +1539,128 @@ function handleApiKeyDelete(req, res, name) {
 	const config = loadConfig();
 	config.apiKeys = config.apiKeys.filter((k) => k.name !== name);
 	saveConfig(config);
+	res.writeHead(200, json());
+	res.end(JSON.stringify({ deleted: name }));
+}
+
+// ─── Account CRUD (v2 unified primitive) ──────────────────────────────────────
+
+async function handleAccountCreate(req, res) {
+	const body = JSON.parse(await readBody(req));
+	const config = loadConfig();
+	const entry = {
+		id: body.id || `account-${Date.now()}`,
+		provider: body.provider || "openai",
+		kind: body.kind || "subscription",
+		key: body.key,
+		baseUrl: body.baseUrl,
+		label: body.label || "",
+		enabled: body.enabled !== false,
+	};
+	if (config.accounts.some((a) => a.id === entry.id)) {
+		res.writeHead(409, json());
+		res.end(JSON.stringify({ error: { message: `Account "${entry.id}" already exists` } }));
+		return;
+	}
+	config.accounts.push(entry);
+	saveConfig(config);
+	res.writeHead(201, json());
+	res.end(JSON.stringify({ account: entry }));
+}
+
+async function handleAccountUpdate(req, res, id) {
+	const body = JSON.parse(await readBody(req));
+	const config = loadConfig();
+	const idx = config.accounts.findIndex((a) => a.id === id);
+	if (idx < 0) { res.writeHead(404, json()); res.end(JSON.stringify({ error: { message: "Account not found" } })); return; }
+	config.accounts[idx] = { ...config.accounts[idx], ...body };
+	saveConfig(config);
+	res.writeHead(200, json());
+	res.end(JSON.stringify({ account: config.accounts[idx] }));
+}
+
+function handleAccountDelete(req, res, id) {
+	const config = loadConfig();
+	config.accounts = config.accounts.filter((a) => a.id !== id);
+	saveConfig(config);
+	res.writeHead(200, json());
+	res.end(JSON.stringify({ deleted: id }));
+}
+
+// ─── Files API (raw config file editor) ───────────────────────────────────────
+
+const FILE_REGISTRY = {
+	"multi-pass.json": { path: () => CONFIG_PATH, language: "json", create: () => JSON.stringify({ subscriptions: [], pools: [], chains: [], presets: [], apiKeys: [], accounts: [], modes: [], routingRules: [] }, null, 2) },
+	"multi-pass.config.js": { path: () => join(AGENT_DIR, "multi-pass.config.js"), language: "javascript", create: () => `// Power-user JS config -- when present, JSON config is ignored.\nimport { defineConfig, account, pool, mode, preset, rule } from "${join(ROOT_DIR, "config.js")}";\n\nexport default defineConfig({\n  accounts: [],\n  pools: [],\n  rules: [],\n  modes: [],\n  presets: [],\n});\n` },
+	"multi-pass-rules.json": { path: () => RULES_PATH, language: "json", create: () => JSON.stringify({ rules: [] }, null, 2) },
+	"multi-pass-users.json": { path: () => USERS_PATH, language: "json", create: () => JSON.stringify({ users: [] }, null, 2) },
+};
+
+function handleFilesList(req, res) {
+	const out = Object.entries(FILE_REGISTRY).map(([name, info]) => {
+		const p = info.path();
+		return { name, path: p, language: info.language, exists: existsSync(p) };
+	});
+	res.writeHead(200, json());
+	res.end(JSON.stringify({ files: out }));
+}
+
+function handleFileGet(req, res, name) {
+	const info = FILE_REGISTRY[name];
+	if (!info) { res.writeHead(404, json()); res.end(JSON.stringify({ error: { message: "Unknown file" } })); return; }
+	const p = info.path();
+	let content = "";
+	if (existsSync(p)) {
+		try { content = readFileSync(p, "utf-8"); } catch (e) { res.writeHead(500, json()); res.end(JSON.stringify({ error: { message: e.message } })); return; }
+	} else {
+		content = info.create();
+	}
+	res.writeHead(200, json());
+	res.end(JSON.stringify({ name, path: p, language: info.language, exists: existsSync(p), content }));
+}
+
+async function handleFilePut(req, res, name) {
+	const info = FILE_REGISTRY[name];
+	if (!info) { res.writeHead(404, json()); res.end(JSON.stringify({ error: { message: "Unknown file" } })); return; }
+	const body = JSON.parse(await readBody(req));
+	const content = body.content || "";
+
+	// Validate JSON files before writing
+	if (info.language === "json") {
+		try { JSON.parse(content); }
+		catch (e) {
+			res.writeHead(400, json());
+			res.end(JSON.stringify({ error: { message: `Invalid JSON: ${e.message}` } }));
+			return;
+		}
+	}
+
+	try {
+		ensureDir();
+		writeFileSync(info.path(), content, "utf-8");
+		// Force reload of in-memory caches
+		_jsConfigCache = null;
+		_jsConfigMtime = 0;
+		// If JS config file was just written, reload it now
+		const jsP = getJsConfigPath();
+		if (jsP) await loadJsConfig(jsP);
+		res.writeHead(200, json());
+		res.end(JSON.stringify({ saved: name, bytes: content.length }));
+	} catch (e) {
+		res.writeHead(500, json());
+		res.end(JSON.stringify({ error: { message: e.message } }));
+	}
+}
+
+function handleFileDelete(req, res, name) {
+	const info = FILE_REGISTRY[name];
+	if (!info) { res.writeHead(404, json()); res.end(JSON.stringify({ error: { message: "Unknown file" } })); return; }
+	const p = info.path();
+	if (existsSync(p)) {
+		try { unlinkSync(p); } catch {}
+	}
+	_jsConfigCache = null;
+	_jsConfigMtime = 0;
 	res.writeHead(200, json());
 	res.end(JSON.stringify({ deleted: name }));
 }
@@ -3053,6 +3175,15 @@ const server = createServer(async (req, res) => {
 		else if (path === "/v1/config/apikeys" && req.method === "POST") { if (!adminOnly()) await handleApiKeyCreate(req, res); }
 		else if (path.startsWith("/v1/config/apikeys/") && req.method === "PUT") { if (!adminOnly()) await handleApiKeyUpdate(req, res, decodeURIComponent(path.split("/v1/config/apikeys/")[1])); }
 		else if (path.startsWith("/v1/config/apikeys/") && req.method === "DELETE") { if (!adminOnly()) handleApiKeyDelete(req, res, decodeURIComponent(path.split("/v1/config/apikeys/")[1])); }
+		// Accounts (v2)
+		else if (path === "/v1/config/accounts" && req.method === "POST") { if (!adminOnly()) await handleAccountCreate(req, res); }
+		else if (path.startsWith("/v1/config/accounts/") && req.method === "PUT") { if (!adminOnly()) await handleAccountUpdate(req, res, decodeURIComponent(path.split("/v1/config/accounts/")[1])); }
+		else if (path.startsWith("/v1/config/accounts/") && req.method === "DELETE") { if (!adminOnly()) handleAccountDelete(req, res, decodeURIComponent(path.split("/v1/config/accounts/")[1])); }
+		// Files (raw editor) -- never read-only blocked, file ops always allowed for admin
+		else if (path === "/v1/files" && req.method === "GET") { if (!adminOnly()) handleFilesList(req, res); }
+		else if (path.startsWith("/v1/files/") && req.method === "GET") { if (!adminOnly()) handleFileGet(req, res, decodeURIComponent(path.split("/v1/files/")[1])); }
+		else if (path.startsWith("/v1/files/") && req.method === "PUT") { if (!adminOnly()) await handleFilePut(req, res, decodeURIComponent(path.split("/v1/files/")[1])); }
+		else if (path.startsWith("/v1/files/") && req.method === "DELETE") { if (!adminOnly()) handleFileDelete(req, res, decodeURIComponent(path.split("/v1/files/")[1])); }
 		// User management (admin only)
 		else if (path === "/v1/users" && req.method === "GET") { if (!adminOnly()) handleUsersList(req, res); }
 		else if (path === "/v1/users" && req.method === "POST") { if (!adminOnly()) await handleUserCreate(req, res); }

--- a/leeloo.js
+++ b/leeloo.js
@@ -1204,8 +1204,11 @@ function handleKnownNames(req, res) {
 	// Chain names
 	const chainNames = config.chains.filter((c) => c.enabled).map((c) => ({ id: `chain:${c.name}`, label: c.name, type: "chain" }));
 
+	// Preset names
+	const presetNames = config.presets.filter((p) => p.enabled).map((p) => ({ id: p.name, label: p.name, type: "preset" }));
+
 	res.writeHead(200, json());
-	res.end(JSON.stringify({ providers: allNames, pools: poolNames, chains: chainNames }));
+	res.end(JSON.stringify({ providers: allNames, pools: poolNames, chains: chainNames, presets: presetNames }));
 }
 
 function handleAuthStatus(req, res) {

--- a/leeloo.js
+++ b/leeloo.js
@@ -1676,7 +1676,7 @@ td{color:#ccc}
 
 <script>
 const BASE = location.origin;
-function esc(s){return String(s).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;")}
+function esc(s){return String(s).replace(/&/g,"&amp;").replace(/\x3c/g,"\x26lt;").replace(/>/g,"\x26gt;")}
 function showTab(id){document.querySelectorAll(".tab").forEach((t,i)=>{t.classList.toggle("active",t.textContent.toLowerCase().replace(" ","")===id)});document.querySelectorAll(".panel").forEach(p=>{p.classList.toggle("active",p.id===id)});loaders[id]?.()}
 function qc(pct){return pct==null?"#555":pct>50?"#4a4":pct>20?"#ca0":"#e44"}
 function bar(pct){if(pct==null)return"--";return'<span class="bar"><span class="bar-fill" style="width:'+pct+"%;background:"+qc(pct)+'"></span></span> '+pct+"%"}
@@ -2064,7 +2064,7 @@ function clearChat() {
   chat.innerHTML = '<div class="welcome"><h2>Leeloo on multi-pass</h2>Chat cleared.</div>';
 }
 
-function esc(s) { return String(s).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;"); }
+function esc(s) { return String(s).replace(/&/g,"&amp;").replace(/\x3c/g,"\x26lt;").replace(/>/g,"\x26gt;"); }
 
 async function sendMessage() {
   const text = input.value.trim();

--- a/leeloo.js
+++ b/leeloo.js
@@ -1729,8 +1729,8 @@ const loaders = {
       h+='<span class="badge '+esc(r.type)+'">'+esc(r.type)+'</span> ';
       h+='<span class="badge '+(r.enabled?"on":"off")+'">'+(r.enabled?"enabled":"disabled")+'</span>';
       h+='</div><div>';
-      h+='<button class="btn" onclick="toggleRule(\''+esc(r.name)+'\','+(!r.enabled)+')">'+(r.enabled?"Disable":"Enable")+'</button> ';
-      h+='<button class="btn danger" onclick="deleteRule(\''+esc(r.name)+'\')">Delete</button>';
+      h+='<button class="btn" data-action="toggle" data-rule="'+esc(r.name)+'" data-val="'+(!r.enabled)+'">'+(r.enabled?"Disable":"Enable")+'</button> ';
+      h+='<button class="btn danger" data-action="delete" data-rule="'+esc(r.name)+'">Delete</button>';
       h+='</div></div>';
       h+='<div class="meta">';
       if(r.scope)h+='scope: '+esc(r.scope)+' | ';
@@ -1810,7 +1810,7 @@ function showRuleForm(){
     +'<label>Model deny list</label><input id="rf-deny" placeholder="gpt-4o*">'
     +'<label>Max requests (for limit type)</label><input id="rf-max" type="number" placeholder="60">'
     +'<label>Window seconds</label><input id="rf-window" type="number" placeholder="60">'
-    +'<div style="display:flex;gap:8px;margin-top:8px"><button class="btn primary" onclick="createRule()">Create Rule</button><button class="btn" onclick="document.getElementById(\'rule-form-area\').innerHTML=\'\'">Cancel</button></div>'
+    +'<div style="display:flex;gap:8px;margin-top:8px"><button class="btn primary" data-action="create-rule">Create Rule</button><button class="btn" data-action="cancel-form">Cancel</button></div>'
     +'</div></div>';
 }
 async function createRule(){
@@ -1838,6 +1838,17 @@ async function createRule(){
   document.getElementById("rule-form-area").innerHTML="";
   loaders.rules();
 }
+
+// Event delegation for dynamic buttons
+document.addEventListener("click", async (e) => {
+  const btn = e.target.closest("[data-action]");
+  if (!btn) return;
+  const action = btn.dataset.action;
+  if (action === "toggle") { await toggleRule(btn.dataset.rule, btn.dataset.val === "true"); }
+  else if (action === "delete") { await deleteRule(btn.dataset.rule); }
+  else if (action === "create-rule") { await createRule(); }
+  else if (action === "cancel-form") { document.getElementById("rule-form-area").innerHTML = ""; }
+});
 
 loaders.dashboard();
 </script>

--- a/leeloo.js
+++ b/leeloo.js
@@ -35,6 +35,7 @@ import { readFileSync, existsSync, writeFileSync, mkdirSync, appendFileSync, cre
 import { join, extname, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createInterface } from "node:readline";
+import { randomBytes } from "node:crypto";
 import { AuthStorage, getAgentDir } from "@mariozechner/pi-coding-agent";
 import { getModel, getModels, stream } from "@mariozechner/pi-ai";
 
@@ -46,6 +47,10 @@ for (let i = 0; i < args.length; i++) {
 	if (args[i] === "--port" && args[i + 1]) PORT = parseInt(args[i + 1], 10);
 }
 
+// ─── Admin token ──────────────────────────────────────────────────────────────
+
+const ADMIN_TOKEN = process.env.LEELOO_KEY || randomBytes(24).toString("hex");
+
 // ─── Config ───────────────────────────────────────────────────────────────────
 
 const AGENT_DIR = getAgentDir();
@@ -53,8 +58,11 @@ const ROOT_DIR = dirname(fileURLToPath(import.meta.url));
 const WEB_DIR = join(ROOT_DIR, "web");
 const CONFIG_PATH = join(AGENT_DIR, "multi-pass.json");
 const RULES_PATH = join(AGENT_DIR, "multi-pass-rules.json");
+const USERS_PATH = join(AGENT_DIR, "multi-pass-users.json");
 const AUDIT_PATH = join(AGENT_DIR, "leeloo-audit.jsonl");
-const AUDIT_MAX_LINES = 5000; // max lines in JSONL file before rotation
+const USAGE_LOG_PATH = join(AGENT_DIR, "leeloo-usage.jsonl");
+const AUDIT_MAX_LINES = 5000;
+const USAGE_LOG_MAX_LINES = 10000;
 
 function ensureDir() {
 	if (!existsSync(AGENT_DIR)) mkdirSync(AGENT_DIR, { recursive: true });
@@ -111,6 +119,96 @@ function loadRules() {
 function saveRules(rules) {
 	ensureDir();
 	writeFileSync(RULES_PATH, JSON.stringify({ rules }, null, 2), "utf-8");
+}
+
+// ─── User management ────────────────────────────────────────────────────────
+// Users file: { users: [{ username, key, allowedPresets?, allowedPools?, enabled }] }
+
+function loadUsers() {
+	if (!existsSync(USERS_PATH)) return [];
+	try {
+		const raw = JSON.parse(readFileSync(USERS_PATH, "utf-8"));
+		return Array.isArray(raw.users) ? raw.users : [];
+	} catch { return []; }
+}
+
+function saveUsers(users) {
+	ensureDir();
+	writeFileSync(USERS_PATH, JSON.stringify({ users }, null, 2), "utf-8");
+}
+
+/**
+ * Authenticate a request. Returns { valid, role, user } where:
+ *  - role "admin" for admin token
+ *  - role "user" for user token with user object
+ *  - valid=false if token missing/invalid
+ */
+function authenticateRequest(req) {
+	const authHeader = req.headers.authorization;
+	const token = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null;
+
+	if (!token) return { valid: false, role: null, user: null };
+
+	// Admin token
+	if (token === ADMIN_TOKEN) return { valid: true, role: "admin", user: { username: "admin" } };
+
+	// User token
+	const users = loadUsers();
+	const user = users.find((u) => u.key === token && u.enabled !== false);
+	if (user) return { valid: true, role: "user", user };
+
+	return { valid: false, role: null, user: null };
+}
+
+/**
+ * Check if a user is allowed to use a specific model/preset/pool.
+ * Admin can do everything. Users with no restrictions can do everything.
+ * Users with allowedPresets/allowedPools are limited to those.
+ */
+function isModelAllowedForUser(user, role, modelId) {
+	if (role === "admin") return true;
+	if (!user) return false;
+
+	const hasRestrictions = (user.allowedPresets?.length > 0) || (user.allowedPools?.length > 0);
+	if (!hasRestrictions) return true;
+
+	const allowed = [...(user.allowedPresets || []), ...(user.allowedPools || []).map((p) => `pool:${p}`)];
+	// Check exact match or prefix match for pool:name/model
+	return allowed.some((a) => modelId === a || modelId.startsWith(a + "/"));
+}
+
+// ─── Persistent usage log (JSONL, per-user) ─────────────────────────────────
+
+function appendUsageLine(entry) {
+	try {
+		ensureDir();
+		appendFileSync(USAGE_LOG_PATH, JSON.stringify(entry) + "\n", "utf-8");
+	} catch {}
+}
+
+function rotateUsageLog() {
+	if (!existsSync(USAGE_LOG_PATH)) return;
+	try {
+		const content = readFileSync(USAGE_LOG_PATH, "utf-8");
+		const lines = content.split("\n").filter(Boolean);
+		if (lines.length <= USAGE_LOG_MAX_LINES) return;
+		const keep = lines.slice(-Math.floor(USAGE_LOG_MAX_LINES * 0.8));
+		writeFileSync(USAGE_LOG_PATH, keep.join("\n") + "\n", "utf-8");
+		log(`[usage] rotated: ${lines.length} -> ${keep.length} lines`);
+	} catch {}
+}
+
+async function loadUsageFromDisk(maxLines = 500) {
+	if (!existsSync(USAGE_LOG_PATH)) return [];
+	const entries = [];
+	try {
+		const rl = createInterface({ input: createReadStream(USAGE_LOG_PATH, "utf-8"), crlfDelay: Infinity });
+		for await (const line of rl) {
+			if (!line.trim()) continue;
+			try { entries.push(JSON.parse(line)); } catch {}
+		}
+	} catch {}
+	return entries.slice(-maxLines);
 }
 
 // ─── Persistent audit log (JSONL) ───────────────────────────────────────────
@@ -508,7 +606,9 @@ function clipText(value, maxLen = 4000) {
 	return text.slice(0, maxLen) + "\n...[truncated]";
 }
 
-function trackRequest(provider, modelId, usage, durationMs, error, requestText, responseText) {
+const userStats = {}; // { username: { requests, tokens_in, tokens_out, errors, last_used } }
+
+function trackRequest(provider, modelId, usage, durationMs, error, requestText, responseText, username) {
 	const entry = {
 		timestamp: new Date().toISOString(),
 		provider,
@@ -519,9 +619,11 @@ function trackRequest(provider, modelId, usage, durationMs, error, requestText, 
 		error: error || null,
 		request_text: clipText(requestText),
 		response_text: clipText(responseText),
+		user: username || null,
 	};
 	usageLog.push(entry);
 	if (usageLog.length > USAGE_LOG_MAX) usageLog.shift();
+	appendUsageLine(entry);
 
 	if (!providerStats[provider]) {
 		providerStats[provider] = { requests: 0, tokens_in: 0, tokens_out: 0, errors: 0, last_used: null };
@@ -532,6 +634,18 @@ function trackRequest(provider, modelId, usage, durationMs, error, requestText, 
 	s.tokens_out += entry.tokens_out;
 	if (error) s.errors++;
 	s.last_used = entry.timestamp;
+
+	if (username) {
+		if (!userStats[username]) {
+			userStats[username] = { requests: 0, tokens_in: 0, tokens_out: 0, errors: 0, last_used: null };
+		}
+		const u = userStats[username];
+		u.requests++;
+		u.tokens_in += entry.tokens_in;
+		u.tokens_out += entry.tokens_out;
+		if (error) u.errors++;
+		u.last_used = entry.timestamp;
+	}
 }
 
 // ─── Rule engine (DLP / policy enforcement) ─────────────────────────────────
@@ -1212,6 +1326,60 @@ async function handleAuthLogout(req, res, providerId) {
 	}
 }
 
+// ─── User CRUD API ────────────────────────────────────────────────────────────
+
+function handleUsersList(req, res) {
+	res.writeHead(200, json());
+	res.end(JSON.stringify({ users: loadUsers().map((u) => ({ ...u, key: u.key?.slice(0, 8) + "..." })) }));
+}
+
+async function handleUserCreate(req, res) {
+	const body = JSON.parse(await readBody(req));
+	const users = loadUsers();
+	const user = {
+		username: body.username || `user-${Date.now()}`,
+		key: body.key || randomBytes(24).toString("hex"),
+		enabled: body.enabled !== false,
+		allowedPresets: body.allowedPresets || [],
+		allowedPools: body.allowedPools || [],
+	};
+	if (users.some((u) => u.username === user.username)) {
+		res.writeHead(409, json());
+		res.end(JSON.stringify({ error: { message: `User "${user.username}" already exists` } }));
+		return;
+	}
+	users.push(user);
+	saveUsers(users);
+	res.writeHead(201, json());
+	res.end(JSON.stringify({ user })); // Return full key on create
+}
+
+async function handleUserUpdate(req, res, username) {
+	const body = JSON.parse(await readBody(req));
+	const users = loadUsers();
+	const idx = users.findIndex((u) => u.username === username);
+	if (idx < 0) { res.writeHead(404, json()); res.end(JSON.stringify({ error: { message: "User not found" } })); return; }
+	users[idx] = { ...users[idx], ...body };
+	saveUsers(users);
+	res.writeHead(200, json());
+	res.end(JSON.stringify({ user: { ...users[idx], key: users[idx].key?.slice(0, 8) + "..." } }));
+}
+
+function handleUserDelete(req, res, username) {
+	const users = loadUsers().filter((u) => u.username !== username);
+	saveUsers(users);
+	res.writeHead(200, json());
+	res.end(JSON.stringify({ deleted: username }));
+}
+
+function handleUserRevealKey(req, res, username) {
+	const users = loadUsers();
+	const user = users.find((u) => u.username === username);
+	if (!user) { res.writeHead(404, json()); res.end(JSON.stringify({ error: { message: "User not found" } })); return; }
+	res.writeHead(200, json());
+	res.end(JSON.stringify({ username: user.username, key: user.key }));
+}
+
 function handleAuditLog(req, res) {
 	const url = new URL(req.url, `http://localhost:${PORT}`);
 	const limit = parseInt(url.searchParams.get("limit") || "100", 10);
@@ -1659,7 +1827,7 @@ function formatUsage(u) {
 
 // ─── Streaming handler ────────────────────────────────────────────────────────
 
-async function handleStreaming(res, model, context, opts, requestModelId, actualProvider, requestText) {
+async function handleStreaming(res, model, context, opts, requestModelId, actualProvider, requestText, username) {
 	const t0 = Date.now();
 	res.writeHead(200, {
 		"Content-Type": "text/event-stream",
@@ -1755,7 +1923,7 @@ async function handleStreaming(res, model, context, opts, requestModelId, actual
 			case "done": {
 				const finish = toolCalls.size > 0 ? "tool_calls" : mapFinishReason(event.reason);
 				const usage = formatUsage(event.message?.usage);
-				trackRequest(actualProvider, model.id, event.message?.usage, Date.now() - t0, null, requestText, collectedResponseText);
+				trackRequest(actualProvider, model.id, event.message?.usage, Date.now() - t0, null, requestText, collectedResponseText, username);
 				const finalChunk = chunk(id, requestModelId, {}, finish, usage);
 				finalChunk.x_provider = actualProvider;
 				finalChunk.x_model = model.id;
@@ -1767,7 +1935,7 @@ async function handleStreaming(res, model, context, opts, requestModelId, actual
 
 			case "error": {
 				const errMsg = event.error?.errorMessage || "Unknown error";
-				trackRequest(actualProvider, model.id, null, Date.now() - t0, errMsg, requestText, collectedResponseText);
+				trackRequest(actualProvider, model.id, null, Date.now() - t0, errMsg, requestText, collectedResponseText, username);
 				if (isRateLimit(errMsg)) throw new Error(errMsg);
 				if (!sentRole) {
 					write(chunk(id, requestModelId, { role: "assistant", content: `[Error: ${errMsg}]` }, null));
@@ -1786,7 +1954,7 @@ async function handleStreaming(res, model, context, opts, requestModelId, actual
 
 // ─── Non-streaming handler ────────────────────────────────────────────────────
 
-async function handleNonStreaming(res, model, context, opts, requestModelId, actualProvider, requestText) {
+async function handleNonStreaming(res, model, context, opts, requestModelId, actualProvider, requestText, username) {
 	const t0 = Date.now();
 	const eventStream = stream(model, context, opts);
 	let fullText = "";
@@ -1815,7 +1983,7 @@ async function handleNonStreaming(res, model, context, opts, requestModelId, act
 				break;
 			case "error": {
 				const errMsg = event.error?.errorMessage || "Unknown error";
-				trackRequest(actualProvider, model.id, null, Date.now() - t0, errMsg, requestText, fullText);
+				trackRequest(actualProvider, model.id, null, Date.now() - t0, errMsg, requestText, fullText, username);
 				if (isRateLimit(errMsg)) throw new Error(errMsg);
 				throw new Error(errMsg);
 			}
@@ -1827,7 +1995,7 @@ async function handleNonStreaming(res, model, context, opts, requestModelId, act
 	if (respRules.length > 0 && fullText) {
 		const respBlock = checkResponseBlock(respRules, fullText);
 		if (respBlock.blocked) {
-			trackRequest(actualProvider, model.id, usage, Date.now() - t0, respBlock.message, requestText, fullText);
+			trackRequest(actualProvider, model.id, usage, Date.now() - t0, respBlock.message, requestText, fullText, username);
 			res.writeHead(403, json());
 			res.end(JSON.stringify({ error: { message: respBlock.message } }));
 			return;
@@ -1835,7 +2003,7 @@ async function handleNonStreaming(res, model, context, opts, requestModelId, act
 		fullText = redactResponse(respRules, fullText);
 	}
 
-	trackRequest(actualProvider, model.id, usage, Date.now() - t0, null, requestText, fullText);
+	trackRequest(actualProvider, model.id, usage, Date.now() - t0, null, requestText, fullText, username);
 
 	const message = { role: "assistant" };
 	if (toolCalls.length > 0) {
@@ -1859,6 +2027,15 @@ async function handleNonStreaming(res, model, context, opts, requestModelId, act
 // ─── Main request handler ─────────────────────────────────────────────────────
 
 async function handleChatCompletions(req, res) {
+	// Auth
+	const auth = authenticateRequest(req);
+	if (!auth.valid) {
+		res.writeHead(401, json());
+		res.end(JSON.stringify({ error: { message: "Unauthorized. Provide Bearer token in Authorization header." } }));
+		return;
+	}
+	const username = auth.user?.username || null;
+
 	const body = await readBody(req);
 	let parsed;
 	try { parsed = JSON.parse(body); }
@@ -1886,6 +2063,13 @@ async function handleChatCompletions(req, res) {
 	if (!requestModelId || !requestMessages) {
 		res.writeHead(400, json());
 		res.end(JSON.stringify({ error: { message: "model and messages are required" } }));
+		return;
+	}
+
+	// ── User access check ──
+	if (!isModelAllowedForUser(auth.user, auth.role, requestModelId)) {
+		res.writeHead(403, json());
+		res.end(JSON.stringify({ error: { message: `Model "${requestModelId}" is not allowed for user "${username}". Allowed: ${[...(auth.user.allowedPresets || []), ...(auth.user.allowedPools || []).map((p) => "pool:" + p)].join(", ") || "none"}` } }));
 		return;
 	}
 
@@ -1950,9 +2134,9 @@ async function handleChatCompletions(req, res) {
 			log(`[${candidate.provider}] ${candidate.modelId} (attempt ${attempt + 1}/${maxAttempts})`);
 
 			if (doStream) {
-				await handleStreaming(res, candidate.model, context, opts, requestModelId, candidate.provider, requestText);
+				await handleStreaming(res, candidate.model, context, opts, requestModelId, candidate.provider, requestText, username);
 			} else {
-				await handleNonStreaming(res, candidate.model, context, opts, requestModelId, candidate.provider, requestText);
+				await handleNonStreaming(res, candidate.model, context, opts, requestModelId, candidate.provider, requestText, username);
 			}
 			return;
 
@@ -2148,6 +2332,7 @@ function handleStats(req, res) {
 			label: getProviderLabel(prov),
 			...s,
 		})),
+		users: Object.entries(userStats).map(([user, s]) => ({ username: user, ...s })),
 		recent: usageLog.slice(-limit).reverse(),
 	}));
 }
@@ -2209,41 +2394,73 @@ const server = createServer(async (req, res) => {
 
 	const path = new URL(req.url, `http://localhost:${PORT}`).pathname;
 	try {
+		// ── Public routes (no auth) ──
+		if (path === "/health" && req.method === "GET") { handleHealth(req, res); return; }
+		if (path.startsWith("/web/") && req.method === "GET") { handleWebAsset(req, res, path); return; }
+		if (path === "/admin" || path === "/ui" || path === "/") { (path === "/admin" ? handleAdmin : handleUI)(req, res); return; }
+
+		// ── Token verify endpoint (for login screens) ──
+		if (path === "/v1/auth/verify" && req.method === "POST") {
+			const auth = authenticateRequest(req);
+			if (!auth.valid) { res.writeHead(401, json()); res.end(JSON.stringify({ valid: false })); }
+			else { res.writeHead(200, json()); res.end(JSON.stringify({ valid: true, role: auth.role, username: auth.user?.username, allowedPresets: auth.user?.allowedPresets, allowedPools: auth.user?.allowedPools })); }
+			return;
+		}
+
+		// ── Auth required for all /v1/* endpoints ──
+		const auth = authenticateRequest(req);
+		if (!auth.valid) {
+			res.writeHead(401, json());
+			res.end(JSON.stringify({ error: { message: "Unauthorized. Provide Bearer token in Authorization header." } }));
+			return;
+		}
+
+		// ── Admin-only routes ──
+		const isAdmin = auth.role === "admin";
+		const adminOnly = () => {
+			if (!isAdmin) { res.writeHead(403, json()); res.end(JSON.stringify({ error: { message: "Admin access required" } })); return true; }
+			return false;
+		};
+
+		// ── API routes ──
 		if (path === "/v1/chat/completions" && req.method === "POST") await handleChatCompletions(req, res);
 		else if (path === "/v1/models" && req.method === "GET") handleModels(req, res);
 		else if (path === "/v1/routing" && req.method === "GET") handleRouting(req, res);
-		else if (path === "/v1/quota" && req.method === "GET") await handleQuota(req, res);
-		else if (path === "/v1/stats" && req.method === "GET") handleStats(req, res);
-		else if (path === "/v1/rules" && req.method === "GET") handleRulesList(req, res);
-		else if (path === "/v1/rules" && req.method === "POST") await handleRulesCreate(req, res);
-		else if (path.startsWith("/v1/rules/") && req.method === "PUT") await handleRulesUpdate(req, res, decodeURIComponent(path.split("/v1/rules/")[1]));
-		else if (path.startsWith("/v1/rules/") && req.method === "DELETE") handleRulesDelete(req, res, decodeURIComponent(path.split("/v1/rules/")[1]));
-		else if (path === "/v1/audit" && req.method === "GET") handleAuditLog(req, res);
-		else if (path === "/v1/auth/providers" && req.method === "GET") handleAuthProviders(req, res);
-		else if (path === "/v1/auth/status" && req.method === "GET") handleAuthStatus(req, res);
-		else if (path === "/v1/auth/names" && req.method === "GET") handleKnownNames(req, res);
-		else if (path.startsWith("/v1/auth/login/") && req.method === "POST") await handleAuthLogin(req, res, decodeURIComponent(path.split("/v1/auth/login/")[1]));
-		else if (path.startsWith("/v1/auth/login/") && req.method === "GET") handleAuthLoginStatus(req, res, decodeURIComponent(path.split("/v1/auth/login/")[1]));
-		else if (path.startsWith("/v1/auth/logout/") && req.method === "POST") await handleAuthLogout(req, res, decodeURIComponent(path.split("/v1/auth/logout/")[1]));
-		else if (path === "/v1/config" && req.method === "GET") handleConfigGet(req, res);
-		else if (path === "/v1/config" && req.method === "PUT") await handleConfigPut(req, res);
-		else if (path === "/v1/config/pools" && req.method === "GET") await handlePoolsGet(req, res);
-		else if (path === "/v1/config/pools" && req.method === "POST") await handlePoolCreate(req, res);
-		else if (path.startsWith("/v1/config/pools/") && req.method === "PUT") await handlePoolUpdate(req, res, decodeURIComponent(path.split("/v1/config/pools/")[1]));
-		else if (path.startsWith("/v1/config/pools/") && req.method === "DELETE") handlePoolDelete(req, res, decodeURIComponent(path.split("/v1/config/pools/")[1]));
-		else if (path === "/v1/config/chains" && req.method === "POST") await handleChainCreate(req, res);
-		else if (path.startsWith("/v1/config/chains/") && req.method === "PUT") await handleChainUpdate(req, res, decodeURIComponent(path.split("/v1/config/chains/")[1]));
-		else if (path.startsWith("/v1/config/chains/") && req.method === "DELETE") handleChainDelete(req, res, decodeURIComponent(path.split("/v1/config/chains/")[1]));
-		else if (path === "/v1/config/presets" && req.method === "POST") await handlePresetCreate(req, res);
-		else if (path.startsWith("/v1/config/presets/") && req.method === "PUT") await handlePresetUpdate(req, res, decodeURIComponent(path.split("/v1/config/presets/")[1]));
-		else if (path.startsWith("/v1/config/presets/") && req.method === "DELETE") handlePresetDelete(req, res, decodeURIComponent(path.split("/v1/config/presets/")[1]));
-		else if (path === "/v1/config/subscriptions" && req.method === "POST") await handleSubCreate(req, res);
-		else if (path.startsWith("/v1/config/subscriptions/") && req.method === "PUT") await handleSubUpdate(req, res, decodeURIComponent(path.split("/v1/config/subscriptions/")[1]));
-		else if (path.startsWith("/v1/config/subscriptions/") && req.method === "DELETE") handleSubDelete(req, res, decodeURIComponent(path.split("/v1/config/subscriptions/")[1]));
-		else if (path === "/health" && req.method === "GET") handleHealth(req, res);
-		else if (path.startsWith("/web/") && req.method === "GET") handleWebAsset(req, res, path);
-		else if (path === "/admin") handleAdmin(req, res);
-		else if (path === "/ui" || path === "/") handleUI(req, res);
+		// Admin-only endpoints
+		else if (path === "/v1/quota" && req.method === "GET") { if (!adminOnly()) await handleQuota(req, res); }
+		else if (path === "/v1/stats" && req.method === "GET") { if (!adminOnly()) handleStats(req, res); }
+		else if (path === "/v1/rules" && req.method === "GET") { if (!adminOnly()) handleRulesList(req, res); }
+		else if (path === "/v1/rules" && req.method === "POST") { if (!adminOnly()) await handleRulesCreate(req, res); }
+		else if (path.startsWith("/v1/rules/") && req.method === "PUT") { if (!adminOnly()) await handleRulesUpdate(req, res, decodeURIComponent(path.split("/v1/rules/")[1])); }
+		else if (path.startsWith("/v1/rules/") && req.method === "DELETE") { if (!adminOnly()) handleRulesDelete(req, res, decodeURIComponent(path.split("/v1/rules/")[1])); }
+		else if (path === "/v1/audit" && req.method === "GET") { if (!adminOnly()) handleAuditLog(req, res); }
+		else if (path === "/v1/auth/providers" && req.method === "GET") { if (!adminOnly()) await handleAuthProviders(req, res); }
+		else if (path === "/v1/auth/status" && req.method === "GET") { if (!adminOnly()) handleAuthStatus(req, res); }
+		else if (path === "/v1/auth/names" && req.method === "GET") { if (!adminOnly()) handleKnownNames(req, res); }
+		else if (path.startsWith("/v1/auth/login/") && req.method === "POST") { if (!adminOnly()) await handleAuthLogin(req, res, decodeURIComponent(path.split("/v1/auth/login/")[1])); }
+		else if (path.startsWith("/v1/auth/login/") && req.method === "GET") { if (!adminOnly()) handleAuthLoginStatus(req, res, decodeURIComponent(path.split("/v1/auth/login/")[1])); }
+		else if (path.startsWith("/v1/auth/logout/") && req.method === "POST") { if (!adminOnly()) await handleAuthLogout(req, res, decodeURIComponent(path.split("/v1/auth/logout/")[1])); }
+		else if (path === "/v1/config" && req.method === "GET") { if (!adminOnly()) handleConfigGet(req, res); }
+		else if (path === "/v1/config" && req.method === "PUT") { if (!adminOnly()) await handleConfigPut(req, res); }
+		else if (path === "/v1/config/pools" && req.method === "GET") { if (!adminOnly()) await handlePoolsGet(req, res); }
+		else if (path === "/v1/config/pools" && req.method === "POST") { if (!adminOnly()) await handlePoolCreate(req, res); }
+		else if (path.startsWith("/v1/config/pools/") && req.method === "PUT") { if (!adminOnly()) await handlePoolUpdate(req, res, decodeURIComponent(path.split("/v1/config/pools/")[1])); }
+		else if (path.startsWith("/v1/config/pools/") && req.method === "DELETE") { if (!adminOnly()) handlePoolDelete(req, res, decodeURIComponent(path.split("/v1/config/pools/")[1])); }
+		else if (path === "/v1/config/chains" && req.method === "POST") { if (!adminOnly()) await handleChainCreate(req, res); }
+		else if (path.startsWith("/v1/config/chains/") && req.method === "PUT") { if (!adminOnly()) await handleChainUpdate(req, res, decodeURIComponent(path.split("/v1/config/chains/")[1])); }
+		else if (path.startsWith("/v1/config/chains/") && req.method === "DELETE") { if (!adminOnly()) handleChainDelete(req, res, decodeURIComponent(path.split("/v1/config/chains/")[1])); }
+		else if (path === "/v1/config/presets" && req.method === "POST") { if (!adminOnly()) await handlePresetCreate(req, res); }
+		else if (path.startsWith("/v1/config/presets/") && req.method === "PUT") { if (!adminOnly()) await handlePresetUpdate(req, res, decodeURIComponent(path.split("/v1/config/presets/")[1])); }
+		else if (path.startsWith("/v1/config/presets/") && req.method === "DELETE") { if (!adminOnly()) handlePresetDelete(req, res, decodeURIComponent(path.split("/v1/config/presets/")[1])); }
+		else if (path === "/v1/config/subscriptions" && req.method === "POST") { if (!adminOnly()) await handleSubCreate(req, res); }
+		else if (path.startsWith("/v1/config/subscriptions/") && req.method === "PUT") { if (!adminOnly()) await handleSubUpdate(req, res, decodeURIComponent(path.split("/v1/config/subscriptions/")[1])); }
+		else if (path.startsWith("/v1/config/subscriptions/") && req.method === "DELETE") { if (!adminOnly()) handleSubDelete(req, res, decodeURIComponent(path.split("/v1/config/subscriptions/")[1])); }
+		// User management (admin only)
+		else if (path === "/v1/users" && req.method === "GET") { if (!adminOnly()) handleUsersList(req, res); }
+		else if (path === "/v1/users" && req.method === "POST") { if (!adminOnly()) await handleUserCreate(req, res); }
+		else if (path.startsWith("/v1/users/") && path.endsWith("/key") && req.method === "GET") { if (!adminOnly()) handleUserRevealKey(req, res, decodeURIComponent(path.split("/v1/users/")[1].replace("/key", ""))); }
+		else if (path.startsWith("/v1/users/") && req.method === "PUT") { if (!adminOnly()) await handleUserUpdate(req, res, decodeURIComponent(path.split("/v1/users/")[1])); }
+		else if (path.startsWith("/v1/users/") && req.method === "DELETE") { if (!adminOnly()) handleUserDelete(req, res, decodeURIComponent(path.split("/v1/users/")[1])); }
 		else { res.writeHead(404, json()); res.end(JSON.stringify({ error: { message: "Not found" } })); }
 	} catch (err) {
 		log("Unhandled:", err?.message || err);
@@ -2283,5 +2500,10 @@ server.listen(PORT, () => {
 
   OPENAI_BASE_URL=http://localhost:${PORT}/v1
   Chat UI: http://localhost:${PORT}/ui
+
+  Admin token: ${ADMIN_TOKEN}
+  ${process.env.LEELOO_KEY ? "(from LEELOO_KEY env)" : "(random, set LEELOO_KEY env to persist)"}
 `);
+
+	rotateUsageLog();
 });

--- a/leeloo.js
+++ b/leeloo.js
@@ -948,6 +948,119 @@ function handleSubDelete(req, res, subName) {
 	res.end(JSON.stringify({ deleted: subName }));
 }
 
+// ─── Auth / OAuth API ─────────────────────────────────────────────────────────
+
+const pendingLogins = new Map(); // provider -> { resolve, reject, authUrl, status }
+
+function handleAuthProviders(req, res) {
+	const provs = authStorage.getOAuthProviders();
+	const authed = getAllProviders();
+	const result = provs.map((p) => ({
+		id: p.id,
+		name: p.name,
+		authenticated: authed.includes(p.id) && authStorage.hasAuth(p.id),
+	}));
+	res.writeHead(200, json());
+	res.end(JSON.stringify({ providers: result }));
+}
+
+function handleAuthStatus(req, res) {
+	const providerList = getAllProviders();
+	const result = {};
+	for (const p of providerList) {
+		result[p] = { hasAuth: authStorage.hasAuth(p), label: getProviderLabel(p) };
+	}
+	res.writeHead(200, json());
+	res.end(JSON.stringify({ status: result }));
+}
+
+async function handleAuthLogin(req, res, providerId) {
+	// Check if already logging in
+	if (pendingLogins.has(providerId)) {
+		const pending = pendingLogins.get(providerId);
+		if (pending.authUrl) {
+			res.writeHead(200, json());
+			res.end(JSON.stringify({ status: "pending", authUrl: pending.authUrl, message: "Login already in progress. Open the URL to complete." }));
+			return;
+		}
+	}
+
+	log(`[auth] starting OAuth login for ${providerId}`);
+
+	let authUrl = null;
+	let loginResolve, loginReject;
+	const loginPromise = new Promise((resolve, reject) => { loginResolve = resolve; loginReject = reject; });
+
+	pendingLogins.set(providerId, { authUrl: null, status: "starting" });
+
+	// Start login in background
+	authStorage.login(providerId, {
+		onAuth(info) {
+			const url = typeof info === "string" ? info : info?.url || info;
+			authUrl = url;
+			const pending = pendingLogins.get(providerId);
+			if (pending) { pending.authUrl = url; pending.status = "waiting"; }
+			log(`[auth] ${providerId} auth URL ready`);
+		},
+		onPrompt(msg) { log(`[auth] ${providerId} prompt: ${msg}`); },
+		onProgress(msg) { log(`[auth] ${providerId} progress: ${msg}`); },
+		onManualCodeInput() {
+			// Return a promise that never resolves -- we rely on the callback server
+			return new Promise(() => {});
+		},
+		signal: undefined,
+	}).then(() => {
+		log(`[auth] ${providerId} login successful`);
+		pendingLogins.delete(providerId);
+		loginResolve({ success: true });
+	}).catch((err) => {
+		log(`[auth] ${providerId} login failed: ${err.message}`);
+		pendingLogins.delete(providerId);
+		loginReject(err);
+	});
+
+	// Wait for authUrl to be available (max 10s)
+	const t0 = Date.now();
+	while (!authUrl && Date.now() - t0 < 10000) {
+		await new Promise((r) => setTimeout(r, 100));
+	}
+
+	if (!authUrl) {
+		pendingLogins.delete(providerId);
+		res.writeHead(500, json());
+		res.end(JSON.stringify({ error: { message: "Timed out waiting for auth URL" } }));
+		return;
+	}
+
+	res.writeHead(200, json());
+	res.end(JSON.stringify({ status: "pending", authUrl, message: "Open the URL to complete OAuth login." }));
+}
+
+function handleAuthLoginStatus(req, res, providerId) {
+	const pending = pendingLogins.get(providerId);
+	if (pending) {
+		res.writeHead(200, json());
+		res.end(JSON.stringify({ status: pending.status, authUrl: pending.authUrl }));
+		return;
+	}
+	// Check if now authenticated
+	const hasAuth = authStorage.hasAuth(providerId);
+	res.writeHead(200, json());
+	res.end(JSON.stringify({ status: hasAuth ? "authenticated" : "not_authenticated", hasAuth }));
+}
+
+async function handleAuthLogout(req, res, providerId) {
+	try {
+		authStorage.remove(providerId);
+		log(`[auth] ${providerId} logged out`);
+		res.writeHead(200, json());
+		res.end(JSON.stringify({ status: "logged_out", provider: providerId }));
+	} catch (e) {
+		res.writeHead(500, json());
+		res.end(JSON.stringify({ error: { message: e.message } }));
+	}
+}
+
 function handleAuditLog(req, res) {
 	const url = new URL(req.url, `http://localhost:${PORT}`);
 	const limit = parseInt(url.searchParams.get("limit") || "100", 10);
@@ -1954,6 +2067,11 @@ const server = createServer(async (req, res) => {
 		else if (path.startsWith("/v1/rules/") && req.method === "PUT") await handleRulesUpdate(req, res, decodeURIComponent(path.split("/v1/rules/")[1]));
 		else if (path.startsWith("/v1/rules/") && req.method === "DELETE") handleRulesDelete(req, res, decodeURIComponent(path.split("/v1/rules/")[1]));
 		else if (path === "/v1/audit" && req.method === "GET") handleAuditLog(req, res);
+		else if (path === "/v1/auth/providers" && req.method === "GET") handleAuthProviders(req, res);
+		else if (path === "/v1/auth/status" && req.method === "GET") handleAuthStatus(req, res);
+		else if (path.startsWith("/v1/auth/login/") && req.method === "POST") await handleAuthLogin(req, res, decodeURIComponent(path.split("/v1/auth/login/")[1]));
+		else if (path.startsWith("/v1/auth/login/") && req.method === "GET") handleAuthLoginStatus(req, res, decodeURIComponent(path.split("/v1/auth/login/")[1]));
+		else if (path.startsWith("/v1/auth/logout/") && req.method === "POST") await handleAuthLogout(req, res, decodeURIComponent(path.split("/v1/auth/logout/")[1]));
 		else if (path === "/v1/config" && req.method === "GET") handleConfigGet(req, res);
 		else if (path === "/v1/config" && req.method === "PUT") await handleConfigPut(req, res);
 		else if (path === "/v1/config/pools" && req.method === "GET") await handlePoolsGet(req, res);

--- a/leeloo.js
+++ b/leeloo.js
@@ -425,10 +425,11 @@ const auditLog = [];
 const AUDIT_LOG_MAX = 1000;
 const rateLimitCounters = {}; // { ruleName: { count, windowStart } }
 
-function auditEvent(rule, action, detail, matchedText, fullMessage, source) {
+function auditEvent(rule, action, detail, matchedText, fullMessage, source, redactedMessage) {
 	const matched = typeof matchedText === "string" ? matchedText : null;
 	const full = typeof fullMessage === "string" ? fullMessage : null;
-	const base = full || matched;
+	const redacted = typeof redactedMessage === "string" ? redactedMessage : null;
+	const base = full || redacted || matched;
 	const entry = {
 		timestamp: new Date().toISOString(),
 		rule: rule.name,
@@ -439,6 +440,7 @@ function auditEvent(rule, action, detail, matchedText, fullMessage, source) {
 		snippet: base ? base.slice(0, 200) : null,
 		matched_text: matched,
 		full_message: full,
+		redacted_message: redacted,
 	};
 	auditLog.push(entry);
 	if (auditLog.length > AUDIT_LOG_MAX) auditLog.shift();
@@ -499,6 +501,7 @@ function evaluateContentRules(rules, messages, scope) {
 					auditEvent(rule, "warned", `Pattern matched: ${re.source}`, matched, text, scope);
 				} else if (rule.type === "redact") {
 					const replacement = rule.replacement || "[REDACTED]";
+					const beforeText = text;
 					// Redact in all message contents
 					messages = messages.map((m) => {
 						if (typeof m.content === "string") {
@@ -512,7 +515,8 @@ function evaluateContentRules(rules, messages, scope) {
 						return m;
 					});
 					modified = true;
-					auditEvent(rule, "redacted", `Pattern replaced: ${re.source}`, matched, text, scope);
+					text = extractText(messages);
+					auditEvent(rule, "redacted", `Pattern replaced: ${re.source}`, matched, beforeText, scope, text);
 				}
 			}
 			re.lastIndex = 0; // reset global regex
@@ -596,9 +600,11 @@ function redactResponse(rules, text) {
 				const re = new RegExp(p, "gi");
 				if (re.test(text)) {
 					const matched = text.match(re)?.[0] || null;
-					auditEvent(rule, "redacted-response", `Pattern replaced: ${re.source}`, matched, text, "response");
+					const beforeText = text;
 					re.lastIndex = 0;
-					text = text.replace(re, replacement);
+					const afterText = text.replace(re, replacement);
+					auditEvent(rule, "redacted-response", `Pattern replaced: ${re.source}`, matched, beforeText, "response", afterText);
+					text = afterText;
 				}
 			} catch {}
 		}
@@ -1758,16 +1764,20 @@ const loaders = {
     const data = await fetch(BASE+"/v1/audit").then(r=>r.json());
     let h = '<h2>Audit Log</h2>';
     if(!data.entries?.length){h+='<div class="empty">No audit events yet. Events appear when rules match requests or responses.</div>';}
-    else{h+='<table><tr><th>Time</th><th>Rule</th><th>Type</th><th>Action</th><th>Source</th><th>Detail</th><th>Matched</th><th>Full message</th></tr>';
+    else{h+='<table><tr><th>Time</th><th>Rule</th><th>Type</th><th>Action</th><th>Source</th><th>Detail</th><th>Matched</th><th>Message (before)</th><th>Message (after redaction)</th></tr>';
     for(const e of data.entries){
       const fullMsg = e.full_message
         ? '<details><summary>view ('+e.full_message.length+' chars)</summary><pre style="white-space:pre-wrap;word-break:break-word;max-height:280px;overflow:auto;background:#0a0a0a;border:1px solid #222;border-radius:6px;padding:8px;margin-top:6px">'+esc(e.full_message)+'</pre></details>'
+        : '--';
+      const redactedMsg = e.redacted_message
+        ? '<details><summary>view ('+e.redacted_message.length+' chars)</summary><pre style="white-space:pre-wrap;word-break:break-word;max-height:280px;overflow:auto;background:#0a0a0a;border:1px solid #222;border-radius:6px;padding:8px;margin-top:6px">'+esc(e.redacted_message)+'</pre></details>'
         : '--';
       h+='<tr><td>'+ago(e.timestamp)+'</td><td>'+esc(e.rule)+'</td>';
       h+='<td><span class="badge '+esc(e.type)+'">'+esc(e.type)+'</span></td>';
       h+='<td>'+esc(e.action)+'</td><td>'+esc(e.source||'--')+'</td><td>'+esc(e.detail)+'</td>';
       h+='<td>'+(e.matched_text?esc(e.matched_text):'--')+'</td>';
-      h+='<td>'+fullMsg+'</td></tr>';
+      h+='<td>'+fullMsg+'</td>';
+      h+='<td>'+redactedMsg+'</td></tr>';
     }h+='</table>';}
     document.getElementById("audit").innerHTML = h;
   },

--- a/leeloo.js
+++ b/leeloo.js
@@ -69,9 +69,12 @@ const envFile = loadEnvFile();
 
 const args = process.argv.slice(2);
 let PORT = parseInt(process.env.LEELOO_PORT || "4000", 10);
+let CLI_COMMAND = null;
 for (let i = 0; i < args.length; i++) {
 	if (args[i] === "--port" && args[i + 1]) PORT = parseInt(args[i + 1], 10);
-	if (args[i] === "init") { await runInit(); process.exit(0); }
+	if (args[i] === "init") CLI_COMMAND = "init";
+	if (args[i] === "migrate") CLI_COMMAND = "migrate";
+	if (args[i] === "export-js") CLI_COMMAND = "export-js";
 }
 
 // ─── Admin token ──────────────────────────────────────────────────────────────
@@ -3115,6 +3118,147 @@ async function runInit() {
 `);
 	rl.close();
 }
+
+// ─── Migration: v1 -> v2 shape ────────────────────────────────────────────────
+
+async function runMigrate() {
+	if (!existsSync(CONFIG_PATH)) {
+		console.log(`No config at ${CONFIG_PATH}. Run 'leeloo init' first.`);
+		return;
+	}
+
+	const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+	const before = JSON.stringify(raw, null, 2);
+
+	// Backup
+	const backupPath = CONFIG_PATH + ".v1.bak";
+	writeFileSync(backupPath, before, "utf-8");
+	console.log(`\n  Backed up ${CONFIG_PATH} -> ${backupPath}`);
+
+	// Build accounts from subscriptions + apiKeys + base providers seen in pools
+	const accounts = Array.isArray(raw.accounts) ? [...raw.accounts] : [];
+	const accountIds = new Set(accounts.map((a) => a.id));
+
+	for (const sub of raw.subscriptions || []) {
+		const id = `${sub.provider}-${sub.index}`;
+		if (!accountIds.has(id)) {
+			accounts.push({ id, provider: sub.provider, kind: "subscription", label: sub.label || "" });
+			accountIds.add(id);
+		}
+	}
+	for (const k of raw.apiKeys || []) {
+		if (!accountIds.has(k.name)) {
+			accounts.push({ id: k.name, provider: "openai", kind: "apiKey", key: k.key, baseUrl: k.baseUrl, label: k.label || "" });
+			accountIds.add(k.name);
+		}
+	}
+
+	// Convert old presets that have entries[] to new shape with mode
+	const modes = Array.isArray(raw.modes) ? [...raw.modes] : [];
+	const newPresets = [];
+	for (const p of raw.presets || []) {
+		if (p.mode) { newPresets.push(p); continue; } // already v2
+		if (!p.entries || p.entries.length === 0) { newPresets.push(p); continue; }
+
+		// Generate a mode from the entries
+		const modeId = `mode-${p.name}`;
+		const modeCandidates = p.entries.filter((e) => e.enabled !== false).map((e) => e.provider);
+		const preferredModels = p.entries.filter((e) => e.enabled !== false && e.model).map((e) => e.model);
+		modes.push({
+			id: modeId,
+			description: `Auto-generated from preset "${p.name}"`,
+			candidates: modeCandidates,
+			rules: ["builtin-cooldown"],
+			onError: "next-in-order",
+		});
+		newPresets.push({
+			...p,
+			mode: modeId,
+			preferredModels,
+			fallbackModels: [],
+		});
+	}
+
+	// Ensure builtin cooldown rule exists
+	const routingRules = Array.isArray(raw.routingRules) ? [...raw.routingRules] : [];
+	if (!routingRules.find((r) => r.id === "builtin-cooldown")) {
+		routingRules.push({ id: "builtin-cooldown", type: "cooldown", description: "Skip exhausted candidates" });
+	}
+
+	const v2 = {
+		...raw,
+		accounts,
+		modes,
+		routingRules,
+		presets: newPresets,
+	};
+
+	writeFileSync(CONFIG_PATH, JSON.stringify(v2, null, 2), "utf-8");
+
+	console.log(`\n  Migration complete:`);
+	console.log(`    accounts: ${accounts.length} (was ${(raw.accounts || []).length})`);
+	console.log(`    modes:    ${modes.length} (was ${(raw.modes || []).length})`);
+	console.log(`    rules:    ${routingRules.length} (was ${(raw.routingRules || []).length})`);
+	console.log(`    presets:  ${newPresets.length}`);
+	console.log(`\n  Restore with: cp ${backupPath} ${CONFIG_PATH}\n`);
+}
+
+// ─── Export: JSON -> JS config ────────────────────────────────────────────────
+
+async function runExportJs() {
+	if (!existsSync(CONFIG_PATH)) {
+		console.log(`No config at ${CONFIG_PATH}.`);
+		return;
+	}
+	const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+
+	const accountsCode = (raw.accounts || []).map((a) => `    account("${a.id}", ${JSON.stringify({ provider: a.provider, kind: a.kind, label: a.label, key: a.key, baseUrl: a.baseUrl })})`).join(",\n");
+	const poolsCode = (raw.pools || []).map((p) => `    pool("${p.name || p.id}", ${JSON.stringify({ baseProvider: p.baseProvider, members: p.members, strategy: p.strategy })})`).join(",\n");
+	const rulesCode = (raw.routingRules || []).map((r) => {
+		if (r.type === "time-window") return `    rule.timeWindow("${r.id}", ${JSON.stringify(r.params)})`;
+		if (r.type === "quota-burn") return `    rule.quotaBurn("${r.id}", ${JSON.stringify(r.params || {})})`;
+		if (r.type === "cost-tier") return `    rule.costTier("${r.id}", ${JSON.stringify(r.params)})`;
+		if (r.type === "cooldown") return `    rule.cooldown("${r.id}")`;
+		if (r.type === "model-fit") return `    rule.modelFit("${r.id}", ${JSON.stringify(r.params)})`;
+		if (r.type === "error-blacklist") return `    rule.errorBlacklist("${r.id}", ${JSON.stringify(r.params || {})})`;
+		if (r.type === "custom") return `    rule.custom("${r.id}", ${JSON.stringify(r.params?.code || "")})`;
+		return `    /* unknown rule type: ${r.type} */`;
+	}).join(",\n");
+	const modesCode = (raw.modes || []).map((m) => `    mode("${m.id}", ${JSON.stringify({ description: m.description, candidates: m.candidates, rules: m.rules, onError: m.onError })})`).join(",\n");
+	const presetsCode = (raw.presets || []).map((p) => `    preset("${p.name || p.id}", ${JSON.stringify({ mode: p.mode, preferredModels: p.preferredModels, fallbackModels: p.fallbackModels, entries: p.entries })})`).join(",\n");
+
+	const out = `// Auto-generated from ${CONFIG_PATH}
+// Edit freely -- when this file exists, JSON config is ignored.
+import { defineConfig, account, pool, mode, preset, rule } from "/PATH/TO/pi-multi-pass/config.js";
+
+export default defineConfig({
+  accounts: [
+${accountsCode}
+  ],
+  pools: [
+${poolsCode}
+  ],
+  rules: [
+${rulesCode}
+  ],
+  modes: [
+${modesCode}
+  ],
+  presets: [
+${presetsCode}
+  ],
+});
+`;
+	const outPath = join(AGENT_DIR, "multi-pass.config.js.exported");
+	writeFileSync(outPath, out, "utf-8");
+	console.log(`\n  Exported to ${outPath}`);
+	console.log(`  Update the import path, then move to ${join(AGENT_DIR, "multi-pass.config.js")} to activate.\n`);
+}
+
+// Run CLI commands and exit (no server)
+if (CLI_COMMAND === "init") { await runInit(); process.exit(0); }
+if (CLI_COMMAND === "migrate") { await runMigrate(); process.exit(0); }
+if (CLI_COMMAND === "export-js") { await runExportJs(); process.exit(0); }
 
 // Load JS config (if any) before binding the server
 const _jsPath = getJsConfigPath();

--- a/leeloo.js
+++ b/leeloo.js
@@ -1060,7 +1060,7 @@ const CHAT_UI_HTML = `<!DOCTYPE html>
 <html lang="en"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Leeloo Dallas Multi Pass</title>
-<script src="https://cdn.jsdelivr.net/npm/streaming-markdown@latest/smd.min.js"></script>
+
 <style>
 *{box-sizing:border-box;margin:0;padding:0}
 body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:#0a0a0a;color:#e0e0e0;height:100vh;display:flex;flex-direction:column}
@@ -1163,7 +1163,8 @@ body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;b
   <button id="send" onclick="sendMessage()">Send</button>
 </div>
 
-<script>
+<script type="module">
+import * as smd from "https://cdn.jsdelivr.net/npm/streaming-markdown@latest/smd.min.js";
 const BASE = location.origin;
 const chat = document.getElementById("chat");
 const input = document.getElementById("input");

--- a/leeloo.js
+++ b/leeloo.js
@@ -1060,42 +1060,96 @@ const CHAT_UI_HTML = `<!DOCTYPE html>
 <html lang="en"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Leeloo Dallas Multi Pass</title>
+<script src="https://cdn.jsdelivr.net/npm/streaming-markdown@latest/smd.min.js"></script>
 <style>
 *{box-sizing:border-box;margin:0;padding:0}
 body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:#0a0a0a;color:#e0e0e0;height:100vh;display:flex;flex-direction:column}
-header{background:#111;border-bottom:1px solid #222;padding:12px 20px;display:flex;align-items:center;gap:12px;flex-shrink:0;flex-wrap:wrap}
-header h1{font-size:15px;color:#f90;font-weight:700;white-space:nowrap;letter-spacing:.5px}
-header select{background:#1a1a1a;color:#e0e0e0;border:1px solid #333;border-radius:6px;padding:7px 12px;font-size:13px;min-width:260px;cursor:pointer}
-header select:focus{border-color:#f90;outline:none}
-header select optgroup{color:#999;font-style:normal;font-weight:600;font-size:12px}
-header select option{color:#e0e0e0;padding:4px}
-.status{margin-left:auto;font-size:12px;color:#555;display:flex;align-items:center;gap:6px}
-.status .dot{width:7px;height:7px;border-radius:50%;background:#444}
-.status .dot.ok{background:#4a4}
-.status .dot.busy{background:#f90}
+
+/* ── Top bar ── */
+#topbar{background:#111;border-bottom:1px solid #222;flex-shrink:0}
+#bar-main{padding:10px 20px;display:flex;align-items:center;gap:12px;flex-wrap:wrap}
+#bar-main h1{font-size:14px;color:#f90;font-weight:700;letter-spacing:.5px;white-space:nowrap}
+#bar-main select{background:#1a1a1a;color:#e0e0e0;border:1px solid #333;border-radius:6px;padding:6px 10px;font-size:13px;min-width:240px;cursor:pointer}
+#bar-main select:focus{border-color:#f90;outline:none}
+#bar-main select optgroup{color:#888;font-style:normal;font-weight:600;font-size:11px}
+.bar-actions{display:flex;gap:6px;margin-left:auto;align-items:center}
+.bar-btn{background:none;border:1px solid #333;color:#888;border-radius:5px;padding:3px 9px;font-size:11px;cursor:pointer}
+.bar-btn:hover{border-color:#666;color:#ccc}
+.dot{width:7px;height:7px;border-radius:50%;background:#444;display:inline-block}
+.dot.ok{background:#4a4}.dot.busy{background:#f90;animation:blink 1s infinite}
+@keyframes blink{50%{opacity:.4}}
+#status-text{font-size:11px;color:#555}
+
+/* ── Info strip ── */
+#info-strip{display:none;padding:6px 20px;background:#0d0d0d;border-bottom:1px solid #1a1a1a;font-size:11px;color:#555;overflow-x:auto;white-space:nowrap}
+#info-strip .tag{display:inline-block;padding:2px 8px;margin-right:6px;border-radius:4px;border:1px solid #222;background:#111}
+#info-strip .tag b{color:#888;font-weight:600}
+#info-strip .tag .val{color:#aaa}
+#info-strip .tag.pool{border-color:#2a2a3a}
+#info-strip .tag.preset{border-color:#3a2a1a}
+#info-strip .tag.provider{border-color:#1a2a1a}
+#info-strip .tag.exhausted{border-color:#4a1a1a;color:#a66}
+
+/* ── Chat ── */
 #chat{flex:1;overflow-y:auto;padding:20px;display:flex;flex-direction:column;gap:14px}
-.msg{max-width:80%;padding:12px 16px;border-radius:14px;line-height:1.6;font-size:14px;white-space:pre-wrap;word-wrap:break-word}
-.msg.user{align-self:flex-end;background:#1a3a5c;color:#cde;border-bottom-right-radius:4px}
-.msg.assistant{align-self:flex-start;background:#151515;border:1px solid #222;border-bottom-left-radius:4px}
-.msg .meta{font-size:11px;color:#555;margin-top:8px;border-top:1px solid #222;padding-top:6px}
+.msg{max-width:82%;border-radius:14px;line-height:1.6;font-size:14px;word-wrap:break-word;overflow:hidden}
+.msg.user{align-self:flex-end;background:#1a3a5c;color:#cde;border-bottom-right-radius:4px;padding:12px 16px;white-space:pre-wrap}
+.msg.assistant{align-self:flex-start;background:#151515;border:1px solid #222;border-bottom-left-radius:4px;padding:0}
+.msg .md-body{padding:12px 16px}
+.msg .meta{font-size:11px;color:#555;padding:6px 16px;border-top:1px solid #222;background:#0d0d0d;display:flex;gap:12px;flex-wrap:wrap;border-radius:0 0 0 14px}
+.msg .meta .provider-tag{color:#f90}
 .welcome{text-align:center;color:#444;padding:60px 20px;font-size:14px;line-height:2}
 .welcome h2{color:#f90;font-size:18px;margin-bottom:8px;font-weight:600}
-#input-area{border-top:1px solid #222;padding:12px 20px;display:flex;gap:10px;flex-shrink:0;background:#111}
+
+/* ── Thinking indicator ── */
+.thinking{padding:12px 16px;display:flex;align-items:center;gap:8px;color:#888;font-size:13px}
+.thinking .dots{display:flex;gap:4px}
+.thinking .dots span{width:6px;height:6px;border-radius:50%;background:#f90;animation:pulse 1.4s infinite}
+.thinking .dots span:nth-child(2){animation-delay:.2s}
+.thinking .dots span:nth-child(3){animation-delay:.4s}
+@keyframes pulse{0%,80%,100%{opacity:.2;transform:scale(.8)}40%{opacity:1;transform:scale(1)}}
+
+/* ── Markdown styles ── */
+.md-body p{margin:0 0 8px}
+.md-body p:last-child{margin:0}
+.md-body code{background:#0d0d0d;padding:1px 5px;border-radius:3px;font-size:13px;font-family:"SF Mono",Menlo,monospace}
+.md-body pre{background:#0d0d0d;padding:12px;border-radius:8px;overflow-x:auto;margin:8px 0;border:1px solid #222}
+.md-body pre code{background:none;padding:0;font-size:13px}
+.md-body ul,.md-body ol{margin:4px 0 4px 20px}
+.md-body blockquote{border-left:3px solid #333;padding-left:12px;margin:4px 0;color:#999}
+.md-body h1,.md-body h2,.md-body h3{margin:8px 0 4px;color:#ddd}
+.md-body h1{font-size:18px} .md-body h2{font-size:16px} .md-body h3{font-size:14px}
+.md-body table{border-collapse:collapse;margin:8px 0}
+.md-body td,.md-body th{border:1px solid #333;padding:4px 8px;font-size:13px}
+.md-body th{background:#1a1a1a}
+.md-body a{color:#6af}
+.md-body strong{color:#eee}
+
+/* ── Input ── */
+#input-area{border-top:1px solid #222;padding:10px 20px;display:flex;gap:10px;flex-shrink:0;background:#111}
 #input-area textarea{flex:1;background:#1a1a1a;color:#e0e0e0;border:1px solid #333;border-radius:10px;padding:10px 14px;font-size:14px;font-family:inherit;resize:none;min-height:44px;max-height:140px;line-height:1.5}
 #input-area textarea:focus{outline:none;border-color:#f90}
+#input-area textarea:disabled{opacity:.5}
 #input-area button{background:#f90;color:#000;border:none;border-radius:10px;padding:0 22px;font-weight:700;cursor:pointer;font-size:14px;transition:background .15s}
 #input-area button:hover{background:#fa0}
 #input-area button:disabled{opacity:.3;cursor:default}
-.clear-btn{background:none;border:1px solid #333;color:#666;border-radius:6px;padding:4px 10px;font-size:11px;cursor:pointer;margin-left:4px}
-.clear-btn:hover{border-color:#666;color:#aaa}
 </style>
 </head><body>
-<header>
-  <h1>LEELOO DALLAS MULTI PASS</h1>
-  <select id="model-select"><option>Loading...</option></select>
-  <button class="clear-btn" onclick="clearChat()">Clear</button>
-  <span class="status"><span class="dot" id="dot"></span><span id="status">loading...</span></span>
-</header>
+
+<div id="topbar">
+  <div id="bar-main">
+    <h1>LEELOO DALLAS MULTI PASS</h1>
+    <select id="model-select"><option>Loading...</option></select>
+    <div class="bar-actions">
+      <button class="bar-btn" onclick="clearChat()">Clear</button>
+      <button class="bar-btn" onclick="toggleInfo()">Config</button>
+      <span class="dot" id="dot"></span>
+      <span id="status-text">loading...</span>
+    </div>
+  </div>
+  <div id="info-strip"></div>
+</div>
+
 <div id="chat">
   <div class="welcome">
     <h2>LEELOO DALLAS MULTI PASS</h2>
@@ -1103,28 +1157,62 @@ header select option{color:#e0e0e0;padding:4px}
     Requests route through your multi-pass pools with automatic failover.
   </div>
 </div>
+
 <div id="input-area">
-  <textarea id="input" rows="1" placeholder="Type a message... (Enter to send, Shift+Enter for newline)" autofocus></textarea>
+  <textarea id="input" rows="1" placeholder="Type a message... (Enter to send)" autofocus></textarea>
   <button id="send" onclick="sendMessage()">Send</button>
 </div>
+
 <script>
 const BASE = location.origin;
 const chat = document.getElementById("chat");
 const input = document.getElementById("input");
 const sel = document.getElementById("model-select");
 const sendBtn = document.getElementById("send");
-const statusEl = document.getElementById("status");
-const dot = document.getElementById("dot");
+const statusEl = document.getElementById("status-text");
+const dotEl = document.getElementById("dot");
+const infoStrip = document.getElementById("info-strip");
 let messages = [];
 let streaming = false;
+let infoVisible = false;
 
 input.addEventListener("input", () => { input.style.height = "auto"; input.style.height = Math.min(input.scrollHeight, 140) + "px"; });
 input.addEventListener("keydown", (e) => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); sendMessage(); } });
 
+function setStatus(state, text) {
+  statusEl.textContent = text;
+  dotEl.className = "dot " + (state === "ready" ? "ok" : state === "busy" ? "busy" : "");
+}
+
+// ── Load config info ──
+async function loadInfo() {
+  try {
+    const h = await (await fetch(BASE + "/health")).json();
+    const tags = [];
+    for (const p of (h.pools || [])) {
+      tags.push('<span class="tag pool"><b>' + esc(p.name) + '</b> <span class="val">' + esc(p.strategy) + ' (' + p.members.length + ')</span></span>');
+    }
+    for (const p of (h.presets || [])) {
+      tags.push('<span class="tag preset"><b>' + esc(p.name) + '</b> <span class="val">' + esc(p.entries.join(" > ")) + '</span></span>');
+    }
+    for (const p of (h.providers || [])) {
+      const exh = (h.exhausted || []).includes(p);
+      tags.push('<span class="tag provider' + (exh ? " exhausted" : "") + '"><b>' + esc(p) + '</b>' + (exh ? ' <span class="val">exhausted</span>' : ' <span class="val">ok</span>') + '</span>');
+    }
+    infoStrip.innerHTML = tags.join("");
+  } catch {}
+}
+
+function toggleInfo() {
+  infoVisible = !infoVisible;
+  infoStrip.style.display = infoVisible ? "block" : "none";
+  if (infoVisible) loadInfo();
+}
+
+// ── Load routing ──
 async function loadRouting() {
   try {
-    const resp = await fetch(BASE + "/v1/routing");
-    const data = await resp.json();
+    const data = await (await fetch(BASE + "/v1/routing")).json();
     sel.innerHTML = "";
     let count = 0;
     for (const group of (data.groups || [])) {
@@ -1144,44 +1232,50 @@ async function loadRouting() {
   } catch (e) { setStatus("error", e.message); }
 }
 
-function setStatus(state, text) {
-  statusEl.textContent = text;
-  dot.className = "dot " + (state === "ready" ? "ok" : state === "busy" ? "busy" : "");
+function clearChat() {
+  messages = [];
+  chat.innerHTML = '<div class="welcome"><h2>LEELOO DALLAS MULTI PASS</h2>Chat cleared.</div>';
 }
 
-function clearChat() { messages = []; chat.innerHTML = '<div class="welcome"><h2>LEELOO DALLAS MULTI PASS</h2>Chat cleared.</div>'; }
-
-function addMessage(role, content, meta) {
-  // Remove welcome message
-  const w = chat.querySelector(".welcome"); if (w) w.remove();
-  const div = document.createElement("div");
-  div.className = "msg " + role;
-  div.innerHTML = esc(content) + (meta ? '<div class="meta">' + esc(meta) + '</div>' : '');
-  chat.appendChild(div);
-  chat.scrollTop = chat.scrollHeight;
-  return div;
-}
-
-function esc(s) { return s.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;"); }
+function esc(s) { return String(s).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;"); }
 
 async function sendMessage() {
   const text = input.value.trim();
   if (!text || streaming) return;
   input.value = ""; input.style.height = "auto";
   messages.push({ role: "user", content: text });
-  addMessage("user", text);
-  streaming = true; sendBtn.disabled = true;
-  setStatus("busy", "streaming...");
 
-  const div = addMessage("assistant", "");
+  // Remove welcome
+  const w = chat.querySelector(".welcome"); if (w) w.remove();
+
+  // User bubble
+  const userDiv = document.createElement("div");
+  userDiv.className = "msg user";
+  userDiv.textContent = text;
+  chat.appendChild(userDiv);
+
+  // Assistant bubble with thinking indicator
+  const msgDiv = document.createElement("div");
+  msgDiv.className = "msg assistant";
+  msgDiv.innerHTML = '<div class="thinking"><div class="dots"><span></span><span></span><span></span></div>Thinking...</div>';
+  chat.appendChild(msgDiv);
+  chat.scrollTop = chat.scrollHeight;
+
+  streaming = true; sendBtn.disabled = true; input.disabled = true;
+  setStatus("busy", "connecting...");
+
   let full = "";
+  let gotFirstToken = false;
+  let smdParser = null;
+  let mdBody = null;
   const t0 = Date.now();
+  const selectedModel = sel.value;
 
   try {
     const resp = await fetch(BASE + "/v1/chat/completions", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ model: sel.value, messages, stream: true }),
+      body: JSON.stringify({ model: selectedModel, messages, stream: true }),
     });
 
     if (!resp.ok) {
@@ -1191,7 +1285,7 @@ async function sendMessage() {
 
     const reader = resp.body.getReader();
     const dec = new TextDecoder();
-    let buf = "", usage = null;
+    let buf = "", usage = null, routedProvider = "";
 
     while (true) {
       const { done, value } = await reader.read();
@@ -1206,30 +1300,70 @@ async function sendMessage() {
         try {
           const j = JSON.parse(p);
           const d = j.choices?.[0]?.delta;
-          if (d?.content) { full += d.content; div.innerHTML = esc(full); chat.scrollTop = chat.scrollHeight; }
-          if (d?.tool_calls) { const tc = d.tool_calls[0]; full += "[tool: " + (tc?.function?.name || "?") + "(" + (tc?.function?.arguments || "") + ")]"; div.innerHTML = esc(full); }
+
+          if (d?.content) {
+            if (!gotFirstToken) {
+              gotFirstToken = true;
+              mdBody = document.createElement("div");
+              mdBody.className = "md-body";
+              msgDiv.innerHTML = "";
+              msgDiv.appendChild(mdBody);
+              smdParser = smd.parser(smd.default_renderer(mdBody));
+              setStatus("busy", "receiving...");
+            }
+            full += d.content;
+            smd.parser_write(smdParser, d.content);
+            chat.scrollTop = chat.scrollHeight;
+          }
+
+          if (d?.tool_calls) {
+            if (!gotFirstToken) {
+              gotFirstToken = true;
+              mdBody = document.createElement("div");
+              mdBody.className = "md-body";
+              msgDiv.innerHTML = "";
+              msgDiv.appendChild(mdBody);
+              smdParser = smd.parser(smd.default_renderer(mdBody));
+            }
+            const tc = d.tool_calls[0];
+            const tcText = "\\n**Tool call:** \`" + (tc?.function?.name || "?") + "\`\\n";
+            full += tcText;
+            smd.parser_write(smdParser, tcText);
+          }
+
           if (j.usage) usage = j.usage;
+          if (j.model && !routedProvider) routedProvider = j.model;
+
           if (j.choices?.[0]?.finish_reason) {
+            if (smdParser) smd.parser_end(smdParser);
             const ms = Date.now() - t0;
-            const parts = [sel.value];
+            const meta = document.createElement("div");
+            meta.className = "meta";
+            const parts = [];
+            parts.push('<span class="provider-tag">' + esc(selectedModel) + '</span>');
             if (usage) parts.push(usage.prompt_tokens + " in / " + usage.completion_tokens + " out");
-            parts.push(ms + "ms");
-            div.innerHTML = esc(full) + '<div class="meta">' + esc(parts.join(" | ")) + '</div>';
+            parts.push((ms / 1000).toFixed(1) + "s");
+            meta.innerHTML = parts.join('<span style="color:#333">|</span>');
+            msgDiv.appendChild(meta);
           }
         } catch {}
       }
     }
     messages.push({ role: "assistant", content: full });
   } catch (e) {
-    div.innerHTML = '<span style="color:#f44">' + esc("[Error: " + e.message + "]") + '</span>';
+    msgDiv.innerHTML = '<div class="md-body" style="color:#f44;padding:12px 16px">[Error: ' + esc(e.message) + ']</div>';
   }
-  streaming = false; sendBtn.disabled = false;
+
+  streaming = false; sendBtn.disabled = false; input.disabled = false;
+  input.focus();
   setStatus("ready", "done");
+  if (infoVisible) loadInfo(); // refresh exhausted state
 }
 
 loadRouting();
 </script>
 </body></html>`;
+
 
 // ─── Server ───────────────────────────────────────────────────────────────────
 

--- a/leeloo.js
+++ b/leeloo.js
@@ -33,15 +33,8 @@
 import { createServer } from "node:http";
 import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
-import {
-	AuthStorage,
-	getAgentDir,
-} from "@mariozechner/pi-coding-agent";
-import {
-	getModel,
-	getModels,
-	stream,
-} from "@mariozechner/pi-ai";
+import { AuthStorage, getAgentDir } from "@mariozechner/pi-coding-agent";
+import { getModel, getModels, stream } from "@mariozechner/pi-ai";
 
 // ─── CLI args ─────────────────────────────────────────────────────────────────
 

--- a/leeloo.js
+++ b/leeloo.js
@@ -1252,11 +1252,9 @@ async function handleAuthProviders(req, res) {
 		if (allIds.some((r) => r.id === k.name)) continue;
 		allIds.push({
 			id: k.name,
-			name: `${k.label || k.name}`,
-			baseProvider: k.type || "openai",
+			name: k.label || k.name,
 			isBuiltin: false,
 			isApiKey: true,
-			baseUrl: k.baseUrl,
 			models: k.models,
 		});
 	}
@@ -1442,14 +1440,20 @@ async function handleAuthLogout(req, res, providerId) {
 
 // ─── API Key CRUD ─────────────────────────────────────────────────────────────
 
+function inferBaseUrl(key) {
+	if (!key) return "https://api.openai.com/v1";
+	if (key.startsWith("sk-ant-")) return "https://api.anthropic.com/v1";
+	return "https://api.openai.com/v1";
+}
+
 async function handleApiKeyCreate(req, res) {
 	const body = JSON.parse(await readBody(req));
 	const config = loadConfig();
+	const key = body.key || "";
 	const entry = {
 		name: body.name || `key-${Date.now()}`,
-		type: body.type || "openai",
-		key: body.key || "",
-		baseUrl: body.baseUrl || "https://api.openai.com/v1",
+		key,
+		baseUrl: body.baseUrl || inferBaseUrl(key),
 		models: body.models || [],
 		enabled: body.enabled !== false,
 		label: body.label || "",
@@ -1657,7 +1661,7 @@ function tryGetModel(providerName, modelId) {
 	if (keyEntry) {
 		const models = keyEntry.models || [];
 		if (models.length > 0 && !models.includes(modelId)) return null;
-		return { id: modelId, provider: providerName, __apiKey: true, __baseUrl: keyEntry.baseUrl || "https://api.openai.com/v1" };
+		return { id: modelId, provider: providerName, __apiKey: true };
 	}
 
 	const base = getBaseProvider(providerName);
@@ -1672,20 +1676,13 @@ function tryGetModel(providerName, modelId) {
  * Bypasses pi-ai entirely -- just forwards the request and streams back.
  */
 async function proxyToApiKeyProvider(res, keyEntry, apiKey, requestBody, doStream) {
-	const baseUrl = (keyEntry.baseUrl || "https://api.openai.com/v1").replace(/\/+$/, "");
+	const baseUrl = (keyEntry.baseUrl || inferBaseUrl(apiKey)).replace(/\/+$/, "");
 	const url = `${baseUrl}/chat/completions`;
 
 	const headers = {
 		"Content-Type": "application/json",
 		Authorization: `Bearer ${apiKey}`,
 	};
-
-	// Anthropic API uses a different header
-	if (keyEntry.type === "anthropic") {
-		headers["x-api-key"] = apiKey;
-		headers["anthropic-version"] = "2023-06-01";
-		delete headers.Authorization;
-	}
 
 	const resp = await fetch(url, { method: "POST", headers, body: JSON.stringify(requestBody) });
 

--- a/leeloo.js
+++ b/leeloo.js
@@ -959,6 +959,61 @@ function handleModels(req, res) {
 
 // ─── /health ──────────────────────────────────────────────────────────────────
 
+/** Returns only models/presets from multi-pass config -- used by the chat UI. */
+function handleRouting(req, res) {
+	const config = loadConfig();
+	const groups = [];
+
+	// Presets
+	const presets = config.presets.filter((p) => p.enabled);
+	if (presets.length > 0) {
+		groups.push({
+			label: "Presets",
+			items: presets.map((p) => ({
+				id: p.name,
+				name: p.name,
+				detail: p.entries.filter((e) => e.enabled).map((e) => `${e.provider}/${e.model}`).join(" -> "),
+			})),
+		});
+	}
+
+	// Pools -- show models available from each pool's base provider
+	for (const pool of config.pools) {
+		if (!pool.enabled) continue;
+		try {
+			const models = getModels(pool.baseProvider);
+			const available = pool.members.filter((m) => authStorage.hasAuth(m));
+			if (available.length === 0) continue;
+			groups.push({
+				label: `${pool.name} [${pool.strategy || "round-robin"}] (${available.length} members)`,
+				items: models.map((m) => ({
+					id: m.id,
+					name: m.id,
+					detail: `${pool.baseProvider} via ${available.join(", ")}`,
+				})),
+			});
+		} catch { /* skip */ }
+	}
+
+	// Non-pool providers (authenticated but not in any pool)
+	const pooled = new Set(config.pools.flatMap((p) => p.members));
+	const standalone = getAllProviders().filter((p) => !pooled.has(p));
+	for (const prov of standalone) {
+		const base = getBaseProvider(prov);
+		if (!base) continue;
+		try {
+			const models = getModels(base);
+			groups.push({
+				label: prov,
+				items: models.map((m) => ({ id: m.id, name: m.id, detail: prov })),
+			});
+		} catch { /* skip */ }
+	}
+
+	res.writeHead(200, json());
+	res.end(JSON.stringify({ groups }));
+}
+
 function handleHealth(req, res) {
 	const config = loadConfig();
 	const providers = getAllProviders();
@@ -1008,97 +1063,106 @@ const CHAT_UI_HTML = `<!DOCTYPE html>
 <style>
 *{box-sizing:border-box;margin:0;padding:0}
 body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:#0a0a0a;color:#e0e0e0;height:100vh;display:flex;flex-direction:column}
-header{background:#111;border-bottom:1px solid #222;padding:12px 20px;display:flex;align-items:center;gap:16px;flex-shrink:0}
-header h1{font-size:16px;color:#f90;font-weight:600;white-space:nowrap}
-header select{background:#1a1a1a;color:#e0e0e0;border:1px solid #333;border-radius:6px;padding:6px 12px;font-size:13px;min-width:200px}
-header .status{margin-left:auto;font-size:12px;color:#666}
-#chat{flex:1;overflow-y:auto;padding:20px;display:flex;flex-direction:column;gap:12px}
-.msg{max-width:85%;padding:10px 14px;border-radius:12px;line-height:1.5;font-size:14px;white-space:pre-wrap;word-wrap:break-word}
+header{background:#111;border-bottom:1px solid #222;padding:12px 20px;display:flex;align-items:center;gap:12px;flex-shrink:0;flex-wrap:wrap}
+header h1{font-size:15px;color:#f90;font-weight:700;white-space:nowrap;letter-spacing:.5px}
+header select{background:#1a1a1a;color:#e0e0e0;border:1px solid #333;border-radius:6px;padding:7px 12px;font-size:13px;min-width:260px;cursor:pointer}
+header select:focus{border-color:#f90;outline:none}
+header select optgroup{color:#999;font-style:normal;font-weight:600;font-size:12px}
+header select option{color:#e0e0e0;padding:4px}
+.status{margin-left:auto;font-size:12px;color:#555;display:flex;align-items:center;gap:6px}
+.status .dot{width:7px;height:7px;border-radius:50%;background:#444}
+.status .dot.ok{background:#4a4}
+.status .dot.busy{background:#f90}
+#chat{flex:1;overflow-y:auto;padding:20px;display:flex;flex-direction:column;gap:14px}
+.msg{max-width:80%;padding:12px 16px;border-radius:14px;line-height:1.6;font-size:14px;white-space:pre-wrap;word-wrap:break-word}
 .msg.user{align-self:flex-end;background:#1a3a5c;color:#cde;border-bottom-right-radius:4px}
-.msg.assistant{align-self:flex-start;background:#1a1a1a;border:1px solid #222;border-bottom-left-radius:4px}
-.msg .meta{font-size:11px;color:#666;margin-top:6px}
-.msg code{background:#0d0d0d;padding:1px 4px;border-radius:3px;font-size:13px}
-.msg pre{background:#0d0d0d;padding:8px;border-radius:6px;overflow-x:auto;margin:6px 0}
-.msg pre code{background:none;padding:0}
+.msg.assistant{align-self:flex-start;background:#151515;border:1px solid #222;border-bottom-left-radius:4px}
+.msg .meta{font-size:11px;color:#555;margin-top:8px;border-top:1px solid #222;padding-top:6px}
+.welcome{text-align:center;color:#444;padding:60px 20px;font-size:14px;line-height:2}
+.welcome h2{color:#f90;font-size:18px;margin-bottom:8px;font-weight:600}
 #input-area{border-top:1px solid #222;padding:12px 20px;display:flex;gap:10px;flex-shrink:0;background:#111}
-#input-area textarea{flex:1;background:#1a1a1a;color:#e0e0e0;border:1px solid #333;border-radius:8px;padding:10px 14px;font-size:14px;font-family:inherit;resize:none;min-height:44px;max-height:120px}
+#input-area textarea{flex:1;background:#1a1a1a;color:#e0e0e0;border:1px solid #333;border-radius:10px;padding:10px 14px;font-size:14px;font-family:inherit;resize:none;min-height:44px;max-height:140px;line-height:1.5}
 #input-area textarea:focus{outline:none;border-color:#f90}
-#input-area button{background:#f90;color:#000;border:none;border-radius:8px;padding:0 20px;font-weight:600;cursor:pointer;font-size:14px}
+#input-area button{background:#f90;color:#000;border:none;border-radius:10px;padding:0 22px;font-weight:700;cursor:pointer;font-size:14px;transition:background .15s}
 #input-area button:hover{background:#fa0}
-#input-area button:disabled{opacity:.4;cursor:default}
-.typing{color:#888;font-style:italic;font-size:13px;padding:4px 14px}
+#input-area button:disabled{opacity:.3;cursor:default}
+.clear-btn{background:none;border:1px solid #333;color:#666;border-radius:6px;padding:4px 10px;font-size:11px;cursor:pointer;margin-left:4px}
+.clear-btn:hover{border-color:#666;color:#aaa}
 </style>
 </head><body>
 <header>
   <h1>LEELOO DALLAS MULTI PASS</h1>
   <select id="model-select"><option>Loading...</option></select>
-  <span class="status" id="status">connecting...</span>
+  <button class="clear-btn" onclick="clearChat()">Clear</button>
+  <span class="status"><span class="dot" id="dot"></span><span id="status">loading...</span></span>
 </header>
-<div id="chat"></div>
+<div id="chat">
+  <div class="welcome">
+    <h2>LEELOO DALLAS MULTI PASS</h2>
+    Select a preset or model above and start chatting.<br>
+    Requests route through your multi-pass pools with automatic failover.
+  </div>
+</div>
 <div id="input-area">
-  <textarea id="input" rows="1" placeholder="Type a message..." autofocus></textarea>
+  <textarea id="input" rows="1" placeholder="Type a message... (Enter to send, Shift+Enter for newline)" autofocus></textarea>
   <button id="send" onclick="sendMessage()">Send</button>
 </div>
 <script>
 const BASE = location.origin;
 const chat = document.getElementById("chat");
 const input = document.getElementById("input");
-const modelSelect = document.getElementById("model-select");
+const sel = document.getElementById("model-select");
 const sendBtn = document.getElementById("send");
 const statusEl = document.getElementById("status");
+const dot = document.getElementById("dot");
 let messages = [];
 let streaming = false;
 
-// Auto-resize textarea
-input.addEventListener("input", () => {
-  input.style.height = "auto";
-  input.style.height = Math.min(input.scrollHeight, 120) + "px";
-});
-input.addEventListener("keydown", (e) => {
-  if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); sendMessage(); }
-});
+input.addEventListener("input", () => { input.style.height = "auto"; input.style.height = Math.min(input.scrollHeight, 140) + "px"; });
+input.addEventListener("keydown", (e) => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); sendMessage(); } });
 
-// Load models
-async function loadModels() {
+async function loadRouting() {
   try {
-    const resp = await fetch(BASE + "/v1/models");
+    const resp = await fetch(BASE + "/v1/routing");
     const data = await resp.json();
-    modelSelect.innerHTML = "";
-    const models = data.data || [];
-    // Group: presets first, then by provider
-    const presets = models.filter(m => m.owned_by === "pi-multi-pass");
-    const regular = models.filter(m => m.owned_by !== "pi-multi-pass");
-    if (presets.length > 0) {
+    sel.innerHTML = "";
+    let count = 0;
+    for (const group of (data.groups || [])) {
       const og = document.createElement("optgroup");
-      og.label = "Presets";
-      presets.forEach(m => { const o = document.createElement("option"); o.value = m.id; o.textContent = m.id; og.appendChild(o); });
-      modelSelect.appendChild(og);
+      og.label = group.label;
+      for (const item of group.items) {
+        const o = document.createElement("option");
+        o.value = item.id;
+        o.textContent = item.name;
+        if (item.detail) o.title = item.detail;
+        og.appendChild(o);
+        count++;
+      }
+      sel.appendChild(og);
     }
-    // Group by provider
-    const byProvider = {};
-    regular.forEach(m => { (byProvider[m.owned_by] = byProvider[m.owned_by] || []).push(m); });
-    for (const [prov, pmodels] of Object.entries(byProvider)) {
-      const og = document.createElement("optgroup");
-      og.label = prov;
-      pmodels.forEach(m => { const o = document.createElement("option"); o.value = m.id; o.textContent = m.id; og.appendChild(o); });
-      modelSelect.appendChild(og);
-    }
-    statusEl.textContent = models.length + " models";
-  } catch (e) { statusEl.textContent = "error: " + e.message; }
+    setStatus("ready", count + " routes");
+  } catch (e) { setStatus("error", e.message); }
 }
 
+function setStatus(state, text) {
+  statusEl.textContent = text;
+  dot.className = "dot " + (state === "ready" ? "ok" : state === "busy" ? "busy" : "");
+}
+
+function clearChat() { messages = []; chat.innerHTML = '<div class="welcome"><h2>LEELOO DALLAS MULTI PASS</h2>Chat cleared.</div>'; }
+
 function addMessage(role, content, meta) {
+  // Remove welcome message
+  const w = chat.querySelector(".welcome"); if (w) w.remove();
   const div = document.createElement("div");
   div.className = "msg " + role;
-  div.innerHTML = escapeHtml(content) + (meta ? '<div class="meta">' + escapeHtml(meta) + '</div>' : '');
+  div.innerHTML = esc(content) + (meta ? '<div class="meta">' + esc(meta) + '</div>' : '');
   chat.appendChild(div);
   chat.scrollTop = chat.scrollHeight;
   return div;
 }
 
-function escapeHtml(s) {
-  return s.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;");
-}
+function esc(s) { return s.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;"); }
 
 async function sendMessage() {
   const text = input.value.trim();
@@ -1107,59 +1171,63 @@ async function sendMessage() {
   messages.push({ role: "user", content: text });
   addMessage("user", text);
   streaming = true; sendBtn.disabled = true;
-  statusEl.textContent = "streaming...";
+  setStatus("busy", "streaming...");
 
-  const assistantDiv = addMessage("assistant", "");
-  let fullText = "";
+  const div = addMessage("assistant", "");
+  let full = "";
+  const t0 = Date.now();
 
   try {
     const resp = await fetch(BASE + "/v1/chat/completions", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        model: modelSelect.value,
-        messages: messages,
-        stream: true,
-      }),
+      body: JSON.stringify({ model: sel.value, messages, stream: true }),
     });
+
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => ({}));
+      throw new Error(err?.error?.message || "HTTP " + resp.status);
+    }
+
     const reader = resp.body.getReader();
-    const decoder = new TextDecoder();
-    let buffer = "";
-    let usage = null;
+    const dec = new TextDecoder();
+    let buf = "", usage = null;
 
     while (true) {
       const { done, value } = await reader.read();
       if (done) break;
-      buffer += decoder.decode(value, { stream: true });
-      const lines = buffer.split("\\n");
-      buffer = lines.pop() || "";
+      buf += dec.decode(value, { stream: true });
+      const lines = buf.split("\\n");
+      buf = lines.pop() || "";
       for (const line of lines) {
         if (!line.startsWith("data: ")) continue;
-        const payload = line.slice(6).trim();
-        if (payload === "[DONE]") continue;
+        const p = line.slice(6).trim();
+        if (p === "[DONE]") continue;
         try {
-          const parsed = JSON.parse(payload);
-          const delta = parsed.choices?.[0]?.delta;
-          if (delta?.content) { fullText += delta.content; assistantDiv.innerHTML = escapeHtml(fullText); chat.scrollTop = chat.scrollHeight; }
-          if (delta?.tool_calls) { fullText += "[tool_call: " + (delta.tool_calls[0]?.function?.name || "?") + "]"; assistantDiv.innerHTML = escapeHtml(fullText); }
-          if (parsed.usage) usage = parsed.usage;
-          const fr = parsed.choices?.[0]?.finish_reason;
-          if (fr) {
-            const meta = (usage ? "tokens: " + usage.prompt_tokens + " in / " + usage.completion_tokens + " out" : "") + " | model: " + modelSelect.value;
-            assistantDiv.innerHTML = escapeHtml(fullText) + '<div class="meta">' + escapeHtml(meta) + '</div>';
+          const j = JSON.parse(p);
+          const d = j.choices?.[0]?.delta;
+          if (d?.content) { full += d.content; div.innerHTML = esc(full); chat.scrollTop = chat.scrollHeight; }
+          if (d?.tool_calls) { const tc = d.tool_calls[0]; full += "[tool: " + (tc?.function?.name || "?") + "(" + (tc?.function?.arguments || "") + ")]"; div.innerHTML = esc(full); }
+          if (j.usage) usage = j.usage;
+          if (j.choices?.[0]?.finish_reason) {
+            const ms = Date.now() - t0;
+            const parts = [sel.value];
+            if (usage) parts.push(usage.prompt_tokens + " in / " + usage.completion_tokens + " out");
+            parts.push(ms + "ms");
+            div.innerHTML = esc(full) + '<div class="meta">' + esc(parts.join(" | ")) + '</div>';
           }
         } catch {}
       }
     }
-    messages.push({ role: "assistant", content: fullText });
+    messages.push({ role: "assistant", content: full });
   } catch (e) {
-    assistantDiv.innerHTML = escapeHtml("[Error: " + e.message + "]");
+    div.innerHTML = '<span style="color:#f44">' + esc("[Error: " + e.message + "]") + '</span>';
   }
   streaming = false; sendBtn.disabled = false;
-  statusEl.textContent = "ready";
+  setStatus("ready", "done");
 }
 
-loadModels();
+loadRouting();
 </script>
 </body></html>`;
 
@@ -1175,6 +1243,7 @@ const server = createServer(async (req, res) => {
 	try {
 		if (path === "/v1/chat/completions" && req.method === "POST") await handleChatCompletions(req, res);
 		else if (path === "/v1/models" && req.method === "GET") handleModels(req, res);
+		else if (path === "/v1/routing" && req.method === "GET") handleRouting(req, res);
 		else if (path === "/health" && req.method === "GET") handleHealth(req, res);
 		else if (path === "/ui" || path === "/") handleUI(req, res);
 		else { res.writeHead(404, json()); res.end(JSON.stringify({ error: { message: "Not found" } })); }

--- a/leeloo.js
+++ b/leeloo.js
@@ -32,7 +32,8 @@
 
 import { createServer } from "node:http";
 import { readFileSync, existsSync, writeFileSync, mkdirSync } from "node:fs";
-import { join } from "node:path";
+import { join, extname, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import { AuthStorage, getAgentDir } from "@mariozechner/pi-coding-agent";
 import { getModel, getModels, stream } from "@mariozechner/pi-ai";
 
@@ -47,6 +48,8 @@ for (let i = 0; i < args.length; i++) {
 // ─── Config ───────────────────────────────────────────────────────────────────
 
 const AGENT_DIR = getAgentDir();
+const ROOT_DIR = dirname(fileURLToPath(import.meta.url));
+const WEB_DIR = join(ROOT_DIR, "web");
 const CONFIG_PATH = join(AGENT_DIR, "multi-pass.json");
 
 function loadConfig() {
@@ -690,6 +693,41 @@ function handleAuditLog(req, res) {
 	res.end(JSON.stringify({ entries: auditLog.slice(-limit).reverse() }));
 }
 
+const MIME_TYPES = {
+	".html": "text/html; charset=utf-8",
+	".js": "text/javascript; charset=utf-8",
+	".css": "text/css; charset=utf-8",
+	".json": "application/json; charset=utf-8",
+	".svg": "image/svg+xml",
+	".png": "image/png",
+	".jpg": "image/jpeg",
+	".jpeg": "image/jpeg",
+	".ico": "image/x-icon",
+};
+
+function serveStaticFile(res, absPath) {
+	if (!existsSync(absPath)) {
+		res.writeHead(404, json());
+		res.end(JSON.stringify({ error: { message: "Not found" } }));
+		return;
+	}
+	const ext = extname(absPath).toLowerCase();
+	const contentType = MIME_TYPES[ext] || "application/octet-stream";
+	res.writeHead(200, { "Content-Type": contentType, "Cache-Control": "no-cache" });
+	res.end(readFileSync(absPath));
+}
+
+function handleWebAsset(req, res, path) {
+	const rel = path.replace(/^\/web\//, "");
+	if (!rel || rel.includes("..")) {
+		res.writeHead(403, json());
+		res.end(JSON.stringify({ error: { message: "Forbidden" } }));
+		return;
+	}
+	const absPath = join(WEB_DIR, rel);
+	serveStaticFile(res, absPath);
+}
+
 /** Sort providers by quota (best first). Providers with unknown quota go last. */
 async function sortByQuota(providers) {
 	const results = await Promise.all(
@@ -1300,7 +1338,7 @@ async function handleChatCompletions(req, res) {
 
 	const {
 		model: requestModelId,
-		messages,
+		messages: incomingMessages,
 		tools,
 		tool_choice,
 		stream: doStream,
@@ -1311,8 +1349,9 @@ async function handleChatCompletions(req, res) {
 		stop,
 		reasoning_effort,
 	} = parsed;
+	let requestMessages = incomingMessages;
 
-	if (!requestModelId || !messages) {
+	if (!requestModelId || !requestMessages) {
 		res.writeHead(400, json());
 		res.end(JSON.stringify({ error: { message: "model and messages are required" } }));
 		return;
@@ -1336,13 +1375,14 @@ async function handleChatCompletions(req, res) {
 			return;
 		}
 		// Content: block/redact/warn on request
-		const contentCheck = evaluateContentRules(rules, parsed.messages, "request");
+		const contentCheck = evaluateContentRules(rules, requestMessages, "request");
 		if (contentCheck.blocked) {
 			res.writeHead(403, json());
 			res.end(JSON.stringify({ error: { message: contentCheck.message } }));
 			return;
 		}
-		parsed.messages = contentCheck.messages; // may be redacted
+		requestMessages = contentCheck.messages; // may be redacted
+		parsed.messages = requestMessages;
 	}
 
 	const candidates = await resolveCandidates(requestModelId);
@@ -1352,7 +1392,7 @@ async function handleChatCompletions(req, res) {
 		return;
 	}
 
-	const context = toContext(messages, tools);
+	const context = toContext(requestMessages, tools);
 	const maxAttempts = Math.min(candidates.length, 5);
 	let lastError = null;
 
@@ -1617,630 +1657,13 @@ function log(...a) { console.log(`[${new Date().toISOString().slice(11, 19)}]`, 
 // ─── Chat UI ──────────────────────────────────────────────────────────────────
 
 function handleAdmin(req, res) {
-	res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
-	res.end(ADMIN_UI_HTML);
+	serveStaticFile(res, join(WEB_DIR, "admin", "index.html"));
 }
 
-const ADMIN_UI_HTML = `<!DOCTYPE html>
-<html lang="en"><head>
-<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Leeloo Admin</title>
-<style>
-*{box-sizing:border-box;margin:0;padding:0}
-body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:#0a0a0a;color:#e0e0e0;height:100vh;display:flex;flex-direction:column}
-header{background:#111;border-bottom:1px solid #222;padding:12px 20px;display:flex;align-items:center;gap:16px}
-header h1{font-size:15px;color:#f90;font-weight:700}
-header a{color:#666;text-decoration:none;font-size:12px;padding:4px 10px;border:1px solid #333;border-radius:5px}
-header a:hover{color:#aaa;border-color:#666}
-.tabs{display:flex;gap:0;border-bottom:1px solid #222;background:#111}
-.tab{padding:10px 20px;font-size:13px;color:#888;cursor:pointer;border-bottom:2px solid transparent}
-.tab:hover{color:#ccc}
-.tab.active{color:#f90;border-color:#f90}
-.panel{flex:1;overflow-y:auto;padding:20px;display:none}
-.panel.active{display:block}
-h2{font-size:14px;color:#999;margin:0 0 12px;text-transform:uppercase;letter-spacing:1px}
-.card{background:#111;border:1px solid #222;border-radius:8px;padding:14px;margin-bottom:10px}
-.card .name{font-weight:600;color:#eee;font-size:14px}
-.card .meta{font-size:11px;color:#666;margin-top:4px}
-.card .badge{display:inline-block;padding:1px 6px;border-radius:3px;font-size:10px;font-weight:600}
-.badge.on{background:#1a3a1a;color:#4a4;border:1px solid #2a4a2a}
-.badge.off{background:#3a1a1a;color:#a44;border:1px solid #4a2a2a}
-.badge.block{background:#3a1a1a;color:#f66}
-.badge.redact{background:#3a2a1a;color:#fa0}
-.badge.warn{background:#1a2a3a;color:#6af}
-.badge.model{background:#2a1a3a;color:#a6f}
-.badge.limit{background:#1a1a2a;color:#66f}
-table{width:100%;border-collapse:collapse;font-size:13px}
-th,td{text-align:left;padding:6px 10px;border-bottom:1px solid #1a1a1a}
-th{color:#888;font-weight:600;font-size:11px;text-transform:uppercase}
-td{color:#ccc}
-.bar{display:inline-block;width:50px;height:8px;background:#222;border-radius:4px;overflow:hidden;vertical-align:middle}
-.bar-fill{height:100%;border-radius:4px}
-.btn{background:#1a1a1a;color:#ccc;border:1px solid #333;border-radius:5px;padding:5px 12px;font-size:12px;cursor:pointer}
-.btn:hover{border-color:#666;color:#fff}
-.btn.danger{border-color:#4a2a2a;color:#f66}
-.btn.danger:hover{background:#3a1a1a}
-.btn.primary{background:#f90;color:#000;border-color:#f90;font-weight:600}
-.form{display:flex;flex-direction:column;gap:8px;max-width:500px}
-.form label{font-size:12px;color:#888}
-.form input,.form select,.form textarea{background:#1a1a1a;color:#eee;border:1px solid #333;border-radius:5px;padding:6px 10px;font-size:13px;font-family:inherit}
-.form input:focus,.form select:focus,.form textarea:focus{border-color:#f90;outline:none}
-.stat-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:10px;margin-bottom:20px}
-.stat-card{background:#111;border:1px solid #222;border-radius:8px;padding:14px;text-align:center}
-.stat-card .num{font-size:24px;font-weight:700;color:#f90}
-.stat-card .label{font-size:11px;color:#666;margin-top:4px}
-.empty{color:#555;font-style:italic;padding:20px;text-align:center}
-</style>
-</head><body>
-<header>
-  <h1>Leeloo Admin</h1>
-  <a href="/ui">Chat UI</a>
-  <a href="/health">Health API</a>
-</header>
-<div class="tabs">
-  <div class="tab active" onclick="showTab('dashboard')">Dashboard</div>
-  <div class="tab" onclick="showTab('rules')">Rules</div>
-  <div class="tab" onclick="showTab('audit')">Audit Log</div>
-  <div class="tab" onclick="showTab('config')">Config</div>
-</div>
-
-<div id="dashboard" class="panel active"></div>
-<div id="rules" class="panel"></div>
-<div id="audit" class="panel"></div>
-<div id="config" class="panel"></div>
-
-<script>
-const BASE = location.origin;
-function esc(s){return String(s).replace(/&/g,"&amp;").replace(/\x3c/g,"\x26lt;").replace(/>/g,"\x26gt;")}
-function showTab(id){document.querySelectorAll(".tab").forEach((t,i)=>{t.classList.toggle("active",t.textContent.toLowerCase().replace(" ","")===id)});document.querySelectorAll(".panel").forEach(p=>{p.classList.toggle("active",p.id===id)});loaders[id]?.()}
-function qc(pct){return pct==null?"#555":pct>50?"#4a4":pct>20?"#ca0":"#e44"}
-function bar(pct){if(pct==null)return"--";return'<span class="bar"><span class="bar-fill" style="width:'+pct+"%;background:"+qc(pct)+'"></span></span> '+pct+"%"}
-function ago(ts){if(!ts)return"--";const d=Date.now()-new Date(ts).getTime();if(d<60000)return Math.round(d/1000)+"s ago";if(d<3600000)return Math.round(d/60000)+"m ago";return Math.round(d/3600000)+"h ago"}
-
-const loaders = {
-  async dashboard() {
-    const [stats,quota,health] = await Promise.all([
-      fetch(BASE+"/v1/stats").then(r=>r.json()),
-      fetch(BASE+"/v1/quota").then(r=>r.json()),
-      fetch(BASE+"/health").then(r=>r.json()),
-    ]);
-    const s = stats.session||{};
-    let h = '<h2>Session Overview</h2><div class="stat-grid">';
-    h += '<div class="stat-card"><div class="num">'+s.total_requests+'</div><div class="label">Requests</div></div>';
-    h += '<div class="stat-card"><div class="num">'+s.total_tokens_in+'</div><div class="label">Tokens In</div></div>';
-    h += '<div class="stat-card"><div class="num">'+s.total_tokens_out+'</div><div class="label">Tokens Out</div></div>';
-    h += '<div class="stat-card"><div class="num">'+s.total_errors+'</div><div class="label">Errors</div></div>';
-    h += '</div>';
-
-    h += '<h2>Provider Health</h2><table><tr><th>Provider</th><th>Quota</th><th>Status</th><th>Requests</th><th>Tokens</th><th>Last Used</th></tr>';
-    for(const p of quota.providers||[]){
-      const ps = (stats.providers||[]).find(x=>x.provider===p.provider)||{};
-      const exh = (health.exhausted||[]).includes(p.provider);
-      h+='<tr><td>'+esc(p.label||p.provider)+'</td><td>'+bar(p.score)+'</td>';
-      h+='<td>'+(exh?'<span class="badge off">exhausted</span>':'<span class="badge on">'+esc(p.status)+'</span>')+'</td>';
-      h+='<td>'+(ps.requests||0)+'</td><td>'+(ps.tokens_in||0)+' / '+(ps.tokens_out||0)+'</td>';
-      h+='<td>'+ago(ps.last_used)+'</td></tr>';
-    }
-    h+='</table>';
-
-    h+='<h2>Recent Requests</h2><table><tr><th>Time</th><th>Provider</th><th>Model</th><th>Tokens</th><th>Duration</th><th>Error</th></tr>';
-    for(const r of (stats.recent||[]).slice(0,20)){
-      h+='<tr><td>'+ago(r.timestamp)+'</td><td>'+esc(r.provider)+'</td><td>'+esc(r.model)+'</td>';
-      h+='<td>'+r.tokens_in+' / '+r.tokens_out+'</td><td>'+r.duration_ms+'ms</td>';
-      h+='<td>'+(r.error?'<span class="badge off">'+esc(r.error).slice(0,40)+'</span>':'--')+'</td></tr>';
-    }
-    h+='</table>';
-    document.getElementById("dashboard").innerHTML = h;
-  },
-
-  async rules() {
-    const data = await fetch(BASE+"/v1/rules").then(r=>r.json());
-    let h = '<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:16px"><h2 style="margin:0">Policy Rules</h2><button class="btn primary" onclick="showRuleForm()">+ Add Rule</button></div>';
-    h += '<div id="rule-form-area"></div>';
-    if(!data.rules||data.rules.length===0){h+='<div class="empty">No rules configured. Add rules to enforce DLP policies, model restrictions, or rate limits.</div>';}
-    else{for(const r of data.rules){
-      h+='<div class="card"><div style="display:flex;justify-content:space-between;align-items:center"><div>';
-      h+='<span class="name">'+esc(r.name)+'</span> ';
-      h+='<span class="badge '+esc(r.type)+'">'+esc(r.type)+'</span> ';
-      h+='<span class="badge '+(r.enabled?"on":"off")+'">'+(r.enabled?"enabled":"disabled")+'</span>';
-      h+='</div><div>';
-      h+='<button class="btn" data-action="toggle" data-rule="'+esc(r.name)+'" data-val="'+(!r.enabled)+'">'+(r.enabled?"Disable":"Enable")+'</button> ';
-      h+='<button class="btn danger" data-action="delete" data-rule="'+esc(r.name)+'">Delete</button>';
-      h+='</div></div>';
-      h+='<div class="meta">';
-      if(r.scope)h+='scope: '+esc(r.scope)+' | ';
-      if(r.patterns?.length)h+='patterns: '+r.patterns.map(p=>esc(p)).join(", ")+' | ';
-      if(r.allow?.length)h+='allow: '+r.allow.join(", ")+' | ';
-      if(r.deny?.length)h+='deny: '+r.deny.join(", ")+' | ';
-      if(r.maxRequests)h+=r.maxRequests+' req/'+r.windowSeconds+'s | ';
-      if(r.replacement)h+='replacement: '+esc(r.replacement)+' | ';
-      if(r.message)h+='message: '+esc(r.message);
-      h+='</div></div>';
-    }}
-    document.getElementById("rules").innerHTML = h;
-  },
-
-  async audit() {
-    const data = await fetch(BASE+"/v1/audit").then(r=>r.json());
-    let h = '<h2>Audit Log</h2>';
-    if(!data.entries?.length){h+='<div class="empty">No audit events yet. Events appear when rules match requests or responses.</div>';}
-    else{h+='<table><tr><th>Time</th><th>Rule</th><th>Type</th><th>Action</th><th>Source</th><th>Detail</th><th>Matched</th><th>Message (before)</th><th>Message (after redaction)</th></tr>';
-    for(const e of data.entries){
-      const fullMsg = e.full_message
-        ? '<details><summary>view ('+e.full_message.length+' chars)</summary><pre style="white-space:pre-wrap;word-break:break-word;max-height:280px;overflow:auto;background:#0a0a0a;border:1px solid #222;border-radius:6px;padding:8px;margin-top:6px">'+esc(e.full_message)+'</pre></details>'
-        : '--';
-      const redactedMsg = e.redacted_message
-        ? '<details><summary>view ('+e.redacted_message.length+' chars)</summary><pre style="white-space:pre-wrap;word-break:break-word;max-height:280px;overflow:auto;background:#0a0a0a;border:1px solid #222;border-radius:6px;padding:8px;margin-top:6px">'+esc(e.redacted_message)+'</pre></details>'
-        : '--';
-      h+='<tr><td>'+ago(e.timestamp)+'</td><td>'+esc(e.rule)+'</td>';
-      h+='<td><span class="badge '+esc(e.type)+'">'+esc(e.type)+'</span></td>';
-      h+='<td>'+esc(e.action)+'</td><td>'+esc(e.source||'--')+'</td><td>'+esc(e.detail)+'</td>';
-      h+='<td>'+(e.matched_text?esc(e.matched_text):'--')+'</td>';
-      h+='<td>'+fullMsg+'</td>';
-      h+='<td>'+redactedMsg+'</td></tr>';
-    }h+='</table>';}
-    document.getElementById("audit").innerHTML = h;
-  },
-
-  async config() {
-    const [health,routing] = await Promise.all([
-      fetch(BASE+"/health").then(r=>r.json()),
-      fetch(BASE+"/v1/routing").then(r=>r.json()),
-    ]);
-    let h = '<h2>Active Configuration</h2>';
-    h+='<h2 style="font-size:12px;margin-top:16px">Pools</h2>';
-    for(const p of health.pools||[]){
-      h+='<div class="card"><span class="name">'+esc(p.name)+'</span> <span class="badge on">'+esc(p.strategy)+'</span>';
-      h+='<div class="meta">Members: '+p.members.map(m=>esc(m)).join(", ")+'</div></div>';
-    }
-    h+='<h2 style="font-size:12px;margin-top:16px">Chains</h2>';
-    if(!health.chains?.length)h+='<div class="empty">No chains</div>';
-    else for(const c of health.chains){h+='<div class="card"><span class="name">'+esc(c)+'</span></div>';}
-    h+='<h2 style="font-size:12px;margin-top:16px">Presets</h2>';
-    for(const p of health.presets||[]){
-      h+='<div class="card"><span class="name">'+esc(p.name)+'</span>';
-      h+='<div class="meta">'+p.entries.map(e=>esc(e)).join(" -> ")+'</div></div>';
-    }
-    h+='<h2 style="font-size:12px;margin-top:16px">Providers</h2>';
-    for(const p of health.providers||[]){
-      const exh=(health.exhausted||[]).includes(p);
-      h+='<div class="card"><span class="name">'+esc(p)+'</span> <span class="badge '+(exh?"off":"on")+'">'+(exh?"exhausted":"ok")+'</span></div>';
-    }
-    document.getElementById("config").innerHTML = h;
-  }
-};
-
-async function toggleRule(name,enabled){
-  await fetch(BASE+"/v1/rules/"+encodeURIComponent(name),{method:"PUT",headers:{"Content-Type":"application/json"},body:JSON.stringify({enabled})});
-  loaders.rules();
-}
-async function deleteRule(name){
-  if(!confirm("Delete rule "+name+"?"))return;
-  await fetch(BASE+"/v1/rules/"+encodeURIComponent(name),{method:"DELETE"});
-  loaders.rules();
-}
-function showRuleForm(){
-  const area=document.getElementById("rule-form-area");
-  if(area.innerHTML){area.innerHTML="";return;}
-  area.innerHTML='<div class="card"><div class="form">'
-    +'<label>Name</label><input id="rf-name" placeholder="e.g. block-secrets">'
-    +'<label>Type</label><select id="rf-type"><option value="block">block</option><option value="redact">redact</option><option value="warn">warn</option><option value="model">model (allow/deny)</option><option value="limit">rate limit</option></select>'
-    +'<label>Scope</label><select id="rf-scope"><option value="request">request</option><option value="response">response</option><option value="both">both</option></select>'
-    +'<label>Patterns (one per line, regex)</label><textarea id="rf-patterns" rows="3" placeholder="AKIA[0-9A-Z]{16}\\nsk-[a-zA-Z0-9]{48}"></textarea>'
-    +'<label>Replacement (for redact)</label><input id="rf-replacement" placeholder="[REDACTED]">'
-    +'<label>Message (shown when blocked)</label><input id="rf-message" placeholder="Request blocked: contains secrets">'
-    +'<label>Model allow list (comma-separated, for model type)</label><input id="rf-allow" placeholder="claude-*, gpt-5*">'
-    +'<label>Model deny list</label><input id="rf-deny" placeholder="gpt-4o*">'
-    +'<label>Max requests (for limit type)</label><input id="rf-max" type="number" placeholder="60">'
-    +'<label>Window seconds</label><input id="rf-window" type="number" placeholder="60">'
-    +'<div style="display:flex;gap:8px;margin-top:8px"><button class="btn primary" data-action="create-rule">Create Rule</button><button class="btn" data-action="cancel-form">Cancel</button></div>'
-    +'</div></div>';
-}
-async function createRule(){
-  const type=document.getElementById("rf-type").value;
-  const rule={
-    name:document.getElementById("rf-name").value||"rule-"+Date.now(),
-    type,
-    enabled:true,
-    scope:document.getElementById("rf-scope").value,
-    patterns:document.getElementById("rf-patterns").value.split("\\n").filter(Boolean),
-    replacement:document.getElementById("rf-replacement").value||undefined,
-    message:document.getElementById("rf-message").value||undefined,
-  };
-  if(type==="model"){
-    const allow=document.getElementById("rf-allow").value;
-    const deny=document.getElementById("rf-deny").value;
-    if(allow)rule.allow=allow.split(",").map(s=>s.trim()).filter(Boolean);
-    if(deny)rule.deny=deny.split(",").map(s=>s.trim()).filter(Boolean);
-  }
-  if(type==="limit"){
-    rule.maxRequests=parseInt(document.getElementById("rf-max").value)||60;
-    rule.windowSeconds=parseInt(document.getElementById("rf-window").value)||60;
-  }
-  await fetch(BASE+"/v1/rules",{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify(rule)});
-  document.getElementById("rule-form-area").innerHTML="";
-  loaders.rules();
-}
-
-// Event delegation for dynamic buttons
-document.addEventListener("click", async (e) => {
-  const btn = e.target.closest("[data-action]");
-  if (!btn) return;
-  const action = btn.dataset.action;
-  if (action === "toggle") { await toggleRule(btn.dataset.rule, btn.dataset.val === "true"); }
-  else if (action === "delete") { await deleteRule(btn.dataset.rule); }
-  else if (action === "create-rule") { await createRule(); }
-  else if (action === "cancel-form") { document.getElementById("rule-form-area").innerHTML = ""; }
-});
-
-loaders.dashboard();
-</script>
-</body></html>`;
 
 function handleUI(req, res) {
-	res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
-	res.end(CHAT_UI_HTML);
+	serveStaticFile(res, join(WEB_DIR, "ui", "index.html"));
 }
-
-const CHAT_UI_HTML = `<!DOCTYPE html>
-<html lang="en"><head>
-<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Leeloo on multi-pass</title>
-
-<style>
-*{box-sizing:border-box;margin:0;padding:0}
-body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:#0a0a0a;color:#e0e0e0;height:100vh;display:flex;flex-direction:column}
-
-/* ── Top bar ── */
-#topbar{background:#111;border-bottom:1px solid #222;flex-shrink:0}
-#bar-main{padding:10px 20px;display:flex;align-items:center;gap:12px;flex-wrap:wrap}
-#bar-main h1{font-size:14px;color:#f90;font-weight:700;letter-spacing:.5px;white-space:nowrap}
-#bar-main select{background:#1a1a1a;color:#e0e0e0;border:1px solid #333;border-radius:6px;padding:6px 10px;font-size:13px;min-width:240px;cursor:pointer}
-#bar-main select:focus{border-color:#f90;outline:none}
-#bar-main select optgroup{color:#888;font-style:normal;font-weight:600;font-size:11px}
-.bar-actions{display:flex;gap:6px;margin-left:auto;align-items:center}
-.bar-btn{background:none;border:1px solid #333;color:#888;border-radius:5px;padding:3px 9px;font-size:11px;cursor:pointer}
-.bar-btn:hover{border-color:#666;color:#ccc}
-.dot{width:7px;height:7px;border-radius:50%;background:#444;display:inline-block}
-.dot.ok{background:#4a4}.dot.busy{background:#f90;animation:blink 1s infinite}
-@keyframes blink{50%{opacity:.4}}
-#status-text{font-size:11px;color:#555}
-
-/* ── Info strip ── */
-#info-strip{padding:5px 20px;background:#0d0d0d;border-bottom:1px solid #1a1a1a;font-size:11px;color:#555;overflow-x:auto;white-space:nowrap;display:flex;gap:6px;align-items:center;flex-wrap:wrap}
-#info-strip .section{display:flex;gap:4px;align-items:center;margin-right:8px}
-#info-strip .section-label{color:#444;font-weight:700;text-transform:uppercase;font-size:9px;letter-spacing:.5px;margin-right:2px}
-#info-strip .tag{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:4px;border:1px solid #222;background:#111}
-#info-strip .tag b{color:#999;font-weight:600}
-#info-strip .tag .val{color:#777}
-#info-strip .tag .bar{display:inline-block;width:40px;height:6px;background:#222;border-radius:3px;overflow:hidden;vertical-align:middle}
-#info-strip .tag .bar-fill{height:100%;border-radius:3px;transition:width .3s}
-#info-strip .tag.pool{border-color:#2a2a3a}
-#info-strip .tag.preset{border-color:#3a2a1a}
-#info-strip .tag.provider{border-color:#1a2a1a}
-#info-strip .tag.exhausted{border-color:#4a1a1a;opacity:.5}
-#info-strip .sep{color:#222;margin:0 2px}
-
-/* ── Chat ── */
-#chat{flex:1;overflow-y:auto;padding:20px;display:flex;flex-direction:column;gap:14px}
-.msg{max-width:82%;border-radius:14px;line-height:1.6;font-size:14px;word-wrap:break-word;overflow:hidden}
-.msg.user{align-self:flex-end;background:#1a3a5c;color:#cde;border-bottom-right-radius:4px;padding:12px 16px;white-space:pre-wrap}
-.msg.assistant{align-self:flex-start;background:#151515;border:1px solid #222;border-bottom-left-radius:4px;padding:0}
-.msg .md-body{padding:12px 16px}
-.msg .meta{font-size:11px;color:#555;padding:6px 16px;border-top:1px solid #222;background:#0d0d0d;display:flex;gap:12px;flex-wrap:wrap;border-radius:0 0 0 14px}
-.msg .meta .provider-tag{color:#f90}
-.welcome{text-align:center;color:#444;padding:60px 20px;font-size:14px;line-height:2}
-.welcome h2{color:#f90;font-size:18px;margin-bottom:8px;font-weight:600}
-
-/* ── Thinking indicator ── */
-.thinking{padding:12px 16px;display:flex;align-items:center;gap:8px;color:#888;font-size:13px}
-.thinking .dots{display:flex;gap:4px}
-.thinking .dots span{width:6px;height:6px;border-radius:50%;background:#f90;animation:pulse 1.4s infinite}
-.thinking .dots span:nth-child(2){animation-delay:.2s}
-.thinking .dots span:nth-child(3){animation-delay:.4s}
-@keyframes pulse{0%,80%,100%{opacity:.2;transform:scale(.8)}40%{opacity:1;transform:scale(1)}}
-
-/* ── Markdown styles ── */
-.md-body p{margin:0 0 8px}
-.md-body p:last-child{margin:0}
-.md-body code{background:#0d0d0d;padding:1px 5px;border-radius:3px;font-size:13px;font-family:"SF Mono",Menlo,monospace}
-.md-body pre{background:#0d0d0d;padding:12px;border-radius:8px;overflow-x:auto;margin:8px 0;border:1px solid #222}
-.md-body pre code{background:none;padding:0;font-size:13px}
-.md-body ul,.md-body ol{margin:4px 0 4px 20px}
-.md-body blockquote{border-left:3px solid #333;padding-left:12px;margin:4px 0;color:#999}
-.md-body h1,.md-body h2,.md-body h3{margin:8px 0 4px;color:#ddd}
-.md-body h1{font-size:18px} .md-body h2{font-size:16px} .md-body h3{font-size:14px}
-.md-body table{border-collapse:collapse;margin:8px 0}
-.md-body td,.md-body th{border:1px solid #333;padding:4px 8px;font-size:13px}
-.md-body th{background:#1a1a1a}
-.md-body a{color:#6af}
-.md-body strong{color:#eee}
-
-/* ── Input ── */
-#input-area{border-top:1px solid #222;padding:10px 20px;display:flex;gap:10px;flex-shrink:0;background:#111}
-#input-area textarea{flex:1;background:#1a1a1a;color:#e0e0e0;border:1px solid #333;border-radius:10px;padding:10px 14px;font-size:14px;font-family:inherit;resize:none;min-height:44px;max-height:140px;line-height:1.5}
-#input-area textarea:focus{outline:none;border-color:#f90}
-#input-area textarea:disabled{opacity:.5}
-#input-area button{background:#f90;color:#000;border:none;border-radius:10px;padding:0 22px;font-weight:700;cursor:pointer;font-size:14px;transition:background .15s}
-#input-area button:hover{background:#fa0}
-#input-area button:disabled{opacity:.3;cursor:default}
-</style>
-</head><body>
-
-<div id="topbar">
-  <div id="bar-main">
-    <h1>Leeloo on multi-pass</h1>
-    <select id="model-select"><option>Loading...</option></select>
-    <div class="bar-actions">
-      <button class="bar-btn" onclick="clearChat()">Clear</button>
-      <span class="dot" id="dot"></span>
-      <span id="status-text">loading...</span>
-    </div>
-  </div>
-  <div id="info-strip"></div>
-</div>
-
-<div id="chat">
-  <div class="welcome">
-    <h2>Leeloo on multi-pass</h2>
-    Select a preset or model above and start chatting.<br>
-    Requests route through your multi-pass pools with automatic failover.
-  </div>
-</div>
-
-<div id="input-area">
-  <textarea id="input" rows="1" placeholder="Type a message... (Enter to send)" autofocus></textarea>
-  <button id="send" onclick="sendMessage()">Send</button>
-</div>
-
-<script type="module">
-let smd = null;
-try { smd = await import("https://cdn.jsdelivr.net/npm/streaming-markdown@latest/smd.min.js"); } catch {}
-const BASE = location.origin;
-const chat = document.getElementById("chat");
-const input = document.getElementById("input");
-const sel = document.getElementById("model-select");
-const sendBtn = document.getElementById("send");
-const statusEl = document.getElementById("status-text");
-const dotEl = document.getElementById("dot");
-const infoStrip = document.getElementById("info-strip");
-let messages = [];
-let streaming = false;
-
-input.addEventListener("input", () => { input.style.height = "auto"; input.style.height = Math.min(input.scrollHeight, 140) + "px"; });
-input.addEventListener("keydown", (e) => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); sendMessage(); } });
-
-function setStatus(state, text) {
-  statusEl.textContent = text;
-  dotEl.className = "dot " + (state === "ready" ? "ok" : state === "busy" ? "busy" : "");
-}
-
-// ── Load config + quota info strip ──
-function quotaColor(pct) {
-  if (pct === null || pct === undefined) return "#555";
-  if (pct > 50) return "#4a4";
-  if (pct > 20) return "#ca0";
-  return "#e44";
-}
-function quotaBar(pct) {
-  if (pct === null || pct === undefined) return '<span class="val">--</span>';
-  return '<span class="bar"><span class="bar-fill" style="width:' + pct + '%;background:' + quotaColor(pct) + '"></span></span> <span class="val">' + pct + '%</span>';
-}
-
-async function loadInfo() {
-  try {
-    const [h, q] = await Promise.all([
-      fetch(BASE + "/health").then(r => r.json()),
-      fetch(BASE + "/v1/quota").then(r => r.json()).catch(() => ({ providers: [] })),
-    ]);
-    const quotaMap = {};
-    for (const p of (q.providers || [])) quotaMap[p.provider] = p;
-
-    let html = "";
-
-    // Pools
-    if (h.pools?.length) {
-      html += '<span class="section"><span class="section-label">pools</span>';
-      for (const p of h.pools) {
-        html += '<span class="tag pool"><b>' + esc(p.name) + '</b> <span class="val">' + esc(p.strategy) + '</span></span>';
-      }
-      html += '</span><span class="sep">|</span>';
-    }
-
-    // Presets
-    if (h.presets?.length) {
-      html += '<span class="section"><span class="section-label">presets</span>';
-      for (const p of h.presets) {
-        html += '<span class="tag preset" title="' + esc(p.entries.join(" > ")) + '"><b>' + esc(p.name) + '</b></span>';
-      }
-      html += '</span><span class="sep">|</span>';
-    }
-
-    // Providers with quota bars
-    html += '<span class="section"><span class="section-label">providers</span>';
-    for (const prov of (h.providers || [])) {
-      const qi = quotaMap[prov] || {};
-      const exh = (h.exhausted || []).includes(prov) || qi.exhausted;
-      const cls = "tag provider" + (exh ? " exhausted" : "");
-      html += '<span class="' + cls + '"><b>' + esc(prov) + '</b> ' + quotaBar(qi.quota) + '</span>';
-    }
-    html += '</span>';
-
-    infoStrip.innerHTML = html;
-  } catch {}
-}
-
-// ── Load routing ──
-async function loadRouting() {
-  try {
-    const data = await (await fetch(BASE + "/v1/routing")).json();
-    sel.innerHTML = "";
-    let count = 0;
-    for (const group of (data.groups || [])) {
-      const og = document.createElement("optgroup");
-      og.label = group.label;
-      for (const item of group.items) {
-        const o = document.createElement("option");
-        o.value = item.id;
-        o.textContent = item.name;
-        if (item.detail) o.title = item.detail;
-        og.appendChild(o);
-        count++;
-      }
-      sel.appendChild(og);
-    }
-    setStatus("ready", count + " routes");
-  } catch (e) { setStatus("error", e.message); }
-}
-
-function clearChat() {
-  messages = [];
-  chat.innerHTML = '<div class="welcome"><h2>Leeloo on multi-pass</h2>Chat cleared.</div>';
-}
-
-function esc(s) { return String(s).replace(/&/g,"&amp;").replace(/\x3c/g,"\x26lt;").replace(/>/g,"\x26gt;"); }
-
-async function sendMessage() {
-  const text = input.value.trim();
-  if (!text || streaming) return;
-  input.value = ""; input.style.height = "auto";
-  messages.push({ role: "user", content: text });
-
-  // Remove welcome
-  const w = chat.querySelector(".welcome"); if (w) w.remove();
-
-  // User bubble
-  const userDiv = document.createElement("div");
-  userDiv.className = "msg user";
-  userDiv.textContent = text;
-  chat.appendChild(userDiv);
-
-  // Assistant bubble with thinking indicator
-  const msgDiv = document.createElement("div");
-  msgDiv.className = "msg assistant";
-  msgDiv.innerHTML = '<div class="thinking"><div class="dots"><span></span><span></span><span></span></div>Thinking...</div>';
-  chat.appendChild(msgDiv);
-  chat.scrollTop = chat.scrollHeight;
-
-  streaming = true; sendBtn.disabled = true; input.disabled = true;
-  setStatus("busy", "connecting...");
-
-  let full = "";
-  let gotFirstToken = false;
-  let smdParser = null;
-  let mdBody = null;
-  const t0 = Date.now();
-  const rawSelection = sel.value;
-  // Clean display: "pool:codex-pool/gpt-5.1" -> "codex-pool / gpt-5.1"
-  const selectedModel = rawSelection.includes("/") ? rawSelection.split("/").pop() : rawSelection;
-  const selectedRoute = rawSelection.replace("pool:", "").replace("provider:", "").replace("/", " / ");
-
-  try {
-    const resp = await fetch(BASE + "/v1/chat/completions", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ model: rawSelection, messages, stream: true }),
-    });
-
-    if (!resp.ok) {
-      const err = await resp.json().catch(() => ({}));
-      throw new Error(err?.error?.message || "HTTP " + resp.status);
-    }
-
-    const reader = resp.body.getReader();
-    const dec = new TextDecoder();
-    let buf = "", usage = null, xProvider = "", xModel = "", xLabel = "";
-
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      buf += dec.decode(value, { stream: true });
-      const lines = buf.split("\\n");
-      buf = lines.pop() || "";
-      for (const line of lines) {
-        if (!line.startsWith("data: ")) continue;
-        const p = line.slice(6).trim();
-        if (p === "[DONE]") continue;
-        try {
-          const j = JSON.parse(p);
-          const d = j.choices?.[0]?.delta;
-
-          if (d?.content) {
-            if (!gotFirstToken) {
-              gotFirstToken = true;
-              mdBody = document.createElement("div");
-              mdBody.className = "md-body";
-              msgDiv.innerHTML = "";
-              msgDiv.appendChild(mdBody);
-              if (smd) smdParser = smd.parser(smd.default_renderer(mdBody));
-              setStatus("busy", "receiving...");
-            }
-            full += d.content;
-            if (smdParser) smd.parser_write(smdParser, d.content);
-            else mdBody.textContent = full;
-            chat.scrollTop = chat.scrollHeight;
-          }
-
-          if (d?.tool_calls) {
-            if (!gotFirstToken) {
-              gotFirstToken = true;
-              mdBody = document.createElement("div");
-              mdBody.className = "md-body";
-              msgDiv.innerHTML = "";
-              msgDiv.appendChild(mdBody);
-              if (smd) smdParser = smd.parser(smd.default_renderer(mdBody));
-            }
-            const tc = d.tool_calls[0];
-            const tcText = "\\n**Tool call:** \`" + (tc?.function?.name || "?") + "\`\\n";
-            full += tcText;
-            if (smdParser) smd.parser_write(smdParser, tcText);
-            else mdBody.textContent = full;
-          }
-
-          if (j.usage) usage = j.usage;
-          if (j.x_provider) xProvider = j.x_provider;
-          if (j.x_model) xModel = j.x_model;
-          if (j.x_label) xLabel = j.x_label;
-
-          if (j.choices?.[0]?.finish_reason) {
-            if (smdParser && smd) smd.parser_end(smdParser);
-            const ms = Date.now() - t0;
-            const meta = document.createElement("div");
-            meta.className = "meta";
-            const parts = [];
-            parts.push('<span class="provider-tag">' + esc(selectedRoute) + '</span>');
-            if (xLabel || xProvider) {
-              parts.push('<span style="color:#8af">' + esc(xLabel || xProvider) + '</span> / <span style="color:#aaa">' + esc(xModel) + '</span>');
-            }
-            if (usage) parts.push(usage.prompt_tokens + " in / " + usage.completion_tokens + " out");
-            parts.push((ms / 1000).toFixed(1) + "s");
-            meta.innerHTML = parts.join(' <span style="color:#333">|</span> ');
-            msgDiv.appendChild(meta);
-          }
-        } catch {}
-      }
-    }
-    messages.push({ role: "assistant", content: full });
-  } catch (e) {
-    // If request failed (e.g. blocked by policy), remove the just-added user turn
-    // from request history so future messages are not repeatedly blocked.
-    const last = messages[messages.length - 1];
-    if (last && last.role === "user" && last.content === text) {
-      messages.pop();
-    }
-    msgDiv.innerHTML = '<div class="md-body" style="color:#f44;padding:12px 16px">[Error: ' + esc(e.message) + ']</div>';
-  }
-
-  streaming = false; sendBtn.disabled = false; input.disabled = false;
-  input.focus();
-  setStatus("ready", "done");
-  loadInfo(); // refresh quota + exhausted state
-}
-
-loadRouting();
-loadInfo();
-</script>
-</body></html>`;
 
 
 // ─── Server ───────────────────────────────────────────────────────────────────
@@ -2264,6 +1687,7 @@ const server = createServer(async (req, res) => {
 		else if (path.startsWith("/v1/rules/") && req.method === "DELETE") handleRulesDelete(req, res, decodeURIComponent(path.split("/v1/rules/")[1]));
 		else if (path === "/v1/audit" && req.method === "GET") handleAuditLog(req, res);
 		else if (path === "/health" && req.method === "GET") handleHealth(req, res);
+		else if (path.startsWith("/web/") && req.method === "GET") handleWebAsset(req, res, path);
 		else if (path === "/admin") handleAdmin(req, res);
 		else if (path === "/ui" || path === "/") handleUI(req, res);
 		else { res.writeHead(404, json()); res.end(JSON.stringify({ error: { message: "Not found" } })); }

--- a/leeloo.js
+++ b/leeloo.js
@@ -2199,6 +2199,12 @@ async function sendMessage() {
     }
     messages.push({ role: "assistant", content: full });
   } catch (e) {
+    // If request failed (e.g. blocked by policy), remove the just-added user turn
+    // from request history so future messages are not repeatedly blocked.
+    const last = messages[messages.length - 1];
+    if (last && last.role === "user" && last.content === text) {
+      messages.pop();
+    }
     msgDiv.innerHTML = '<div class="md-body" style="color:#f44;padding:12px 16px">[Error: ' + esc(e.message) + ']</div>';
   }
 

--- a/leeloo.js
+++ b/leeloo.js
@@ -1087,6 +1087,10 @@ async function handleConfigPut(req, res) {
 	if (body.pools !== undefined) config.pools = body.pools;
 	if (body.chains !== undefined) config.chains = body.chains;
 	if (body.presets !== undefined) config.presets = body.presets;
+	if (body.apiKeys !== undefined) config.apiKeys = body.apiKeys;
+	if (body.accounts !== undefined) config.accounts = body.accounts;
+	if (body.modes !== undefined) config.modes = body.modes;
+	if (body.routingRules !== undefined) config.routingRules = body.routingRules;
 	saveConfig(config);
 	res.writeHead(200, json());
 	res.end(JSON.stringify(config));

--- a/leeloo.js
+++ b/leeloo.js
@@ -1012,41 +1012,53 @@ function handleRouting(req, res) {
 		});
 	}
 
-	// Pools -- models scoped to pool via "pool:<name>/<model>" ID
-	for (const pool of config.pools) {
-		if (!pool.enabled) continue;
-		try {
-			const models = getModels(pool.baseProvider);
-			const available = pool.members.filter((m) => authStorage.hasAuth(m));
-			if (available.length === 0) continue;
-			groups.push({
-				label: `${pool.name} [${pool.strategy || "round-robin"}] (${available.length} members)`,
-				items: models.map((m) => ({
-					id: `pool:${pool.name}/${m.id}`,
-					name: m.id,
-					detail: `via ${available.join(", ")}`,
-				})),
-			});
-		} catch { /* skip */ }
+	// Pools -- each pool as a selectable group with specific models
+	const enabledPools = config.pools.filter((p) => p.enabled);
+	if (enabledPools.length > 0) {
+		const poolItems = [];
+		for (const pool of enabledPools) {
+			try {
+				const models = getModels(pool.baseProvider);
+				const available = pool.members.filter((m) => authStorage.hasAuth(m));
+				if (available.length === 0) continue;
+				const strat = pool.strategy || "round-robin";
+				// Pool-level entries with specific models
+				for (const m of models) {
+					poolItems.push({
+						id: `pool:${pool.name}/${m.id}`,
+						name: `${pool.name} / ${m.id}`,
+						detail: `[${strat}] via ${available.join(", ")}`,
+					});
+				}
+			} catch { /* skip */ }
+		}
+		if (poolItems.length > 0) {
+			groups.push({ label: "Pools", items: poolItems });
+		}
 	}
 
-	// Non-pool providers scoped via "provider:<name>/<model>" ID
+	// Non-pool providers
 	const pooled = new Set(config.pools.flatMap((p) => p.members));
 	const standalone = getAllProviders().filter((p) => !pooled.has(p));
-	for (const prov of standalone) {
-		const base = getBaseProvider(prov);
-		if (!base) continue;
-		try {
-			const models = getModels(base);
-			groups.push({
-				label: prov,
-				items: models.map((m) => ({
-					id: `provider:${prov}/${m.id}`,
-					name: m.id,
-					detail: prov,
-				})),
-			});
-		} catch { /* skip */ }
+	if (standalone.length > 0) {
+		const provItems = [];
+		for (const prov of standalone) {
+			const base = getBaseProvider(prov);
+			if (!base) continue;
+			try {
+				const models = getModels(base);
+				for (const m of models) {
+					provItems.push({
+						id: `provider:${prov}/${m.id}`,
+						name: `${prov} / ${m.id}`,
+						detail: prov,
+					});
+				}
+			} catch { /* skip */ }
+		}
+		if (provItems.length > 0) {
+			groups.push({ label: "Providers", items: provItems });
+		}
 	}
 
 	res.writeHead(200, json());

--- a/leeloo.js
+++ b/leeloo.js
@@ -39,12 +39,39 @@ import { randomBytes } from "node:crypto";
 import { AuthStorage, getAgentDir } from "@mariozechner/pi-coding-agent";
 import { getModel, getModels, stream } from "@mariozechner/pi-ai";
 
+// ─── .env file support ───────────────────────────────────────────────────────
+
+function loadEnvFile() {
+	const candidates = [
+		join(dirname(fileURLToPath(import.meta.url)), ".env"),
+		join(process.cwd(), ".env"),
+	];
+	for (const p of candidates) {
+		if (!existsSync(p)) continue;
+		const lines = readFileSync(p, "utf-8").split("\n");
+		for (const line of lines) {
+			const trimmed = line.trim();
+			if (!trimmed || trimmed.startsWith("#")) continue;
+			const eq = trimmed.indexOf("=");
+			if (eq < 0) continue;
+			const key = trimmed.slice(0, eq).trim();
+			let val = trimmed.slice(eq + 1).trim();
+			if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) val = val.slice(1, -1);
+			if (!process.env[key]) process.env[key] = val; // don't override existing env
+		}
+		return p;
+	}
+	return null;
+}
+const envFile = loadEnvFile();
+
 // ─── CLI args ─────────────────────────────────────────────────────────────────
 
 const args = process.argv.slice(2);
 let PORT = parseInt(process.env.LEELOO_PORT || "4000", 10);
 for (let i = 0; i < args.length; i++) {
 	if (args[i] === "--port" && args[i + 1]) PORT = parseInt(args[i + 1], 10);
+	if (args[i] === "init") { await runInit(); process.exit(0); }
 }
 
 // ─── Admin token ──────────────────────────────────────────────────────────────
@@ -175,6 +202,42 @@ function isModelAllowedForUser(user, role, modelId) {
 	const allowed = [...(user.allowedPresets || []), ...(user.allowedPools || []).map((p) => `pool:${p}`)];
 	// Check exact match or prefix match for pool:name/model
 	return allowed.some((a) => modelId === a || modelId.startsWith(a + "/"));
+}
+
+/**
+ * Check user budget. Returns { allowed, message, usage }.
+ * Budgets: { daily_tokens, monthly_tokens } on the user object.
+ * Uses userStats (in-memory) for fast checks.
+ */
+function checkUserBudget(user, role) {
+	if (role === "admin") return { allowed: true };
+	if (!user?.budgets) return { allowed: true };
+
+	const username = user.username;
+	const stats = userStats[username];
+	if (!stats) return { allowed: true };
+
+	const totalTokens = (stats.tokens_in || 0) + (stats.tokens_out || 0);
+
+	// Daily check -- uses daily_tokens_today which resets at midnight
+	if (user.budgets.daily_tokens && user.budgets.daily_tokens > 0) {
+		const dailyUsed = stats.daily_tokens || 0;
+		if (dailyUsed >= user.budgets.daily_tokens) {
+			const pct = Math.round((dailyUsed / user.budgets.daily_tokens) * 100);
+			return { allowed: false, message: `Daily token budget exceeded for "${username}": ${dailyUsed.toLocaleString()} / ${user.budgets.daily_tokens.toLocaleString()} (${pct}%)` };
+		}
+	}
+
+	// Monthly check
+	if (user.budgets.monthly_tokens && user.budgets.monthly_tokens > 0) {
+		const monthlyUsed = stats.monthly_tokens || 0;
+		if (monthlyUsed >= user.budgets.monthly_tokens) {
+			const pct = Math.round((monthlyUsed / user.budgets.monthly_tokens) * 100);
+			return { allowed: false, message: `Monthly token budget exceeded for "${username}": ${monthlyUsed.toLocaleString()} / ${user.budgets.monthly_tokens.toLocaleString()} (${pct}%)` };
+		}
+	}
+
+	return { allowed: true };
 }
 
 // ─── Persistent usage log (JSONL, per-user) ─────────────────────────────────
@@ -636,13 +699,26 @@ function trackRequest(provider, modelId, usage, durationMs, error, requestText, 
 	s.last_used = entry.timestamp;
 
 	if (username) {
+		const now = new Date();
+		const today = now.toISOString().slice(0, 10); // YYYY-MM-DD
+		const month = now.toISOString().slice(0, 7);  // YYYY-MM
+
 		if (!userStats[username]) {
-			userStats[username] = { requests: 0, tokens_in: 0, tokens_out: 0, errors: 0, last_used: null };
+			userStats[username] = { requests: 0, tokens_in: 0, tokens_out: 0, errors: 0, last_used: null, daily_tokens: 0, daily_date: today, monthly_tokens: 0, monthly_date: month };
 		}
 		const u = userStats[username];
+
+		// Reset daily counter if date changed
+		if (u.daily_date !== today) { u.daily_tokens = 0; u.daily_date = today; }
+		// Reset monthly counter if month changed
+		if (u.monthly_date !== month) { u.monthly_tokens = 0; u.monthly_date = month; }
+
+		const reqTokens = entry.tokens_in + entry.tokens_out;
 		u.requests++;
 		u.tokens_in += entry.tokens_in;
 		u.tokens_out += entry.tokens_out;
+		u.daily_tokens += reqTokens;
+		u.monthly_tokens += reqTokens;
 		if (error) u.errors++;
 		u.last_used = entry.timestamp;
 	}
@@ -1339,12 +1415,17 @@ function handleUsersList(req, res) {
 async function handleUserCreate(req, res) {
 	const body = JSON.parse(await readBody(req));
 	const users = loadUsers();
+	const budgets = {};
+	if (body.budgets?.daily_tokens) budgets.daily_tokens = body.budgets.daily_tokens;
+	if (body.budgets?.monthly_tokens) budgets.monthly_tokens = body.budgets.monthly_tokens;
+
 	const user = {
 		username: body.username || `user-${Date.now()}`,
 		key: body.key || randomBytes(24).toString("hex"),
 		enabled: body.enabled !== false,
 		allowedPresets: body.allowedPresets || [],
 		allowedPools: body.allowedPools || [],
+		...(Object.keys(budgets).length > 0 ? { budgets } : {}),
 	};
 	if (users.some((u) => u.username === user.username)) {
 		res.writeHead(409, json());
@@ -2069,6 +2150,14 @@ async function handleChatCompletions(req, res) {
 		return;
 	}
 
+	// ── Budget check ──
+	const budgetCheck = checkUserBudget(auth.user, auth.role);
+	if (!budgetCheck.allowed) {
+		res.writeHead(429, json());
+		res.end(JSON.stringify({ error: { message: budgetCheck.message } }));
+		return;
+	}
+
 	// ── User access check ──
 	if (!isModelAllowedForUser(auth.user, auth.role, requestModelId)) {
 		res.writeHead(403, json());
@@ -2335,7 +2424,10 @@ function handleStats(req, res) {
 			label: getProviderLabel(prov),
 			...s,
 		})),
-		users: Object.entries(userStats).map(([user, s]) => ({ username: user, ...s })),
+		users: Object.entries(userStats).map(([uname, s]) => {
+			const userCfg = loadUsers().find((u) => u.username === uname);
+			return { username: uname, ...s, budgets: userCfg?.budgets || null };
+		}),
 		recent: usageLog.slice(-limit).reverse(),
 	}));
 }
@@ -2471,6 +2563,59 @@ const server = createServer(async (req, res) => {
 	}
 });
 
+// ─── Init wizard ──────────────────────────────────────────────────────────────
+
+async function runInit() {
+	const rl = createInterface({ input: process.stdin, output: process.stdout });
+	const ask = (q) => new Promise((resolve) => rl.question(q, resolve));
+
+	console.log("\n  Leeloo init -- quick setup wizard\n");
+
+	// Admin token
+	let key = await ask("  Admin token (leave empty to generate random): ");
+	key = key.trim() || randomBytes(24).toString("hex");
+
+	// Port
+	let port = await ask("  Port [4000]: ");
+	port = port.trim() || "4000";
+
+	// Write .env
+	const envPath = join(dirname(fileURLToPath(import.meta.url)), ".env");
+	const envContent = [
+		"# Leeloo configuration",
+		`LEELOO_KEY=${key}`,
+		`LEELOO_PORT=${port}`,
+		"",
+	].join("\n");
+	writeFileSync(envPath, envContent, "utf-8");
+	console.log(`\n  Created ${envPath}`);
+
+	// Create config if missing
+	const agentDir = getAgentDir();
+	const configPath = join(agentDir, "multi-pass.json");
+	if (!existsSync(configPath)) {
+		if (!existsSync(agentDir)) mkdirSync(agentDir, { recursive: true });
+		writeFileSync(configPath, JSON.stringify({ subscriptions: [], pools: [], chains: [], presets: [] }, null, 2), "utf-8");
+		console.log(`  Created ${configPath}`);
+	} else {
+		console.log(`  Config already exists: ${configPath}`);
+	}
+
+	console.log(`
+  Done! Start Leeloo:
+
+    node leeloo.js
+
+  Then open:
+    Admin:  http://localhost:${port}/admin
+    Chat:   http://localhost:${port}/ui
+    API:    http://localhost:${port}/v1
+
+  Admin token: ${key}
+`);
+	rl.close();
+}
+
 server.listen(PORT, () => {
 	const config = loadConfig();
 	const providers = getAllProviders();
@@ -2505,7 +2650,7 @@ server.listen(PORT, () => {
   Chat UI: http://localhost:${PORT}/ui
 
   Admin token: ${ADMIN_TOKEN}
-  ${process.env.LEELOO_KEY ? "(from LEELOO_KEY env)" : "(random, set LEELOO_KEY env to persist)"}
+  ${process.env.LEELOO_KEY ? "(from LEELOO_KEY" + (envFile ? " via " + envFile : " env") + ")" : "(random -- run 'leeloo init' or set LEELOO_KEY to persist)"}
 `);
 
 	rotateUsageLog();

--- a/leeloo.js
+++ b/leeloo.js
@@ -71,6 +71,29 @@ const SUPPORTED_PROVIDERS = [
 	"google-gemini-cli", "google-antigravity",
 ];
 
+const PROVIDER_DISPLAY_NAMES = {
+	"anthropic": "Anthropic (Claude Pro/Max)",
+	"openai-codex": "ChatGPT Plus/Pro (Codex)",
+	"github-copilot": "GitHub Copilot",
+	"google-gemini-cli": "Google Cloud Code Assist",
+	"google-antigravity": "Antigravity",
+};
+
+/** Get a human-readable label for a provider name. */
+function getProviderLabel(providerName) {
+	const config = loadConfig();
+	// Check if it's an extra subscription with a label
+	for (const sub of config.subscriptions) {
+		const subName = sub.provider + "-" + sub.index;
+		if (subName === providerName) {
+			const base = PROVIDER_DISPLAY_NAMES[sub.provider] || sub.provider;
+			const display = base + " #" + sub.index;
+			return sub.label ? sub.label + " -- " + display : display;
+		}
+	}
+	return PROVIDER_DISPLAY_NAMES[providerName] || providerName;
+}
+
 function getBaseProvider(name) {
 	if (SUPPORTED_PROVIDERS.includes(name)) return name;
 	const m = name.match(/^(.+)-(\d+)$/);
@@ -793,6 +816,7 @@ async function handleStreaming(res, model, context, opts, requestModelId, actual
 				const finalChunk = chunk(id, requestModelId, {}, finish, usage);
 				finalChunk.x_provider = actualProvider;
 				finalChunk.x_model = model.id;
+				finalChunk.x_label = getProviderLabel(actualProvider);
 				write(finalChunk);
 				res.write("data: [DONE]\n\n");
 				break;
@@ -866,6 +890,7 @@ async function handleNonStreaming(res, model, context, opts, requestModelId, act
 	response.choices[0].finish_reason = toolCalls.length > 0 ? "tool_calls" : mapFinishReason(finishReason);
 	response.x_provider = actualProvider;
 	response.x_model = model.id;
+	response.x_label = getProviderLabel(actualProvider);
 
 	res.writeHead(200, { "Content-Type": "application/json" });
 	res.end(JSON.stringify(response));
@@ -1405,7 +1430,7 @@ async function sendMessage() {
 
     const reader = resp.body.getReader();
     const dec = new TextDecoder();
-    let buf = "", usage = null, xProvider = "", xModel = "";
+    let buf = "", usage = null, xProvider = "", xModel = "", xLabel = "";
 
     while (true) {
       const { done, value } = await reader.read();
@@ -1456,6 +1481,7 @@ async function sendMessage() {
           if (j.usage) usage = j.usage;
           if (j.x_provider) xProvider = j.x_provider;
           if (j.x_model) xModel = j.x_model;
+          if (j.x_label) xLabel = j.x_label;
 
           if (j.choices?.[0]?.finish_reason) {
             if (smdParser && smd) smd.parser_end(smdParser);
@@ -1464,8 +1490,8 @@ async function sendMessage() {
             meta.className = "meta";
             const parts = [];
             parts.push('<span class="provider-tag">' + esc(selectedRoute) + '</span>');
-            if (xProvider || xModel) {
-              parts.push('<span style="color:#8af">' + esc(xProvider) + '</span> / <span style="color:#aaa">' + esc(xModel) + '</span>');
+            if (xLabel || xProvider) {
+              parts.push('<span style="color:#8af">' + esc(xLabel || xProvider) + '</span> / <span style="color:#aaa">' + esc(xModel) + '</span>');
             }
             if (usage) parts.push(usage.prompt_tokens + " in / " + usage.completion_tokens + " out");
             parts.push((ms / 1000).toFixed(1) + "s");

--- a/leeloo.js
+++ b/leeloo.js
@@ -6,7 +6,7 @@
  *
  * Reads pi-multi-pass config and pi's auth storage, then exposes a local
  * OpenAI-compatible API that routes requests through your configured
- * subscriptions with pool failover.
+ * subscriptions with pool/chain/preset failover.
  *
  * Usage:
  *   ./leeloo.js [--port 4000]
@@ -15,21 +15,24 @@
  *   OPENAI_BASE_URL=http://localhost:4000/v1
  *
  * Endpoints:
- *   GET  /v1/models             List all available models
+ *   GET  /v1/models             List all available models + presets
  *   POST /v1/chat/completions   Chat completions (streaming + non-streaming)
  *   GET  /health                Proxy status
  *
- * Requires pi to be installed globally (npm i -g @mariozechner/pi-coding-agent).
- * Symlink the SDK into node_modules/:
- *   mkdir -p node_modules/@mariozechner
- *   ln -s $(npm root -g)/@mariozechner/pi-coding-agent node_modules/@mariozechner/pi-coding-agent
- *   ln -s $(npm root -g)/@mariozechner/pi-coding-agent/node_modules/@mariozechner/pi-ai node_modules/@mariozechner/pi-ai
+ * Features:
+ *   - Full OpenAI chat completions compatibility (text, tools, images, streaming)
+ *   - Pool-aware routing with strategy support (round-robin, quota-first, scheduled, custom)
+ *   - Chain-based cross-pool failover
+ *   - Preset resolution (model: "coding-premium" routes through preset entries)
+ *   - Automatic rate-limit failover (up to 5 attempts)
+ *   - OAuth token auto-refresh via pi's AuthStorage
+ *
+ * Requires pi installed globally (npm i -g @mariozechner/pi-coding-agent).
  */
 
 import { createServer } from "node:http";
-import { readFileSync, existsSync, mkdirSync, symlinkSync } from "node:fs";
+import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
-import { execSync } from "node:child_process";
 import {
 	AuthStorage,
 	getAgentDir,
@@ -48,12 +51,12 @@ for (let i = 0; i < args.length; i++) {
 	if (args[i] === "--port" && args[i + 1]) PORT = parseInt(args[i + 1], 10);
 }
 
-// ─── Config loading ───────────────────────────────────────────────────────────
+// ─── Config ───────────────────────────────────────────────────────────────────
 
 const AGENT_DIR = getAgentDir();
 const CONFIG_PATH = join(AGENT_DIR, "multi-pass.json");
 
-function loadMultiPassConfig() {
+function loadConfig() {
 	if (!existsSync(CONFIG_PATH)) return { subscriptions: [], pools: [], chains: [], presets: [] };
 	try {
 		const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
@@ -68,270 +71,560 @@ function loadMultiPassConfig() {
 	}
 }
 
-// ─── Auth ─────────────────────────────────────────────────────────────────────
-
 const authStorage = AuthStorage.create();
 
-// ─── Model registry ───────────────────────────────────────────────────────────
-
 const SUPPORTED_PROVIDERS = [
-	"anthropic",
-	"openai-codex",
-	"github-copilot",
-	"google-gemini-cli",
-	"google-antigravity",
+	"anthropic", "openai-codex", "github-copilot",
+	"google-gemini-cli", "google-antigravity",
 ];
 
-/**
- * Build a flat list of all servable models with their provider info.
- * Includes base providers + extra subscriptions from multi-pass config.
- */
-function buildModelList() {
-	const config = loadMultiPassConfig();
-	const models = [];
-	const seen = new Set();
-
-	for (const provider of SUPPORTED_PROVIDERS) {
-		if (!authStorage.hasAuth(provider)) continue;
-		try {
-			const providerModels = getModels(provider);
-			for (const m of providerModels) {
-				const key = `${provider}/${m.id}`;
-				if (seen.has(key)) continue;
-				seen.add(key);
-				models.push({ ...m, provider });
-			}
-		} catch {
-			// Provider not available
-		}
-	}
-
-	// Extra subscriptions (e.g. openai-codex-2, anthropic-3)
-	for (const sub of config.subscriptions) {
-		const provName = `${sub.provider}-${sub.index}`;
-		if (!authStorage.hasAuth(provName)) continue;
-		try {
-			const providerModels = getModels(sub.provider);
-			for (const m of providerModels) {
-				const key = `${provName}/${m.id}`;
-				if (seen.has(key)) continue;
-				seen.add(key);
-				models.push({ ...m, provider: provName });
-			}
-		} catch {
-			// Provider not available
-		}
-	}
-
-	return models;
-}
-
-/**
- * Find the best provider for a model ID, considering pools and auth.
- */
-function resolveModel(modelId) {
-	const config = loadMultiPassConfig();
-	const candidates = [];
-
-	for (const provider of SUPPORTED_PROVIDERS) {
-		if (!authStorage.hasAuth(provider)) continue;
-		try {
-			const m = getModel(provider, modelId);
-			if (m) candidates.push({ model: m, provider });
-		} catch { /* not found */ }
-	}
-
-	for (const sub of config.subscriptions) {
-		const provName = `${sub.provider}-${sub.index}`;
-		if (!authStorage.hasAuth(provName)) continue;
-		try {
-			const m = getModel(sub.provider, modelId);
-			if (m) candidates.push({ model: { ...m, provider: provName }, provider: provName });
-		} catch { /* not found */ }
-	}
-
-	if (candidates.length === 0) return null;
-
-	// Prefer pool member ordering
-	for (const pool of config.pools) {
-		if (!pool.enabled) continue;
-		for (const member of pool.members) {
-			const match = candidates.find((c) => c.provider === member);
-			if (match) return match;
-		}
-	}
-
-	return candidates[0];
-}
-
-/**
- * Get failover candidate, excluding already-tried providers.
- */
-function getFailoverCandidate(modelId, triedProviders) {
-	const config = loadMultiPassConfig();
-	const tried = new Set(triedProviders);
-
-	for (const pool of config.pools) {
-		if (!pool.enabled) continue;
-		for (const member of pool.members) {
-			if (tried.has(member)) continue;
-			if (!authStorage.hasAuth(member)) continue;
-			const base = getBaseProvider(member);
-			if (!base) continue;
-			try {
-				const m = getModel(base, modelId);
-				if (m) return { model: { ...m, provider: member }, provider: member };
-			} catch { continue; }
-		}
-	}
-
-	for (const provider of SUPPORTED_PROVIDERS) {
-		if (tried.has(provider)) continue;
-		if (!authStorage.hasAuth(provider)) continue;
-		try {
-			const m = getModel(provider, modelId);
-			if (m) return { model: m, provider };
-		} catch { continue; }
-	}
-
+function getBaseProvider(name) {
+	if (SUPPORTED_PROVIDERS.includes(name)) return name;
+	const m = name.match(/^(.+)-(\d+)$/);
+	if (m && SUPPORTED_PROVIDERS.includes(m[1])) return m[1];
 	return null;
 }
 
-function getBaseProvider(providerName) {
-	if (SUPPORTED_PROVIDERS.includes(providerName)) return providerName;
-	const match = providerName.match(/^(.+)-(\d+)$/);
-	if (match && SUPPORTED_PROVIDERS.includes(match[1])) return match[1];
-	return null;
+/** Get all provider names (base + extras) that are authenticated. */
+function getAllProviders() {
+	const config = loadConfig();
+	const providers = [];
+	for (const p of SUPPORTED_PROVIDERS) {
+		if (authStorage.hasAuth(p)) providers.push(p);
+	}
+	for (const sub of config.subscriptions) {
+		const name = `${sub.provider}-${sub.index}`;
+		if (authStorage.hasAuth(name)) providers.push(name);
+	}
+	return providers;
 }
 
 // ─── Rate limit detection ─────────────────────────────────────────────────────
 
-const RATE_LIMIT_PATTERNS = [
+const RATE_LIMIT_RE = [
 	/usage.?limit/i, /rate.?limit/i, /limit.*reached/i,
 	/too many requests/i, /overloaded/i, /capacity/i, /429/, /quota/i,
 ];
+function isRateLimit(msg) { return RATE_LIMIT_RE.some((r) => r.test(msg)); }
 
-function isRateLimitError(msg) {
-	return RATE_LIMIT_PATTERNS.some((p) => p.test(msg));
+// ─── Model resolution ─────────────────────────────────────────────────────────
+
+/**
+ * Try to get a pi-ai Model for a given provider and modelId.
+ * Returns null if the provider doesn't serve that model.
+ */
+function tryGetModel(providerName, modelId) {
+	const base = getBaseProvider(providerName);
+	if (!base) return null;
+	try {
+		const m = getModel(base, modelId);
+		// Re-tag with the actual provider name (may be an extra sub)
+		return base !== providerName ? { ...m, provider: providerName } : m;
+	} catch {
+		return null;
+	}
 }
 
-// ─── OpenAI format helpers ────────────────────────────────────────────────────
+/**
+ * Resolve a model ID (or preset name) into an ordered list of
+ * { model, provider } candidates, respecting pools, chains, and presets.
+ */
+function resolveCandidates(modelId) {
+	const config = loadConfig();
 
-function makeCompletionChunk(id, model, delta, finishReason) {
-	return {
+	// ── 1. Check if modelId is a preset name ──
+	const preset = config.presets.find(
+		(p) => p.enabled && p.name.toLowerCase() === modelId.toLowerCase(),
+	);
+	if (preset) {
+		const candidates = [];
+		for (const entry of preset.entries) {
+			if (!entry.enabled) continue;
+			if (!authStorage.hasAuth(entry.provider)) continue;
+			const m = tryGetModel(entry.provider, entry.model);
+			if (m) candidates.push({ model: m, provider: entry.provider, modelId: entry.model });
+		}
+		return candidates;
+	}
+
+	// ── 2. Collect all providers that can serve this model ──
+	const allProviders = getAllProviders();
+	const raw = [];
+	for (const prov of allProviders) {
+		const m = tryGetModel(prov, modelId);
+		if (m) raw.push({ model: m, provider: prov, modelId });
+	}
+	if (raw.length === 0) return [];
+
+	// ── 3. Order by pool membership ──
+	// Providers in an enabled pool come first (in pool member order),
+	// then non-pool providers.
+	const ordered = [];
+	const used = new Set();
+
+	for (const pool of config.pools) {
+		if (!pool.enabled) continue;
+		for (const member of pool.members) {
+			const match = raw.find((c) => c.provider === member);
+			if (match && !used.has(member)) {
+				ordered.push(match);
+				used.add(member);
+			}
+		}
+	}
+
+	// ── 4. Append chain targets ──
+	for (const chain of config.chains) {
+		if (!chain.enabled) continue;
+		for (const entry of chain.entries) {
+			if (!entry.enabled) continue;
+			const pool = config.pools.find((p) => p.name === entry.pool && p.enabled);
+			if (!pool) continue;
+			for (const member of pool.members) {
+				if (used.has(member)) continue;
+				// Chain entries may specify a different model
+				const m = tryGetModel(member, entry.model);
+				if (m) {
+					ordered.push({ model: m, provider: member, modelId: entry.model });
+					used.add(member);
+				}
+			}
+		}
+	}
+
+	// ── 5. Append remaining non-pool providers ──
+	for (const c of raw) {
+		if (!used.has(c.provider)) {
+			ordered.push(c);
+			used.add(c.provider);
+		}
+	}
+
+	return ordered;
+}
+
+// ─── OpenAI <-> pi-ai message conversion ──────────────────────────────────────
+
+/**
+ * Convert OpenAI-format messages to pi-ai Context.
+ */
+function toContext(messages, tools) {
+	const ctx = { messages: [], systemPrompt: undefined, tools: undefined };
+
+	// System prompt
+	const sysMessages = messages.filter((m) => m.role === "system");
+	if (sysMessages.length > 0) {
+		ctx.systemPrompt = sysMessages
+			.map((m) => typeof m.content === "string" ? m.content : flattenContent(m.content))
+			.join("\n\n");
+	}
+
+	// Messages (skip system)
+	for (const m of messages) {
+		if (m.role === "system") continue;
+		const ts = Date.now();
+
+		if (m.role === "user") {
+			ctx.messages.push({
+				role: "user",
+				content: convertUserContent(m.content),
+				timestamp: ts,
+			});
+
+		} else if (m.role === "assistant") {
+			const content = [];
+
+			// Text content
+			if (m.content) {
+				content.push({ type: "text", text: typeof m.content === "string" ? m.content : flattenContent(m.content) });
+			}
+
+			// Tool calls
+			if (m.tool_calls) {
+				for (const tc of m.tool_calls) {
+					content.push({
+						type: "toolCall",
+						id: tc.id,
+						name: tc.function.name,
+						arguments: safeParseJson(tc.function.arguments),
+					});
+				}
+			}
+
+			ctx.messages.push({
+				role: "assistant",
+				content,
+				api: "openai-completions",
+				provider: "proxy",
+				model: "proxy",
+				usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+				stopReason: m.tool_calls ? "toolUse" : "stop",
+				timestamp: ts,
+			});
+
+		} else if (m.role === "tool") {
+			ctx.messages.push({
+				role: "toolResult",
+				toolCallId: m.tool_call_id,
+				toolName: m.name || "",
+				content: [{ type: "text", text: typeof m.content === "string" ? m.content : JSON.stringify(m.content) }],
+				isError: false,
+				timestamp: ts,
+			});
+		}
+	}
+
+	// Tools
+	if (tools && tools.length > 0) {
+		ctx.tools = tools.map((t) => ({
+			name: t.function.name,
+			description: t.function.description || "",
+			parameters: t.function.parameters || { type: "object", properties: {} },
+		}));
+	}
+
+	return ctx;
+}
+
+function convertUserContent(content) {
+	if (typeof content === "string") return content;
+	if (!Array.isArray(content)) return String(content);
+
+	// Multi-part content (text + images)
+	const parts = [];
+	for (const part of content) {
+		if (part.type === "text") {
+			parts.push({ type: "text", text: part.text });
+		} else if (part.type === "image_url") {
+			const url = part.image_url?.url || "";
+			if (url.startsWith("data:")) {
+				// data:image/png;base64,...
+				const match = url.match(/^data:(image\/[^;]+);base64,(.+)$/);
+				if (match) {
+					parts.push({ type: "image", data: match[2], mimeType: match[1] });
+				}
+			} else {
+				// URL-based image -- download and convert to base64
+				parts.push({ type: "text", text: `[Image: ${url}]` });
+			}
+		}
+	}
+	return parts.length === 1 && parts[0].type === "text" ? parts[0].text : parts;
+}
+
+function flattenContent(content) {
+	if (typeof content === "string") return content;
+	if (Array.isArray(content)) {
+		return content.map((p) => p.text || "").join("");
+	}
+	return String(content);
+}
+
+function safeParseJson(str) {
+	try { return JSON.parse(str); } catch { return {}; }
+}
+
+/**
+ * Map pi-ai stop reason to OpenAI finish_reason.
+ */
+function mapFinishReason(reason) {
+	switch (reason) {
+		case "stop": return "stop";
+		case "length": return "length";
+		case "toolUse": return "tool_calls";
+		default: return "stop";
+	}
+}
+
+// ─── OpenAI response builders ─────────────────────────────────────────────────
+
+function chunk(id, model, delta, finishReason, usage) {
+	const c = {
 		id,
 		object: "chat.completion.chunk",
 		created: Math.floor(Date.now() / 1000),
 		model,
-		choices: [{
-			index: 0,
-			delta,
-			finish_reason: finishReason || null,
-		}],
+		choices: [{ index: 0, delta, finish_reason: finishReason || null }],
 	};
+	if (usage) c.usage = usage;
+	return c;
 }
 
-function makeCompletionResponse(id, model, content, usage) {
+function completionResponse(id, model, message, usage) {
 	return {
 		id,
 		object: "chat.completion",
 		created: Math.floor(Date.now() / 1000),
 		model,
-		choices: [{
-			index: 0,
-			message: { role: "assistant", content },
-			finish_reason: "stop",
-		}],
-		usage: usage ? {
-			prompt_tokens: usage.input,
-			completion_tokens: usage.output,
-			total_tokens: usage.totalTokens,
-		} : undefined,
+		choices: [{ index: 0, message, finish_reason: message.tool_calls ? "tool_calls" : "stop" }],
+		usage,
 	};
 }
 
-// ─── Request handler ──────────────────────────────────────────────────────────
+function formatUsage(u) {
+	if (!u) return undefined;
+	return {
+		prompt_tokens: u.input || 0,
+		completion_tokens: u.output || 0,
+		total_tokens: u.totalTokens || 0,
+	};
+}
+
+// ─── Streaming handler ────────────────────────────────────────────────────────
+
+async function handleStreaming(res, model, context, opts, requestModelId) {
+	res.writeHead(200, {
+		"Content-Type": "text/event-stream",
+		"Cache-Control": "no-cache",
+		Connection: "keep-alive",
+	});
+
+	const id = `chatcmpl-leeloo-${Date.now()}`;
+	const eventStream = stream(model, context, opts);
+	let sentRole = false;
+	const toolCalls = new Map(); // contentIndex -> { index, id, name, args }
+	let toolCallIdx = 0;
+
+	const write = (data) => {
+		if (!res.destroyed) res.write(`data: ${JSON.stringify(data)}\n\n`);
+	};
+
+	for await (const event of eventStream) {
+		if (res.destroyed) break;
+
+		switch (event.type) {
+			case "text_start": {
+				if (!sentRole) {
+					write(chunk(id, requestModelId, { role: "assistant", content: "" }, null));
+					sentRole = true;
+				}
+				break;
+			}
+
+			case "text_delta": {
+				if (!sentRole) {
+					write(chunk(id, requestModelId, { role: "assistant", content: event.delta }, null));
+					sentRole = true;
+				} else {
+					write(chunk(id, requestModelId, { content: event.delta }, null));
+				}
+				break;
+			}
+
+			case "thinking_delta": {
+				// Some clients support reasoning -- send as a custom field
+				// For now, skip thinking content in the stream
+				break;
+			}
+
+			case "toolcall_start": {
+				const idx = toolCallIdx++;
+				toolCalls.set(event.contentIndex, { index: idx, id: "", name: "", args: "" });
+				break;
+			}
+
+			case "toolcall_delta": {
+				const tc = toolCalls.get(event.contentIndex);
+				if (tc) tc.args += event.delta;
+				break;
+			}
+
+			case "toolcall_end": {
+				const tc = toolCalls.get(event.contentIndex);
+				if (!tc) break;
+				tc.id = event.toolCall.id;
+				tc.name = event.toolCall.name;
+				tc.args = JSON.stringify(event.toolCall.arguments);
+
+				if (!sentRole) {
+					write(chunk(id, requestModelId, {
+						role: "assistant",
+						content: null,
+						tool_calls: [{
+							index: tc.index,
+							id: tc.id,
+							type: "function",
+							function: { name: tc.name, arguments: tc.args },
+						}],
+					}, null));
+					sentRole = true;
+				} else {
+					write(chunk(id, requestModelId, {
+						tool_calls: [{
+							index: tc.index,
+							id: tc.id,
+							type: "function",
+							function: { name: tc.name, arguments: tc.args },
+						}],
+					}, null));
+				}
+				break;
+			}
+
+			case "done": {
+				const finish = toolCalls.size > 0 ? "tool_calls" : mapFinishReason(event.reason);
+				const usage = formatUsage(event.message?.usage);
+				write(chunk(id, requestModelId, {}, finish, usage));
+				res.write("data: [DONE]\n\n");
+				break;
+			}
+
+			case "error": {
+				const errMsg = event.error?.errorMessage || "Unknown error";
+				if (isRateLimit(errMsg)) throw new Error(errMsg);
+				// Send error as final text delta + stop
+				if (!sentRole) {
+					write(chunk(id, requestModelId, { role: "assistant", content: `[Error: ${errMsg}]` }, null));
+				} else {
+					write(chunk(id, requestModelId, { content: `\n[Error: ${errMsg}]` }, null));
+				}
+				write(chunk(id, requestModelId, {}, "stop"));
+				res.write("data: [DONE]\n\n");
+				break;
+			}
+		}
+	}
+
+	res.end();
+}
+
+// ─── Non-streaming handler ────────────────────────────────────────────────────
+
+async function handleNonStreaming(res, model, context, opts, requestModelId) {
+	const eventStream = stream(model, context, opts);
+	let fullText = "";
+	const toolCalls = [];
+	let usage = null;
+	let finishReason = "stop";
+
+	for await (const event of eventStream) {
+		switch (event.type) {
+			case "text_delta":
+				fullText += event.delta;
+				break;
+			case "toolcall_end":
+				toolCalls.push({
+					id: event.toolCall.id,
+					type: "function",
+					function: {
+						name: event.toolCall.name,
+						arguments: JSON.stringify(event.toolCall.arguments),
+					},
+				});
+				break;
+			case "done":
+				usage = event.message?.usage;
+				finishReason = event.reason;
+				break;
+			case "error": {
+				const errMsg = event.error?.errorMessage || "Unknown error";
+				if (isRateLimit(errMsg)) throw new Error(errMsg);
+				throw new Error(errMsg);
+			}
+		}
+	}
+
+	const message = { role: "assistant" };
+	if (toolCalls.length > 0) {
+		message.content = fullText || null;
+		message.tool_calls = toolCalls;
+	} else {
+		message.content = fullText;
+	}
+
+	const id = `chatcmpl-leeloo-${Date.now()}`;
+	const response = completionResponse(id, requestModelId, message, formatUsage(usage));
+	response.choices[0].finish_reason = toolCalls.length > 0 ? "tool_calls" : mapFinishReason(finishReason);
+
+	res.writeHead(200, { "Content-Type": "application/json" });
+	res.end(JSON.stringify(response));
+}
+
+// ─── Main request handler ─────────────────────────────────────────────────────
 
 async function handleChatCompletions(req, res) {
 	const body = await readBody(req);
 	let parsed;
-	try {
-		parsed = JSON.parse(body);
-	} catch {
-		res.writeHead(400, { "Content-Type": "application/json" });
+	try { parsed = JSON.parse(body); }
+	catch {
+		res.writeHead(400, json());
 		res.end(JSON.stringify({ error: { message: "Invalid JSON body" } }));
 		return;
 	}
 
-	const { model: modelId, messages, stream: doStream, temperature, max_tokens } = parsed;
-	if (!modelId || !messages) {
-		res.writeHead(400, { "Content-Type": "application/json" });
+	const {
+		model: requestModelId,
+		messages,
+		tools,
+		tool_choice,
+		stream: doStream,
+		temperature,
+		max_tokens,
+		max_completion_tokens,
+		top_p,
+		stop,
+		reasoning_effort,
+	} = parsed;
+
+	if (!requestModelId || !messages) {
+		res.writeHead(400, json());
 		res.end(JSON.stringify({ error: { message: "model and messages are required" } }));
 		return;
 	}
 
-	const triedProviders = [];
+	const candidates = resolveCandidates(requestModelId);
+	if (candidates.length === 0) {
+		res.writeHead(404, json());
+		res.end(JSON.stringify({ error: { message: `No provider found for model "${requestModelId}"` } }));
+		return;
+	}
+
+	const context = toContext(messages, tools);
+	const maxAttempts = Math.min(candidates.length, 5);
 	let lastError = null;
-	const maxAttempts = 5;
 
 	for (let attempt = 0; attempt < maxAttempts; attempt++) {
-		const resolved = attempt === 0
-			? resolveModel(modelId)
-			: getFailoverCandidate(modelId, triedProviders);
-
-		if (!resolved) {
-			const msg = triedProviders.length > 0
-				? `All providers exhausted for model "${modelId}" (tried: ${triedProviders.join(", ")})`
-				: `No provider found for model "${modelId}"`;
-			res.writeHead(404, { "Content-Type": "application/json" });
-			res.end(JSON.stringify({ error: { message: msg } }));
-			return;
-		}
-
-		triedProviders.push(resolved.provider);
+		const candidate = candidates[attempt];
 
 		try {
-			const apiKey = await authStorage.getApiKey(resolved.provider);
+			const apiKey = await authStorage.getApiKey(candidate.provider);
 			if (!apiKey) {
-				log(`[${resolved.provider}] no API key, skipping`);
+				log(`[${candidate.provider}] no API key, skipping`);
 				continue;
 			}
 
-			// Build pi-ai context from OpenAI messages
-			const context = { messages: [] };
-			const systemMsg = messages.find((m) => m.role === "system");
-			if (systemMsg) {
-				context.systemPrompt = typeof systemMsg.content === "string"
-					? systemMsg.content
-					: systemMsg.content.map((c) => c.text || "").join("");
-			}
-			context.messages = messages
-				.filter((m) => m.role !== "system")
-				.map((m) => ({ role: m.role, content: m.content, timestamp: Date.now() }));
+			const opts = {
+				apiKey,
+				temperature,
+				maxTokens: max_completion_tokens || max_tokens,
+				...(top_p !== undefined && { top_p }),
+				...(stop && { stop }),
+			};
 
-			const streamOpts = { apiKey, temperature, maxTokens: max_tokens };
-			log(`[${resolved.provider}] routing ${modelId} (attempt ${attempt + 1})`);
+			log(`[${candidate.provider}] ${candidate.modelId} (attempt ${attempt + 1}/${maxAttempts})`);
 
 			if (doStream) {
-				await handleStreamingResponse(res, resolved.model, context, streamOpts, modelId);
+				await handleStreaming(res, candidate.model, context, opts, requestModelId);
 			} else {
-				await handleNonStreamingResponse(res, resolved.model, context, streamOpts, modelId);
+				await handleNonStreaming(res, candidate.model, context, opts, requestModelId);
 			}
 			return;
 
 		} catch (err) {
 			const errMsg = err?.message || String(err);
-			log(`[${resolved.provider}] error: ${errMsg}`);
+			log(`[${candidate.provider}] error: ${errMsg}`);
 			lastError = errMsg;
 
-			if (isRateLimitError(errMsg) && attempt < maxAttempts - 1) {
-				log(`[${resolved.provider}] rate limited, failover...`);
+			if (isRateLimit(errMsg)) {
+				log(`[${candidate.provider}] rate limited, failover -> next candidate`);
+				// If streaming already started writing, we can't retry
+				if (res.headersSent) return;
 				continue;
 			}
-			if (attempt < maxAttempts - 1) continue;
+			if (attempt < maxAttempts - 1 && !res.headersSent) continue;
 
 			if (!res.headersSent) {
-				res.writeHead(502, { "Content-Type": "application/json" });
+				res.writeHead(502, json());
 				res.end(JSON.stringify({ error: { message: `Provider error: ${errMsg}` } }));
 			}
 			return;
@@ -339,91 +632,65 @@ async function handleChatCompletions(req, res) {
 	}
 
 	if (!res.headersSent) {
-		res.writeHead(502, { "Content-Type": "application/json" });
-		res.end(JSON.stringify({ error: { message: lastError || "All providers failed" } }));
+		const tried = candidates.slice(0, maxAttempts).map((c) => c.provider).join(", ");
+		res.writeHead(502, json());
+		res.end(JSON.stringify({ error: { message: `All providers failed for "${requestModelId}" (tried: ${tried}). Last error: ${lastError}` } }));
 	}
 }
 
-async function handleStreamingResponse(res, model, context, opts, modelId) {
-	res.writeHead(200, {
-		"Content-Type": "text/event-stream",
-		"Cache-Control": "no-cache",
-		Connection: "keep-alive",
-	});
-
-	const id = `chatcmpl-${Date.now()}`;
-	const eventStream = stream(model, context, opts);
-
-	for await (const event of eventStream) {
-		if (res.destroyed) break;
-
-		if (event.type === "text_delta") {
-			const chunk = makeCompletionChunk(id, modelId, { content: event.delta }, null);
-			res.write(`data: ${JSON.stringify(chunk)}\n\n`);
-		} else if (event.type === "done") {
-			const chunk = makeCompletionChunk(id, modelId, {}, "stop");
-			res.write(`data: ${JSON.stringify(chunk)}\n\n`);
-			res.write("data: [DONE]\n\n");
-		} else if (event.type === "error") {
-			const errMsg = event.error?.errorMessage || "Unknown error";
-			if (isRateLimitError(errMsg)) throw new Error(errMsg);
-			const chunk = makeCompletionChunk(id, modelId, { content: `\n\n[Error: ${errMsg}]` }, "stop");
-			res.write(`data: ${JSON.stringify(chunk)}\n\n`);
-			res.write("data: [DONE]\n\n");
-		}
-	}
-
-	res.end();
-}
-
-async function handleNonStreamingResponse(res, model, context, opts, modelId) {
-	const eventStream = stream(model, context, opts);
-	let fullText = "";
-	let usage = null;
-
-	for await (const event of eventStream) {
-		if (event.type === "text_delta") {
-			fullText += event.delta;
-		} else if (event.type === "done") {
-			usage = event.message?.usage;
-		} else if (event.type === "error") {
-			const errMsg = event.error?.errorMessage || "Unknown error";
-			if (isRateLimitError(errMsg)) throw new Error(errMsg);
-			throw new Error(errMsg);
-		}
-	}
-
-	const id = `chatcmpl-${Date.now()}`;
-	const response = makeCompletionResponse(id, modelId, fullText, usage);
-	res.writeHead(200, { "Content-Type": "application/json" });
-	res.end(JSON.stringify(response));
-}
+// ─── /v1/models ───────────────────────────────────────────────────────────────
 
 function handleModels(req, res) {
-	const models = buildModelList();
+	const allProviders = getAllProviders();
 	const unique = new Map();
-	for (const m of models) {
-		if (!unique.has(m.id)) unique.set(m.id, {
-			id: m.id, object: "model", created: 0, owned_by: m.provider,
+
+	for (const prov of allProviders) {
+		const base = getBaseProvider(prov);
+		if (!base) continue;
+		try {
+			for (const m of getModels(base)) {
+				if (!unique.has(m.id)) {
+					unique.set(m.id, { id: m.id, object: "model", created: 0, owned_by: prov });
+				}
+			}
+		} catch { /* skip */ }
+	}
+
+	// Add preset names as virtual models
+	const config = loadConfig();
+	for (const preset of config.presets) {
+		if (!preset.enabled) continue;
+		unique.set(`preset:${preset.name}`, {
+			id: preset.name,
+			object: "model",
+			created: 0,
+			owned_by: "pi-multi-pass",
 		});
 	}
-	res.writeHead(200, { "Content-Type": "application/json" });
+
+	res.writeHead(200, json());
 	res.end(JSON.stringify({ object: "list", data: [...unique.values()] }));
 }
 
-function handleHealth(req, res) {
-	const config = loadMultiPassConfig();
-	const authed = SUPPORTED_PROVIDERS.filter((p) => authStorage.hasAuth(p));
-	const extraSubs = config.subscriptions
-		.map((s) => `${s.provider}-${s.index}`)
-		.filter((p) => authStorage.hasAuth(p));
+// ─── /health ──────────────────────────────────────────────────────────────────
 
-	res.writeHead(200, { "Content-Type": "application/json" });
+function handleHealth(req, res) {
+	const config = loadConfig();
+	const providers = getAllProviders();
+	res.writeHead(200, json());
 	res.end(JSON.stringify({
 		status: "ok",
-		providers: [...authed, ...extraSubs],
-		pools: config.pools.filter((p) => p.enabled).map((p) => p.name),
-		presets: config.presets.filter((p) => p.enabled).map((p) => p.name),
+		providers,
+		pools: config.pools.filter((p) => p.enabled).map((p) => ({
+			name: p.name,
+			strategy: p.strategy || "round-robin",
+			members: p.members,
+		})),
+		chains: config.chains.filter((c) => c.enabled).map((c) => c.name),
+		presets: config.presets.filter((p) => p.enabled).map((p) => ({
+			name: p.name,
+			entries: p.entries.filter((e) => e.enabled).map((e) => `${e.provider}/${e.model}`),
+		})),
 	}));
 }
 
@@ -432,16 +699,13 @@ function handleHealth(req, res) {
 function readBody(req) {
 	return new Promise((resolve, reject) => {
 		const chunks = [];
-		req.on("data", (chunk) => chunks.push(chunk));
+		req.on("data", (c) => chunks.push(c));
 		req.on("end", () => resolve(Buffer.concat(chunks).toString()));
 		req.on("error", reject);
 	});
 }
-
-function log(...args) {
-	const ts = new Date().toISOString().slice(11, 19);
-	console.log(`[${ts}]`, ...args);
-}
+function json() { return { "Content-Type": "application/json" }; }
+function log(...a) { console.log(`[${new Date().toISOString().slice(11, 19)}]`, ...a); }
 
 // ─── Server ───────────────────────────────────────────────────────────────────
 
@@ -452,32 +716,22 @@ const server = createServer(async (req, res) => {
 	if (req.method === "OPTIONS") { res.writeHead(204); res.end(); return; }
 
 	const path = new URL(req.url, `http://localhost:${PORT}`).pathname;
-
 	try {
-		if (path === "/v1/chat/completions" && req.method === "POST") {
-			await handleChatCompletions(req, res);
-		} else if (path === "/v1/models" && req.method === "GET") {
-			handleModels(req, res);
-		} else if (path === "/health" && req.method === "GET") {
-			handleHealth(req, res);
-		} else {
-			res.writeHead(404, { "Content-Type": "application/json" });
-			res.end(JSON.stringify({ error: { message: "Not found" } }));
-		}
+		if (path === "/v1/chat/completions" && req.method === "POST") await handleChatCompletions(req, res);
+		else if (path === "/v1/models" && req.method === "GET") handleModels(req, res);
+		else if (path === "/health" && req.method === "GET") handleHealth(req, res);
+		else { res.writeHead(404, json()); res.end(JSON.stringify({ error: { message: "Not found" } })); }
 	} catch (err) {
-		log("Unhandled error:", err?.message || err);
-		if (!res.headersSent) {
-			res.writeHead(500, { "Content-Type": "application/json" });
-			res.end(JSON.stringify({ error: { message: "Internal server error" } }));
-		}
+		log("Unhandled:", err?.message || err);
+		if (!res.headersSent) { res.writeHead(500, json()); res.end(JSON.stringify({ error: { message: "Internal server error" } })); }
 	}
 });
 
 server.listen(PORT, () => {
-	const config = loadMultiPassConfig();
-	const authed = SUPPORTED_PROVIDERS.filter((p) => authStorage.hasAuth(p));
-	const extras = config.subscriptions.map((s) => `${s.provider}-${s.index}`).filter((p) => authStorage.hasAuth(p));
+	const config = loadConfig();
+	const providers = getAllProviders();
 	const pools = config.pools.filter((p) => p.enabled);
+	const presets = config.presets.filter((p) => p.enabled);
 
 	console.log(`
   ╔══════════════════════════════════════════╗
@@ -486,14 +740,17 @@ server.listen(PORT, () => {
 
   OpenAI-compatible proxy powered by pi-multi-pass
 
-  Listening:  http://localhost:${PORT}
-  Base URL:   http://localhost:${PORT}/v1
+  http://localhost:${PORT}/v1
 
-  Providers:  ${[...authed, ...extras].join(", ") || "none (login via pi first)"}
-  Pools:      ${pools.map((p) => `${p.name} (${p.members.length} members)`).join(", ") || "none"}
-  Presets:    ${config.presets.filter((p) => p.enabled).map((p) => p.name).join(", ") || "none"}
+  Providers:  ${providers.join(", ") || "none (login via pi first)"}
+  Pools:      ${pools.map((p) => `${p.name} [${p.strategy || "round-robin"}] (${p.members.length})`).join(", ") || "none"}
+  Chains:     ${config.chains.filter((c) => c.enabled).map((c) => c.name).join(", ") || "none"}
+  Presets:    ${presets.map((p) => p.name).join(", ") || "none"}
 
-  Usage:
-    OPENAI_BASE_URL=http://localhost:${PORT}/v1
+  POST /v1/chat/completions   (streaming, tools, images, failover)
+  GET  /v1/models             (all models + preset names)
+  GET  /health
+
+  OPENAI_BASE_URL=http://localhost:${PORT}/v1
 `);
 });

--- a/leeloo.js
+++ b/leeloo.js
@@ -917,22 +917,43 @@ function handlePresetDelete(req, res, presetName) {
 async function handleSubCreate(req, res) {
 	const body = JSON.parse(await readBody(req));
 	const config = loadConfig();
+	const provider = body.provider;
+	if (!provider) {
+		res.writeHead(400, json());
+		res.end(JSON.stringify({ error: { message: "provider is required" } }));
+		return;
+	}
+
+	// Auto-assign next available index for this provider (matches extension format)
+	const existingIndices = config.subscriptions
+		.filter((s) => s.provider === provider)
+		.map((s) => s.index || 0);
+	const nextIndex = existingIndices.length === 0 ? 2 : Math.max(...existingIndices) + 1;
+
 	const sub = {
-		name: body.name || `sub-${Date.now()}`,
-		provider: body.provider,
-		enabled: body.enabled !== false,
-		alias: body.alias || body.name || `sub-${Date.now()}`,
+		provider,
+		index: body.index || nextIndex,
+		label: body.label || body.alias || "",
 	};
+
+	// The canonical ID is "${provider}-${index}" (e.g. "openai-codex-2")
+	const subId = `${sub.provider}-${sub.index}`;
+
 	config.subscriptions.push(sub);
 	saveConfig(config);
 	res.writeHead(201, json());
-	res.end(JSON.stringify({ subscription: sub }));
+	res.end(JSON.stringify({ subscription: sub, subId }));
+}
+
+// subName here is the canonical ID like "openai-codex-2"
+function findSubIndex(config, subId) {
+	return config.subscriptions.findIndex((s) => `${s.provider}-${s.index}` === subId);
 }
 
 async function handleSubUpdate(req, res, subName) {
 	const body = JSON.parse(await readBody(req));
 	const config = loadConfig();
-	const idx = config.subscriptions.findIndex((s) => s.name === subName);
+	const idx = findSubIndex(config, subName);
 	if (idx < 0) { res.writeHead(404, json()); res.end(JSON.stringify({ error: { message: "Subscription not found" } })); return; }
 	config.subscriptions[idx] = { ...config.subscriptions[idx], ...body };
 	saveConfig(config);
@@ -942,7 +963,11 @@ async function handleSubUpdate(req, res, subName) {
 
 function handleSubDelete(req, res, subName) {
 	const config = loadConfig();
-	config.subscriptions = config.subscriptions.filter((s) => s.name !== subName);
+	const idx = findSubIndex(config, subName);
+	if (idx < 0) { res.writeHead(404, json()); res.end(JSON.stringify({ error: { message: "Subscription not found" } })); return; }
+	// Also remove auth
+	try { authStorage.remove(subName); } catch {}
+	config.subscriptions.splice(idx, 1);
 	saveConfig(config);
 	res.writeHead(200, json());
 	res.end(JSON.stringify({ deleted: subName }));
@@ -970,16 +995,17 @@ function handleAuthProviders(req, res) {
 
 	// Extra subscription accounts
 	for (const sub of config.subscriptions) {
-		const subId = `${sub.provider}-${sub.index || sub.name}`;
+		const subId = `${sub.provider}-${sub.index}`;
 		if (result.some((r) => r.id === subId)) continue;
 		const baseProv = provs.find((p) => p.id === sub.provider);
 		result.push({
 			id: subId,
-			name: `${baseProv?.name || sub.provider} #${sub.index || sub.name}`,
+			name: `${baseProv?.name || sub.provider} #${sub.index}${sub.label ? " (" + sub.label + ")" : ""}`,
 			baseProvider: sub.provider,
 			authenticated: authStorage.hasAuth(subId),
 			isBuiltin: false,
-			subscription: sub.name,
+			index: sub.index,
+			label: sub.label,
 		});
 	}
 
@@ -998,10 +1024,10 @@ function handleKnownNames(req, res) {
 		allNames.push({ id: p.id, label: p.name, type: "provider", authenticated: authStorage.hasAuth(p.id) });
 	}
 	for (const sub of config.subscriptions) {
-		const subId = `${sub.provider}-${sub.index || sub.name}`;
+		const subId = `${sub.provider}-${sub.index}`;
 		if (allNames.some((n) => n.id === subId)) continue;
 		const baseProv = provs.find((p) => p.id === sub.provider);
-		allNames.push({ id: subId, label: `${baseProv?.name || sub.provider} #${sub.index || sub.name}`, type: "subscription", authenticated: authStorage.hasAuth(subId) });
+		allNames.push({ id: subId, label: `${baseProv?.name || sub.provider} #${sub.index}${sub.label ? " (" + sub.label + ")" : ""}`, type: "subscription", authenticated: authStorage.hasAuth(subId) });
 	}
 
 	// Pool names

--- a/leeloo.js
+++ b/leeloo.js
@@ -95,27 +95,70 @@ function ensureDir() {
 	if (!existsSync(AGENT_DIR)) mkdirSync(AGENT_DIR, { recursive: true });
 }
 
-function loadConfig() {
-	if (!existsSync(CONFIG_PATH)) return { subscriptions: [], pools: [], chains: [], presets: [], apiKeys: [], accounts: [], modes: [], routingRules: [] };
+const JS_CONFIG_PATHS = [
+	join(AGENT_DIR, "multi-pass.config.js"),
+	join(AGENT_DIR, "multi-pass.config.mjs"),
+];
+
+function getJsConfigPath() {
+	return JS_CONFIG_PATHS.find((p) => existsSync(p));
+}
+
+let _jsConfigCache = null;
+let _jsConfigMtime = 0;
+
+async function loadJsConfig(jsPath) {
 	try {
-		const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
-		return {
-			subscriptions: Array.isArray(raw.subscriptions) ? raw.subscriptions : [],
-			pools: Array.isArray(raw.pools) ? raw.pools : [],
-			chains: Array.isArray(raw.chains) ? raw.chains : [],
-			presets: Array.isArray(raw.presets) ? raw.presets : [],
-			apiKeys: Array.isArray(raw.apiKeys) ? raw.apiKeys : [],
-			// v2 fields (optional)
-			accounts: Array.isArray(raw.accounts) ? raw.accounts : [],
-			modes: Array.isArray(raw.modes) ? raw.modes : [],
-			routingRules: Array.isArray(raw.routingRules) ? raw.routingRules : [],
-		};
-	} catch {
-		return { subscriptions: [], pools: [], chains: [], presets: [], apiKeys: [], accounts: [], modes: [], routingRules: [] };
+		const stat = (await import("node:fs")).statSync(jsPath);
+		const mtime = stat.mtimeMs;
+		if (_jsConfigCache && _jsConfigMtime === mtime) return _jsConfigCache;
+		const mod = await import(`file://${jsPath}?t=${mtime}`);
+		const cfg = mod.default || mod.config;
+		if (!cfg) throw new Error("config.js must export default a config object");
+		_jsConfigCache = normalizeConfig(cfg);
+		_jsConfigMtime = mtime;
+		return _jsConfigCache;
+	} catch (e) {
+		log(`[config] failed to load JS config ${jsPath}: ${e.message}`);
+		return null;
 	}
 }
 
+function normalizeConfig(raw) {
+	return {
+		subscriptions: Array.isArray(raw.subscriptions) ? raw.subscriptions : [],
+		pools: Array.isArray(raw.pools) ? raw.pools : [],
+		chains: Array.isArray(raw.chains) ? raw.chains : [],
+		presets: Array.isArray(raw.presets) ? raw.presets : [],
+		apiKeys: Array.isArray(raw.apiKeys) ? raw.apiKeys : [],
+		accounts: Array.isArray(raw.accounts) ? raw.accounts : [],
+		modes: Array.isArray(raw.modes) ? raw.modes : [],
+		routingRules: Array.isArray(raw.routingRules) ? raw.routingRules : (Array.isArray(raw.rules) ? raw.rules : []),
+	};
+}
+
+const _emptyConfig = () => ({ subscriptions: [], pools: [], chains: [], presets: [], apiKeys: [], accounts: [], modes: [], routingRules: [] });
+
+function loadConfig() {
+	// JS config takes precedence (cached for hot reload via mtime)
+	const jsPath = getJsConfigPath();
+	if (jsPath && _jsConfigCache) return _jsConfigCache;
+
+	if (!existsSync(CONFIG_PATH)) return _emptyConfig();
+	try {
+		const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+		return normalizeConfig(raw);
+	} catch {
+		return _emptyConfig();
+	}
+}
+
+function isReadOnlyConfig() {
+	return !!getJsConfigPath();
+}
+
 function saveConfig(config) {
+	if (isReadOnlyConfig()) throw new Error("Config is read-only (managed by multi-pass.config.js)");
 	ensureDir();
 	// Strip rules from config if they were accidentally included
 	const { rules, ...clean } = config;
@@ -1031,8 +1074,9 @@ function handleRulesDelete(req, res, ruleName) {
 // ─── Config CRUD API ─────────────────────────────────────────────────────────
 
 function handleConfigGet(req, res) {
+	const cfg = loadConfig();
 	res.writeHead(200, json());
-	res.end(JSON.stringify(loadConfig()));
+	res.end(JSON.stringify({ ...cfg, _readOnly: isReadOnlyConfig(), _source: getJsConfigPath() || CONFIG_PATH }));
 }
 
 async function handleConfigPut(req, res) {
@@ -2957,6 +3001,13 @@ const server = createServer(async (req, res) => {
 			if (!isAdmin) { res.writeHead(403, json()); res.end(JSON.stringify({ error: { message: "Admin access required" } })); return true; }
 			return false;
 		};
+		// ── Block writes when JS config is in use ──
+		const isWrite = req.method === "POST" || req.method === "PUT" || req.method === "DELETE";
+		if (isWrite && isReadOnlyConfig() && path.startsWith("/v1/config/")) {
+			res.writeHead(403, json());
+			res.end(JSON.stringify({ error: { message: "Config is managed by multi-pass.config.js (read-only via admin)" } }));
+			return;
+		}
 
 		// ── API routes ──
 		if (path === "/v1/chat/completions" && req.method === "POST") await handleChatCompletions(req, res);
@@ -3061,6 +3112,12 @@ async function runInit() {
 	rl.close();
 }
 
+// Load JS config (if any) before binding the server
+const _jsPath = getJsConfigPath();
+if (_jsPath) {
+	await loadJsConfig(_jsPath);
+}
+
 server.listen(PORT, () => {
 	const config = loadConfig();
 	const providers = getAllProviders();
@@ -3096,6 +3153,7 @@ server.listen(PORT, () => {
 
   Admin token: ${ADMIN_TOKEN}
   ${process.env.LEELOO_KEY ? "(from LEELOO_KEY" + (envFile ? " via " + envFile : " env") + ")" : "(random -- run 'leeloo init' or set LEELOO_KEY to persist)"}
+${_jsPath ? `\n  Config: ${_jsPath} (read-only via JS)` : ""}
 `);
 
 	rotateUsageLog();

--- a/leeloo.js
+++ b/leeloo.js
@@ -388,7 +388,15 @@ const usageLog = [];       // Recent requests (ring buffer)
 const USAGE_LOG_MAX = 500;
 const providerStats = {};  // { provider: { requests, tokens_in, tokens_out, errors, last_used } }
 
-function trackRequest(provider, modelId, usage, durationMs, error) {
+function clipText(value, maxLen = 4000) {
+	if (typeof value !== "string") return null;
+	const text = value.trim();
+	if (!text) return null;
+	if (text.length <= maxLen) return text;
+	return text.slice(0, maxLen) + "\n...[truncated]";
+}
+
+function trackRequest(provider, modelId, usage, durationMs, error, requestText, responseText) {
 	const entry = {
 		timestamp: new Date().toISOString(),
 		provider,
@@ -397,6 +405,8 @@ function trackRequest(provider, modelId, usage, durationMs, error) {
 		tokens_out: usage?.output || 0,
 		duration_ms: durationMs,
 		error: error || null,
+		request_text: clipText(requestText),
+		response_text: clipText(responseText),
 	};
 	usageLog.push(entry);
 	if (usageLog.length > USAGE_LOG_MAX) usageLog.shift();
@@ -1132,7 +1142,7 @@ function formatUsage(u) {
 
 // ─── Streaming handler ────────────────────────────────────────────────────────
 
-async function handleStreaming(res, model, context, opts, requestModelId, actualProvider) {
+async function handleStreaming(res, model, context, opts, requestModelId, actualProvider, requestText) {
 	const t0 = Date.now();
 	res.writeHead(200, {
 		"Content-Type": "text/event-stream",
@@ -1145,6 +1155,7 @@ async function handleStreaming(res, model, context, opts, requestModelId, actual
 	let sentRole = false;
 	const toolCalls = new Map(); // contentIndex -> { index, id, name, args }
 	let toolCallIdx = 0;
+	let collectedResponseText = "";
 
 	const write = (data) => {
 		if (!res.destroyed) res.write(`data: ${JSON.stringify(data)}\n\n`);
@@ -1163,6 +1174,7 @@ async function handleStreaming(res, model, context, opts, requestModelId, actual
 			}
 
 			case "text_delta": {
+				collectedResponseText += event.delta || "";
 				if (!sentRole) {
 					write(chunk(id, requestModelId, { role: "assistant", content: event.delta }, null));
 					sentRole = true;
@@ -1196,6 +1208,7 @@ async function handleStreaming(res, model, context, opts, requestModelId, actual
 				tc.id = event.toolCall.id;
 				tc.name = event.toolCall.name;
 				tc.args = JSON.stringify(event.toolCall.arguments);
+				collectedResponseText += `\n[Tool call: ${tc.name}]\n`;
 
 				if (!sentRole) {
 					write(chunk(id, requestModelId, {
@@ -1225,7 +1238,7 @@ async function handleStreaming(res, model, context, opts, requestModelId, actual
 			case "done": {
 				const finish = toolCalls.size > 0 ? "tool_calls" : mapFinishReason(event.reason);
 				const usage = formatUsage(event.message?.usage);
-				trackRequest(actualProvider, model.id, event.message?.usage, Date.now() - t0, null);
+				trackRequest(actualProvider, model.id, event.message?.usage, Date.now() - t0, null, requestText, collectedResponseText);
 				const finalChunk = chunk(id, requestModelId, {}, finish, usage);
 				finalChunk.x_provider = actualProvider;
 				finalChunk.x_model = model.id;
@@ -1237,7 +1250,7 @@ async function handleStreaming(res, model, context, opts, requestModelId, actual
 
 			case "error": {
 				const errMsg = event.error?.errorMessage || "Unknown error";
-				trackRequest(actualProvider, model.id, null, Date.now() - t0, errMsg);
+				trackRequest(actualProvider, model.id, null, Date.now() - t0, errMsg, requestText, collectedResponseText);
 				if (isRateLimit(errMsg)) throw new Error(errMsg);
 				if (!sentRole) {
 					write(chunk(id, requestModelId, { role: "assistant", content: `[Error: ${errMsg}]` }, null));
@@ -1256,7 +1269,7 @@ async function handleStreaming(res, model, context, opts, requestModelId, actual
 
 // ─── Non-streaming handler ────────────────────────────────────────────────────
 
-async function handleNonStreaming(res, model, context, opts, requestModelId, actualProvider) {
+async function handleNonStreaming(res, model, context, opts, requestModelId, actualProvider, requestText) {
 	const t0 = Date.now();
 	const eventStream = stream(model, context, opts);
 	let fullText = "";
@@ -1282,11 +1295,10 @@ async function handleNonStreaming(res, model, context, opts, requestModelId, act
 			case "done":
 				usage = event.message?.usage;
 				finishReason = event.reason;
-				trackRequest(actualProvider, model.id, usage, Date.now() - t0, null);
 				break;
 			case "error": {
 				const errMsg = event.error?.errorMessage || "Unknown error";
-				trackRequest(actualProvider, model.id, null, Date.now() - t0, errMsg);
+				trackRequest(actualProvider, model.id, null, Date.now() - t0, errMsg, requestText, fullText);
 				if (isRateLimit(errMsg)) throw new Error(errMsg);
 				throw new Error(errMsg);
 			}
@@ -1298,12 +1310,15 @@ async function handleNonStreaming(res, model, context, opts, requestModelId, act
 	if (respRules.length > 0 && fullText) {
 		const respBlock = checkResponseBlock(respRules, fullText);
 		if (respBlock.blocked) {
+			trackRequest(actualProvider, model.id, usage, Date.now() - t0, respBlock.message, requestText, fullText);
 			res.writeHead(403, json());
 			res.end(JSON.stringify({ error: { message: respBlock.message } }));
 			return;
 		}
 		fullText = redactResponse(respRules, fullText);
 	}
+
+	trackRequest(actualProvider, model.id, usage, Date.now() - t0, null, requestText, fullText);
 
 	const message = { role: "assistant" };
 	if (toolCalls.length > 0) {
@@ -1392,6 +1407,7 @@ async function handleChatCompletions(req, res) {
 		return;
 	}
 
+	const requestText = extractText(requestMessages);
 	const context = toContext(requestMessages, tools);
 	const maxAttempts = Math.min(candidates.length, 5);
 	let lastError = null;
@@ -1417,9 +1433,9 @@ async function handleChatCompletions(req, res) {
 			log(`[${candidate.provider}] ${candidate.modelId} (attempt ${attempt + 1}/${maxAttempts})`);
 
 			if (doStream) {
-				await handleStreaming(res, candidate.model, context, opts, requestModelId, candidate.provider);
+				await handleStreaming(res, candidate.model, context, opts, requestModelId, candidate.provider, requestText);
 			} else {
-				await handleNonStreaming(res, candidate.model, context, opts, requestModelId, candidate.provider);
+				await handleNonStreaming(res, candidate.model, context, opts, requestModelId, candidate.provider, requestText);
 			}
 			return;
 

--- a/leeloo.js
+++ b/leeloo.js
@@ -96,7 +96,7 @@ function ensureDir() {
 }
 
 function loadConfig() {
-	if (!existsSync(CONFIG_PATH)) return { subscriptions: [], pools: [], chains: [], presets: [], apiKeys: [] };
+	if (!existsSync(CONFIG_PATH)) return { subscriptions: [], pools: [], chains: [], presets: [], apiKeys: [], accounts: [], modes: [], routingRules: [] };
 	try {
 		const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 		return {
@@ -105,9 +105,13 @@ function loadConfig() {
 			chains: Array.isArray(raw.chains) ? raw.chains : [],
 			presets: Array.isArray(raw.presets) ? raw.presets : [],
 			apiKeys: Array.isArray(raw.apiKeys) ? raw.apiKeys : [],
+			// v2 fields (optional)
+			accounts: Array.isArray(raw.accounts) ? raw.accounts : [],
+			modes: Array.isArray(raw.modes) ? raw.modes : [],
+			routingRules: Array.isArray(raw.routingRules) ? raw.routingRules : [],
 		};
 	} catch {
-		return { subscriptions: [], pools: [], chains: [], presets: [], apiKeys: [] };
+		return { subscriptions: [], pools: [], chains: [], presets: [], apiKeys: [], accounts: [], modes: [], routingRules: [] };
 	}
 }
 
@@ -1653,6 +1657,290 @@ async function runCustomSelector(pool, available, currentProvider, modelId) {
 	return null;
 }
 
+// ═════════════════════════════════════════════════════════════════════════════
+// Routing v2: accounts -> modes -> rules pipeline
+// ═════════════════════════════════════════════════════════════════════════════
+//
+// New routing model that runs alongside the legacy pool/chain/preset path.
+// A request is routed via v2 only if `model` resolves to a v2 mode or to a
+// v2 preset (which references a mode). Otherwise we fall back to the legacy
+// routing in resolveCandidates().
+//
+// Built-in rule types:
+//   time-window     -- score boost during specified time windows
+//   quota-burn      -- score boost for accounts whose quota expires soonest
+//   cost-tier       -- score boost for cheap/free accounts
+//   model-fit       -- filter out accounts that can't serve the request
+//   error-blacklist -- filter out accounts that errored recently
+//   cooldown        -- filter out exhausted accounts (default applied)
+//   custom          -- run a JS function (file path or inline)
+
+const ROUTING_RULE_REGISTRY = {
+	"time-window": (params) => async (candidates, ctx) => {
+		const targets = new Set(params.targets || []);
+		const boost = params.boost ?? 50;
+		const now = ctx.now || new Date();
+		const dow = JS_DAY_TO_DOW[now.getDay()];
+		const hour = now.getHours();
+		const inWindow = (params.windows || []).some((w) => {
+			if (w.days && !w.days.includes(dow) && !w.days.some((d) => expandDayRange(d).includes(dow))) return false;
+			if (w.hours && !isInHourRange(hour, w.hours)) return false;
+			return true;
+		});
+		if (!inWindow) return { candidates };
+		const scores = {};
+		for (const c of candidates) {
+			const matches = targets.has(c.id) || (c.poolId && targets.has(c.poolId));
+			if (matches || targets.size === 0) scores[c.id] = boost;
+		}
+		return { candidates, scores };
+	},
+
+	"quota-burn": (params) => async (candidates, ctx) => {
+		const scores = {};
+		await Promise.all(candidates.map(async (c) => {
+			try {
+				const detail = await checkQuotaDetailed(c.id);
+				if (detail?.windows?.length) {
+					const earliest = detail.windows
+						.map((w) => w.resetAt ? new Date(w.resetAt).getTime() : Infinity)
+						.reduce((a, b) => Math.min(a, b), Infinity);
+					if (earliest !== Infinity) {
+						const hoursUntilReset = (earliest - Date.now()) / (60 * 60 * 1000);
+						// Smaller hoursUntilReset = higher boost (use it before you lose it)
+						scores[c.id] = Math.max(0, 100 - hoursUntilReset);
+					}
+				}
+			} catch {}
+		}));
+		return { candidates, scores };
+	},
+
+	"cost-tier": (params) => async (candidates, ctx) => {
+		const targets = new Set(params.targets || []);
+		const boost = params.boost ?? 30;
+		const scores = {};
+		for (const c of candidates) {
+			if (targets.has(c.id) || (c.poolId && targets.has(c.poolId))) scores[c.id] = boost;
+		}
+		return { candidates, scores };
+	},
+
+	"model-fit": (params) => async (candidates, ctx) => {
+		const minContext = params.minContext || 0;
+		const requireTools = !!params.requireTools;
+		const requireVision = !!params.requireVision;
+		// Filter is best-effort -- without per-model metadata we mostly let things through.
+		// Custom rules can do more sophisticated checks.
+		return { candidates };
+	},
+
+	"error-blacklist": (params) => async (candidates, ctx) => {
+		const windowMs = (params.windowMinutes || 5) * 60 * 1000;
+		const now = Date.now();
+		const recentErrored = new Set(
+			(ctx.history || [])
+				.filter((h) => h.error && (now - new Date(h.timestamp).getTime()) < windowMs)
+				.map((h) => h.candidate)
+		);
+		return { candidates: candidates.filter((c) => !recentErrored.has(c.id)) };
+	},
+
+	"cooldown": (params) => async (candidates, ctx) => {
+		return { candidates: candidates.filter((c) => !isExhausted(c.id)) };
+	},
+
+	"custom": (params) => {
+		// Inline function or file path
+		if (typeof params.fn === "function") return params.fn;
+		if (params.code) {
+			const path = params.code;
+			return async (candidates, ctx) => {
+				try {
+					const fn = await loadCustomRoutingRule(path);
+					if (typeof fn === "function") return await fn(candidates, ctx);
+				} catch (e) { log(`[rule:custom] error in ${path}: ${e.message}`); }
+				return { candidates };
+			};
+		}
+		return async (candidates) => ({ candidates });
+	},
+};
+
+const customRuleCache = new Map();
+async function loadCustomRoutingRule(scriptPath) {
+	let resolved = scriptPath;
+	if (!scriptPath.startsWith("/") && !scriptPath.startsWith("~/")) {
+		resolved = join(AGENT_DIR, scriptPath);
+	} else if (scriptPath.startsWith("~/")) {
+		const home = process.env.HOME || process.env.USERPROFILE || "";
+		resolved = join(home, scriptPath.slice(2));
+	}
+	if (customRuleCache.has(resolved)) return customRuleCache.get(resolved);
+	if (!existsSync(resolved)) return null;
+	try {
+		const mod = await import(`file://${resolved}?t=${Date.now()}`);
+		const fn = mod.default || mod.rule;
+		customRuleCache.set(resolved, fn);
+		return fn;
+	} catch (e) { log(`[rule:custom] failed to load ${resolved}: ${e.message}`); return null; }
+}
+
+function expandDayRange(spec) {
+	const days = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"];
+	const m = spec.match(/^(mon|tue|wed|thu|fri|sat|sun)-(mon|tue|wed|thu|fri|sat|sun)$/);
+	if (!m) return [spec];
+	const a = days.indexOf(m[1]);
+	const b = days.indexOf(m[2]);
+	if (a < 0 || b < 0) return [spec];
+	const out = [];
+	let i = a;
+	while (true) { out.push(days[i]); if (i === b) break; i = (i + 1) % 7; }
+	return out;
+}
+
+/** Compile a rule config entry into an apply function. */
+function compileRoutingRule(ruleConfig) {
+	const factory = ROUTING_RULE_REGISTRY[ruleConfig.type];
+	if (!factory) { log(`[rule] unknown type: ${ruleConfig.type}`); return null; }
+	return factory(ruleConfig.params || {});
+}
+
+/**
+ * Resolve a list of candidate references (account IDs, pool IDs, mode IDs)
+ * into a flat list of account candidates. Detects cycles and limits depth.
+ */
+function expandModeCandidates(refs, config, depth = 0, visited = new Set()) {
+	if (depth > 5) { log("[mode] max depth exceeded"); return []; }
+	const out = [];
+	for (const rawRef of refs || []) {
+		// Strip "pool:" / "mode:" prefixes -- both forms accepted
+		const ref = rawRef.replace(/^(pool|mode):/, "");
+		if (visited.has(ref)) continue;
+		visited.add(ref);
+
+		// Account?
+		const account = config.accounts.find((a) => a.id === ref);
+		if (account) { out.push({ id: account.id, account }); continue; }
+
+		// API key entry (legacy v1 shape, treat as account)
+		const apiKey = config.apiKeys.find((k) => k.name === ref);
+		if (apiKey) { out.push({ id: apiKey.name, account: { id: apiKey.name, kind: "apiKey", ...apiKey } }); continue; }
+
+		// OAuth subscription/provider (treat as implicit account)
+		if (getBaseProvider(ref) || SUPPORTED_PROVIDERS.includes(ref)) {
+			out.push({ id: ref, account: { id: ref, kind: "oauth", provider: getBaseProvider(ref) || ref } });
+			continue;
+		}
+
+		// Pool?
+		const pool = config.pools.find((p) => (p.name === ref || p.id === ref) && p.enabled !== false);
+		if (pool) {
+			for (const m of pool.members || []) {
+				if (visited.has(m)) continue;
+				const sub = expandModeCandidates([m], config, depth + 1, visited);
+				for (const s of sub) { s.poolId = pool.name || pool.id; out.push(s); }
+			}
+			continue;
+		}
+
+		// Mode?
+		const mode = config.modes.find((m) => m.id === ref);
+		if (mode) {
+			const sub = expandModeCandidates(mode.candidates, config, depth + 1, visited);
+			for (const s of sub) { s.modeId = mode.id; out.push(s); }
+			continue;
+		}
+
+		log(`[mode] unknown candidate ref: ${rawRef}`);
+	}
+	return out;
+}
+
+/** Resolve a model/preset ID to a v2 mode + preset (if applicable). */
+function resolveV2Route(modelOrPresetId) {
+	const config = loadConfig();
+	let preset = config.presets.find((p) => p.id === modelOrPresetId || p.name === modelOrPresetId);
+	let mode;
+	if (preset && preset.mode) {
+		mode = config.modes.find((m) => m.id === preset.mode);
+	} else {
+		mode = config.modes.find((m) => m.id === modelOrPresetId);
+	}
+	if (!mode) return null;
+	return { config, preset, mode };
+}
+
+/**
+ * Run the v2 routing pipeline. Returns an ordered list of { provider, modelId, model }
+ * candidates compatible with the existing chat handler loop.
+ */
+async function routeViaV2(modelOrPresetId, ctx) {
+	const route = resolveV2Route(modelOrPresetId);
+	if (!route) return null;
+	const { config, preset, mode } = route;
+
+	// 1. Expand candidates (accounts/pools/nested modes)
+	let candidates = expandModeCandidates(mode.candidates, config);
+	if (candidates.length === 0) return [];
+
+	// 2. Always apply cooldown filter (skip exhausted)
+	candidates = candidates.filter((c) => !isExhausted(c.id));
+
+	// 3. Build accumulated scores from rules
+	const scores = {};
+	for (const ruleId of (mode.rules || [])) {
+		const ruleConfig = config.routingRules.find((r) => r.id === ruleId);
+		if (!ruleConfig) { log(`[mode:${mode.id}] rule not found: ${ruleId}`); continue; }
+		const apply = compileRoutingRule(ruleConfig);
+		if (!apply) continue;
+		try {
+			const result = await apply(candidates, ctx);
+			if (result?.candidates) candidates = result.candidates;
+			if (result?.scores) {
+				for (const [id, s] of Object.entries(result.scores)) {
+					scores[id] = (scores[id] || 0) + s;
+				}
+			}
+		} catch (e) { log(`[rule:${ruleId}] error: ${e.message}`); }
+	}
+
+	// 4. Sort by accumulated score (descending), tie-break by original order
+	candidates.sort((a, b) => (scores[b.id] || 0) - (scores[a.id] || 0));
+
+	// 5. Pick the model. Prefer preset.preferredModels in order, fall back to fallbackModels.
+	const preferredModels = preset?.preferredModels || [];
+	const fallbackModels = preset?.fallbackModels || [];
+	const modelOrder = [...preferredModels, ...fallbackModels];
+
+	const result = [];
+	for (const cand of candidates) {
+		const providerName = cand.account?.id || cand.id;
+		// Try each model in preference order
+		const tries = modelOrder.length > 0 ? modelOrder : [null];
+		for (const wantedModel of tries) {
+			let modelId = wantedModel;
+			if (!modelId) {
+				// No preference -- pick the provider's first available model
+				try {
+					const base = getBaseProvider(providerName) || cand.account?.provider;
+					if (base) {
+						const models = getModels(base);
+						modelId = models[0]?.id;
+					}
+				} catch {}
+			}
+			if (!modelId) continue;
+			const model = tryGetModel(providerName, modelId);
+			if (model) {
+				result.push({ model, provider: providerName, modelId, score: scores[cand.id] || 0 });
+				break; // one model per candidate is enough; the loop tries next candidate
+			}
+		}
+	}
+	return result;
+}
+
 // ─── Model resolution ─────────────────────────────────────────────────────────
 
 function tryGetModel(providerName, modelId) {
@@ -1746,6 +2034,15 @@ async function applyPoolStrategy(pool, members, modelId) {
 
 async function resolveCandidates(modelId) {
 	const config = loadConfig();
+
+	// ── v2 routing: check if this is a mode or v2 preset ──
+	if (config.modes.length > 0 || (config.presets.some((p) => p.mode))) {
+		const v2 = await routeViaV2(modelId, { now: new Date(), history: [] });
+		if (v2 && v2.length > 0) {
+			log(`[v2] routed ${modelId} -> ${v2.length} candidates`);
+			return v2;
+		}
+	}
 
 	// ── 0. Pool-scoped: "pool:<name>" or "pool:<name>/<model>" ──
 	const poolMatch = modelId.match(/^pool:([^/]+)(?:\/(.+))?$/);

--- a/leeloo.js
+++ b/leeloo.js
@@ -1025,9 +1025,14 @@ function handleAuthStatus(req, res) {
 }
 
 async function handleAuthLogin(req, res, providerId) {
+	// Support ?storeAs=name to run OAuth for base provider but store under a different name
+	const url = new URL(req.url, `http://localhost:${PORT}`);
+	const storeAs = url.searchParams.get("storeAs") || null;
+	const trackId = storeAs || providerId; // ID used for pending tracking + final storage
+
 	// Check if already logging in
-	if (pendingLogins.has(providerId)) {
-		const pending = pendingLogins.get(providerId);
+	if (pendingLogins.has(trackId)) {
+		const pending = pendingLogins.get(trackId);
 		if (pending.authUrl) {
 			res.writeHead(200, json());
 			res.end(JSON.stringify({ status: "pending", authUrl: pending.authUrl, message: "Login already in progress. Open the URL to complete." }));
@@ -1035,37 +1040,48 @@ async function handleAuthLogin(req, res, providerId) {
 		}
 	}
 
-	log(`[auth] starting OAuth login for ${providerId}`);
+	log(`[auth] starting OAuth login for ${providerId}${storeAs ? ` (store as ${storeAs})` : ""}`);
+
+	// Find the OAuth provider to use (always the base provider's flow)
+	const oauthProviders = authStorage.getOAuthProviders();
+	const oauthProvider = oauthProviders.find((p) => p.id === providerId);
+	if (!oauthProvider) {
+		res.writeHead(400, json());
+		res.end(JSON.stringify({ error: { message: `Unknown OAuth provider: ${providerId}. Known: ${oauthProviders.map((p) => p.id).join(", ")}` } }));
+		return;
+	}
 
 	let authUrl = null;
 	let loginResolve, loginReject;
 	const loginPromise = new Promise((resolve, reject) => { loginResolve = resolve; loginReject = reject; });
 
-	pendingLogins.set(providerId, { authUrl: null, status: "starting" });
+	pendingLogins.set(trackId, { authUrl: null, status: "starting" });
 
-	// Start login in background
-	authStorage.login(providerId, {
+	// Run the OAuth login flow from the base provider
+	oauthProvider.login({
 		onAuth(info) {
-			const url = typeof info === "string" ? info : info?.url || info;
-			authUrl = url;
-			const pending = pendingLogins.get(providerId);
-			if (pending) { pending.authUrl = url; pending.status = "waiting"; }
-			log(`[auth] ${providerId} auth URL ready`);
+			const u = typeof info === "string" ? info : info?.url || info;
+			authUrl = u;
+			const pending = pendingLogins.get(trackId);
+			if (pending) { pending.authUrl = u; pending.status = "waiting"; }
+			log(`[auth] ${trackId} auth URL ready`);
 		},
-		onPrompt(msg) { log(`[auth] ${providerId} prompt: ${msg}`); },
-		onProgress(msg) { log(`[auth] ${providerId} progress: ${msg}`); },
+		onPrompt(msg) { log(`[auth] ${trackId} prompt: ${msg}`); },
+		onProgress(msg) { log(`[auth] ${trackId} progress: ${msg}`); },
 		onManualCodeInput() {
 			// Return a promise that never resolves -- we rely on the callback server
 			return new Promise(() => {});
 		},
 		signal: undefined,
-	}).then(() => {
-		log(`[auth] ${providerId} login successful`);
-		pendingLogins.delete(providerId);
+	}).then((credentials) => {
+		// Store credentials under the target name (storeAs or providerId)
+		authStorage.set(trackId, { type: "oauth", ...credentials });
+		log(`[auth] ${trackId} login successful, credentials stored`);
+		pendingLogins.delete(trackId);
 		loginResolve({ success: true });
 	}).catch((err) => {
-		log(`[auth] ${providerId} login failed: ${err.message}`);
-		pendingLogins.delete(providerId);
+		log(`[auth] ${trackId} login failed: ${err.message}`);
+		pendingLogins.delete(trackId);
 		loginReject(err);
 	});
 
@@ -1076,25 +1092,30 @@ async function handleAuthLogin(req, res, providerId) {
 	}
 
 	if (!authUrl) {
-		pendingLogins.delete(providerId);
+		pendingLogins.delete(trackId);
 		res.writeHead(500, json());
 		res.end(JSON.stringify({ error: { message: "Timed out waiting for auth URL" } }));
 		return;
 	}
 
 	res.writeHead(200, json());
-	res.end(JSON.stringify({ status: "pending", authUrl, message: "Open the URL to complete OAuth login." }));
+	res.end(JSON.stringify({ status: "pending", authUrl, trackId, message: "Open the URL to complete OAuth login." }));
 }
 
 function handleAuthLoginStatus(req, res, providerId) {
-	const pending = pendingLogins.get(providerId);
+	// Check query param for storeAs tracking
+	const url = new URL(req.url, `http://localhost:${PORT}`);
+	const storeAs = url.searchParams.get("storeAs") || null;
+	const trackId = storeAs || providerId;
+
+	const pending = pendingLogins.get(trackId);
 	if (pending) {
 		res.writeHead(200, json());
 		res.end(JSON.stringify({ status: pending.status, authUrl: pending.authUrl }));
 		return;
 	}
 	// Check if now authenticated
-	const hasAuth = authStorage.hasAuth(providerId);
+	const hasAuth = authStorage.hasAuth(trackId);
 	res.writeHead(200, json());
 	res.end(JSON.stringify({ status: hasAuth ? "authenticated" : "not_authenticated", hasAuth }));
 }

--- a/leeloo.js
+++ b/leeloo.js
@@ -96,7 +96,7 @@ function ensureDir() {
 }
 
 function loadConfig() {
-	if (!existsSync(CONFIG_PATH)) return { subscriptions: [], pools: [], chains: [], presets: [] };
+	if (!existsSync(CONFIG_PATH)) return { subscriptions: [], pools: [], chains: [], presets: [], apiKeys: [] };
 	try {
 		const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 		return {
@@ -104,9 +104,10 @@ function loadConfig() {
 			pools: Array.isArray(raw.pools) ? raw.pools : [],
 			chains: Array.isArray(raw.chains) ? raw.chains : [],
 			presets: Array.isArray(raw.presets) ? raw.presets : [],
+			apiKeys: Array.isArray(raw.apiKeys) ? raw.apiKeys : [],
 		};
 	} catch {
-		return { subscriptions: [], pools: [], chains: [], presets: [] };
+		return { subscriptions: [], pools: [], chains: [], presets: [], apiKeys: [] };
 	}
 }
 
@@ -356,26 +357,32 @@ function getBaseProvider(name) {
  * it doesn't know the OAuth provider. We fall back to extracting the access token
  * directly from stored credentials, same as the base provider's getApiKey would.
  */
+/** Lookup an API key entry by name from config. */
+function getApiKeyEntry(providerName) {
+	return loadConfig().apiKeys.find((k) => k.name === providerName && k.enabled !== false);
+}
+
 async function getApiKeyForProvider(providerName) {
-	// Try the standard path first (works for base providers)
+	// 1. Check API key entries first (raw keys in config)
+	const keyEntry = getApiKeyEntry(providerName);
+	if (keyEntry?.key) return keyEntry.key;
+
+	// 2. Try the standard path (works for base OAuth providers)
 	const key = await authStorage.getApiKey(providerName);
 	if (key) return key;
 
-	// For subscriptions: extract directly from stored creds
+	// 3. For subscriptions: extract directly from stored creds
 	const cred = authStorage.get(providerName);
 	if (!cred || cred.type !== "oauth" || !cred.access) return null;
 
 	const base = getBaseProvider(providerName);
 	if (base === "google-gemini-cli" || base === "google-antigravity") {
-		// Google providers store { access, projectId } serialized
 		return JSON.stringify({ token: cred.access, projectId: cred.projectId });
 	}
-
-	// Anthropic, OpenAI Codex, GitHub Copilot: just the access token
 	return cred.access;
 }
 
-/** Get all provider names (base + extras) that are authenticated. */
+/** Get all provider names (base OAuth + subscriptions + API keys) that are ready. */
 function getAllProviders() {
 	const config = loadConfig();
 	const providers = [];
@@ -386,7 +393,16 @@ function getAllProviders() {
 		const name = `${sub.provider}-${sub.index}`;
 		if (authStorage.hasAuth(name)) providers.push(name);
 	}
+	// API key entries -- always "authenticated" if they have a key
+	for (const k of config.apiKeys) {
+		if (k.enabled !== false && k.key) providers.push(k.name);
+	}
 	return providers;
+}
+
+/** Check if a provider is an API key entry (not OAuth). */
+function isApiKeyProvider(providerName) {
+	return !!getApiKeyEntry(providerName);
 }
 
 // ─── Rate limit detection ─────────────────────────────────────────────────────
@@ -418,7 +434,9 @@ function isExhausted(provider) {
 }
 
 function isAvailable(provider) {
-	return authStorage.hasAuth(provider) && !isExhausted(provider);
+	if (isExhausted(provider)) return false;
+	if (isApiKeyProvider(provider)) return true; // API key entries are always "authed"
+	return authStorage.hasAuth(provider);
 }
 
 // ─── Schedule evaluation (same logic as extension) ────────────────────────────
@@ -1229,25 +1247,37 @@ async function handleAuthProviders(req, res) {
 		});
 	}
 
-	// Check actual auth status for each (fast: just checks stored creds + JWT expiry)
+	// API key entries
+	for (const k of config.apiKeys) {
+		if (allIds.some((r) => r.id === k.name)) continue;
+		allIds.push({
+			id: k.name,
+			name: `${k.label || k.name}`,
+			baseProvider: k.type || "openai",
+			isBuiltin: false,
+			isApiKey: true,
+			baseUrl: k.baseUrl,
+			models: k.models,
+		});
+	}
+
+	// Check actual auth status for each
 	for (const entry of allIds) {
+		if (entry.isApiKey) {
+			const ke = config.apiKeys.find((k) => k.name === entry.id);
+			result.push({ ...entry, authenticated: !!(ke?.key), tokenStatus: ke?.key ? "ok" : "no-key", enabled: ke?.enabled !== false });
+			continue;
+		}
 		const hasAuth = authStorage.hasAuth(entry.id);
 		let tokenStatus = "no-auth";
 		if (hasAuth) {
 			const cred = authStorage.get(entry.id);
 			if (cred?.type === "oauth" && cred.access) {
-				// Quick JWT expiry check (no API call)
 				try {
 					const payload = decodeJwtPayload(cred.access);
-					if (payload?.exp && payload.exp < Date.now() / 1000) {
-						tokenStatus = "expired";
-					} else {
-						tokenStatus = "ok";
-					}
-				} catch {
-					// Non-JWT token (e.g. Google) -- assume ok if cred exists
-					tokenStatus = "ok";
-				}
+					if (payload?.exp && payload.exp < Date.now() / 1000) tokenStatus = "expired";
+					else tokenStatus = "ok";
+				} catch { tokenStatus = "ok"; }
 			}
 		}
 		result.push({ ...entry, authenticated: hasAuth, tokenStatus });
@@ -1272,6 +1302,11 @@ function handleKnownNames(req, res) {
 		if (allNames.some((n) => n.id === subId)) continue;
 		const baseProv = provs.find((p) => p.id === sub.provider);
 		allNames.push({ id: subId, label: `${baseProv?.name || sub.provider} #${sub.index}${sub.label ? " (" + sub.label + ")" : ""}`, type: "subscription", authenticated: authStorage.hasAuth(subId) });
+	}
+	// API key entries
+	for (const k of config.apiKeys) {
+		if (allNames.some((n) => n.id === k.name)) continue;
+		allNames.push({ id: k.name, label: k.label || k.name, type: "apikey", authenticated: !!(k.key) });
 	}
 
 	// Pool names
@@ -1403,6 +1438,50 @@ async function handleAuthLogout(req, res, providerId) {
 		res.writeHead(500, json());
 		res.end(JSON.stringify({ error: { message: e.message } }));
 	}
+}
+
+// ─── API Key CRUD ─────────────────────────────────────────────────────────────
+
+async function handleApiKeyCreate(req, res) {
+	const body = JSON.parse(await readBody(req));
+	const config = loadConfig();
+	const entry = {
+		name: body.name || `key-${Date.now()}`,
+		type: body.type || "openai",
+		key: body.key || "",
+		baseUrl: body.baseUrl || "https://api.openai.com/v1",
+		models: body.models || [],
+		enabled: body.enabled !== false,
+		label: body.label || "",
+	};
+	if (config.apiKeys.some((k) => k.name === entry.name)) {
+		res.writeHead(409, json());
+		res.end(JSON.stringify({ error: { message: `API key "${entry.name}" already exists` } }));
+		return;
+	}
+	config.apiKeys.push(entry);
+	saveConfig(config);
+	res.writeHead(201, json());
+	res.end(JSON.stringify({ apiKey: { ...entry, key: entry.key ? entry.key.slice(0, 8) + "..." : "" } }));
+}
+
+async function handleApiKeyUpdate(req, res, name) {
+	const body = JSON.parse(await readBody(req));
+	const config = loadConfig();
+	const idx = config.apiKeys.findIndex((k) => k.name === name);
+	if (idx < 0) { res.writeHead(404, json()); res.end(JSON.stringify({ error: { message: "API key not found" } })); return; }
+	config.apiKeys[idx] = { ...config.apiKeys[idx], ...body };
+	saveConfig(config);
+	res.writeHead(200, json());
+	res.end(JSON.stringify({ apiKey: { ...config.apiKeys[idx], key: config.apiKeys[idx].key?.slice(0, 8) + "..." } }));
+}
+
+function handleApiKeyDelete(req, res, name) {
+	const config = loadConfig();
+	config.apiKeys = config.apiKeys.filter((k) => k.name !== name);
+	saveConfig(config);
+	res.writeHead(200, json());
+	res.end(JSON.stringify({ deleted: name }));
 }
 
 // ─── User CRUD API ────────────────────────────────────────────────────────────
@@ -1573,13 +1652,71 @@ async function runCustomSelector(pool, available, currentProvider, modelId) {
 // ─── Model resolution ─────────────────────────────────────────────────────────
 
 function tryGetModel(providerName, modelId) {
+	// API key providers: create a virtual model object (no pi-ai needed)
+	const keyEntry = getApiKeyEntry(providerName);
+	if (keyEntry) {
+		const models = keyEntry.models || [];
+		if (models.length > 0 && !models.includes(modelId)) return null;
+		return { id: modelId, provider: providerName, __apiKey: true, __baseUrl: keyEntry.baseUrl || "https://api.openai.com/v1" };
+	}
+
 	const base = getBaseProvider(providerName);
 	if (!base) return null;
 	try {
-		// Always use base provider in the model object (pi-ai needs it for API routing).
-		// The subscription name (providerName) is tracked separately for auth lookup.
 		return getModel(base, modelId);
 	} catch { return null; }
+}
+
+/**
+ * Direct proxy to an OpenAI-compatible endpoint (for API key providers).
+ * Bypasses pi-ai entirely -- just forwards the request and streams back.
+ */
+async function proxyToApiKeyProvider(res, keyEntry, apiKey, requestBody, doStream) {
+	const baseUrl = (keyEntry.baseUrl || "https://api.openai.com/v1").replace(/\/+$/, "");
+	const url = `${baseUrl}/chat/completions`;
+
+	const headers = {
+		"Content-Type": "application/json",
+		Authorization: `Bearer ${apiKey}`,
+	};
+
+	// Anthropic API uses a different header
+	if (keyEntry.type === "anthropic") {
+		headers["x-api-key"] = apiKey;
+		headers["anthropic-version"] = "2023-06-01";
+		delete headers.Authorization;
+	}
+
+	const resp = await fetch(url, { method: "POST", headers, body: JSON.stringify(requestBody) });
+
+	if (!resp.ok) {
+		const errText = await resp.text().catch(() => "");
+		const status = resp.status;
+		if (status === 429 || /rate.?limit|too many/i.test(errText)) throw new Error(`Rate limited (${status})`);
+		throw new Error(`API error ${status}: ${errText.slice(0, 200)}`);
+	}
+
+	if (doStream) {
+		res.writeHead(200, { "Content-Type": "text/event-stream", "Cache-Control": "no-cache", Connection: "keep-alive" });
+		// Pipe the SSE stream directly
+		const reader = resp.body.getReader();
+		const dec = new TextDecoder();
+		try {
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) break;
+				if (!res.destroyed) res.write(dec.decode(value, { stream: true }));
+			}
+		} finally {
+			if (!res.destroyed) res.end();
+		}
+	} else {
+		const data = await resp.json();
+		res.writeHead(200, { "Content-Type": "application/json" });
+		res.end(JSON.stringify(data));
+	}
+
+	return resp;
 }
 
 /**
@@ -2225,6 +2362,16 @@ async function handleChatCompletions(req, res) {
 
 			log(`[${candidate.provider}] ${candidate.modelId} (attempt ${attempt + 1}/${maxAttempts})`);
 
+			// API key providers: direct proxy (bypass pi-ai)
+			const keyEntry = getApiKeyEntry(candidate.provider);
+			if (keyEntry) {
+				const t0p = Date.now();
+				const proxyBody = { ...parsed, model: candidate.modelId, messages: requestMessages, stream: doStream };
+				await proxyToApiKeyProvider(res, keyEntry, apiKey, proxyBody, doStream);
+				trackRequest(candidate.provider, candidate.modelId, null, Date.now() - t0p, null, requestText, null, username);
+				return;
+			}
+
 			if (doStream) {
 				await handleStreaming(res, candidate.model, context, opts, requestModelId, candidate.provider, requestText, username);
 			} else {
@@ -2550,6 +2697,10 @@ const server = createServer(async (req, res) => {
 		else if (path === "/v1/config/subscriptions" && req.method === "POST") { if (!adminOnly()) await handleSubCreate(req, res); }
 		else if (path.startsWith("/v1/config/subscriptions/") && req.method === "PUT") { if (!adminOnly()) await handleSubUpdate(req, res, decodeURIComponent(path.split("/v1/config/subscriptions/")[1])); }
 		else if (path.startsWith("/v1/config/subscriptions/") && req.method === "DELETE") { if (!adminOnly()) handleSubDelete(req, res, decodeURIComponent(path.split("/v1/config/subscriptions/")[1])); }
+		// API keys
+		else if (path === "/v1/config/apikeys" && req.method === "POST") { if (!adminOnly()) await handleApiKeyCreate(req, res); }
+		else if (path.startsWith("/v1/config/apikeys/") && req.method === "PUT") { if (!adminOnly()) await handleApiKeyUpdate(req, res, decodeURIComponent(path.split("/v1/config/apikeys/")[1])); }
+		else if (path.startsWith("/v1/config/apikeys/") && req.method === "DELETE") { if (!adminOnly()) handleApiKeyDelete(req, res, decodeURIComponent(path.split("/v1/config/apikeys/")[1])); }
 		// User management (admin only)
 		else if (path === "/v1/users" && req.method === "GET") { if (!adminOnly()) handleUsersList(req, res); }
 		else if (path === "/v1/users" && req.method === "POST") { if (!adminOnly()) await handleUserCreate(req, res); }

--- a/leeloo.js
+++ b/leeloo.js
@@ -1099,6 +1099,271 @@ async function handleConfigPut(req, res) {
 	res.end(JSON.stringify(config));
 }
 
+// ─── AI config editor ────────────────────────────────────────────────────────
+
+const CONFIG_REFERENCE = `
+multi-pass.json schema reference:
+
+{
+  "subscriptions": [
+    // OAuth-based extra accounts (managed via login flow)
+    { "provider": "openai-codex", "index": 2, "label": "work email" }
+  ],
+
+  "apiKeys": [
+    // Raw API keys (e.g. OpenAI sk-..., Anthropic sk-ant-...)
+    {
+      "name": "oai-team-1",     // unique ID
+      "label": "Team account",
+      "key": "sk-...",
+      "models": ["gpt-4o", "gpt-4o-mini"], // optional restriction
+      "enabled": true
+    }
+  ],
+
+  "accounts": [
+    // v2 unified primitive: any access point. Used in v2 modes/pools.
+    {
+      "id": "anthropic-main",
+      "provider": "anthropic",
+      "kind": "subscription",  // or "apiKey"
+      "key": "sk-ant-...",     // for apiKey kind
+      "baseUrl": "https://api.anthropic.com/v1",  // optional
+      "label": "Personal Claude",
+      "enabled": true
+    }
+  ],
+
+  "pools": [
+    // Same-provider rotation
+    {
+      "name": "codex-shared",
+      "baseProvider": "openai-codex",
+      "members": ["openai-codex", "openai-codex-2"],
+      "strategy": "round-robin",  // or "quota-first" | "scheduled" | "custom"
+      "enabled": true
+    }
+  ],
+
+  "routingRules": [
+    // Reusable decision pieces. Filter and/or score candidates.
+    {
+      "id": "prefer-anthropic-evening",
+      "type": "time-window",     // see types below
+      "description": "Boost Anthropic on weekday evenings",
+      "params": {
+        "targets": ["anthropic"],
+        "windows": [
+          { "days": ["mon","tue","wed","thu","fri"], "hours": [18, 23], "tz": "Europe/Vienna" }
+        ],
+        "boost": 100
+      }
+    },
+    // Other rule types:
+    // type: "quota-burn"     params: {} (boosts soonest-expiring)
+    // type: "cost-tier"      params: { targets: [...], boost: number }
+    // type: "model-fit"      params: { minContext, requireTools, requireVision }
+    // type: "error-blacklist" params: { windowMinutes }
+    // type: "cooldown"       params: {} (always applied)
+    // type: "custom"         params: { code: "rules/my-rule.js" }
+  ],
+
+  "modes": [
+    // v2 cross-provider routing pipeline
+    {
+      "id": "coding-premium",
+      "description": "Best quality coding mode",
+      "candidates": ["anthropic", "pool:codex-shared", "openrouter"],
+      // candidates can reference: account.id, pool name (with or without "pool:" prefix), or another mode.id
+      "rules": ["prefer-anthropic-evening", "burn-expiring-first"],
+      // rules apply in order; filter shrinks candidates, score adds to priority
+      "onError": "re-evaluate"  // or "next-in-order" | "fail-fast"
+    }
+  ],
+
+  "presets": [
+    // v2 client-facing alias: virtual model name -> mode + preferred models
+    {
+      "name": "coding-premium",
+      "id": "coding-premium",
+      "mode": "coding-premium",
+      "preferredModels": ["claude-sonnet-4-20250514", "gpt-5.1"],
+      "fallbackModels": ["gpt-5.0-mini"],
+      "enabled": true
+    }
+    // Or v1 legacy form with entries[]:
+    // { "name": "x", "entries": [{ "provider": "anthropic", "model": "claude-sonnet-4", "enabled": true }] }
+  ],
+
+  "chains": [
+    // Legacy ordered failover (v1)
+    { "name": "premium", "enabled": true, "entries": [{ "pool": "codex-shared", "model": "gpt-5.1" }] }
+  ]
+}
+
+Routing pipeline (when client requests model="<preset-or-mode-id>"):
+  1. Resolve preset -> mode (or mode directly)
+  2. Expand mode.candidates (accounts/pools/nested modes flatten in)
+  3. Filter exhausted accounts
+  4. For each rule in mode.rules: filter and/or score candidates
+  5. Sort by accumulated score (descending)
+  6. Try preset.preferredModels in order against the top candidate
+  7. On error: re-evaluate (rules see error in ctx.history)
+`;
+
+async function handleConfigAiEdit(req, res) {
+	const body = JSON.parse(await readBody(req));
+	const instruction = body.instruction;
+	const targetModel = body.model || "coding-premium"; // use the user's preset
+
+	if (!instruction) {
+		res.writeHead(400, json());
+		res.end(JSON.stringify({ error: { message: "instruction required" } }));
+		return;
+	}
+
+	const config = loadConfig();
+	const cleanConfig = { ...config };
+	delete cleanConfig._readOnly; delete cleanConfig._source;
+	// Strip secrets before sending to LLM
+	cleanConfig.apiKeys = (cleanConfig.apiKeys || []).map((k) => ({ ...k, key: k.key ? "[REDACTED]" : "" }));
+	cleanConfig.accounts = (cleanConfig.accounts || []).map((a) => ({ ...a, key: a.key ? "[REDACTED]" : undefined }));
+
+	const systemPrompt = `You are a configuration assistant for pi-multi-pass / Leeloo, an OpenAI-compatible LLM routing proxy.
+
+Your job: take the user's natural-language request and propose a precise update to their multi-pass.json config.
+
+${CONFIG_REFERENCE}
+
+Rules:
+1. Return ONLY a single JSON code block followed by a markdown explanation.
+2. The JSON code block must be the COMPLETE updated config (not a diff, not a patch).
+3. Preserve all existing fields the user did not ask to change.
+4. Never invent API keys -- if a key is shown as "[REDACTED]" in the input, keep it as "[REDACTED]" in the output (the server will preserve the real key).
+5. Never break existing routing -- if the user adds a new rule, leave existing rules intact unless they explicitly say to replace them.
+6. Use IDs that already exist in the config. If you need to reference a new account/pool/rule, also create it.
+7. After the JSON, add a short markdown section (## Changes) explaining what you changed and why, in bullet points.
+
+Output format:
+\`\`\`json
+{ ... entire updated config ... }
+\`\`\`
+
+## Changes
+- Added rule X because the user wanted Y
+- Modified mode Z to ...
+`;
+
+	const userPrompt = `Current config (apiKeys/account keys redacted for security):
+\`\`\`json
+${JSON.stringify(cleanConfig, null, 2)}
+\`\`\`
+
+User request:
+${instruction}`;
+
+	// Call ourselves on /v1/chat/completions using the admin token
+	try {
+		const resp = await fetch(`http://localhost:${PORT}/v1/chat/completions`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer ${ADMIN_TOKEN}`,
+			},
+			body: JSON.stringify({
+				model: targetModel,
+				stream: false,
+				messages: [
+					{ role: "system", content: systemPrompt },
+					{ role: "user", content: userPrompt },
+				],
+			}),
+		});
+
+		if (!resp.ok) {
+			const err = await resp.json().catch(() => ({}));
+			res.writeHead(502, json());
+			res.end(JSON.stringify({ error: { message: `LLM call failed: ${err?.error?.message || resp.statusText}` } }));
+			return;
+		}
+
+		const data = await resp.json();
+		const content = data?.choices?.[0]?.message?.content || "";
+
+		// Extract JSON code block
+		const jsonMatch = content.match(/```json\s*([\s\S]*?)```/);
+		if (!jsonMatch) {
+			res.writeHead(502, json());
+			res.end(JSON.stringify({ error: { message: "LLM response missing JSON code block", raw: content } }));
+			return;
+		}
+
+		let proposed;
+		try { proposed = JSON.parse(jsonMatch[1]); }
+		catch (e) {
+			res.writeHead(502, json());
+			res.end(JSON.stringify({ error: { message: `LLM produced invalid JSON: ${e.message}`, raw: jsonMatch[1] } }));
+			return;
+		}
+
+		// Re-inject real keys (LLM only saw [REDACTED])
+		if (Array.isArray(proposed.apiKeys)) {
+			for (const k of proposed.apiKeys) {
+				if (k.key === "[REDACTED]") {
+					const orig = (config.apiKeys || []).find((x) => x.name === k.name);
+					if (orig) k.key = orig.key;
+				}
+			}
+		}
+		if (Array.isArray(proposed.accounts)) {
+			for (const a of proposed.accounts) {
+				if (a.key === "[REDACTED]") {
+					const orig = (config.accounts || []).find((x) => x.id === a.id);
+					if (orig) a.key = orig.key;
+				}
+			}
+		}
+
+		// Extract markdown explanation (everything after the JSON block)
+		const explanation = content.slice(jsonMatch.index + jsonMatch[0].length).trim();
+
+		res.writeHead(200, json());
+		res.end(JSON.stringify({
+			proposed,
+			explanation,
+			model_used: data.x_model,
+			provider_used: data.x_provider,
+			usage: data.usage,
+		}));
+	} catch (e) {
+		res.writeHead(500, json());
+		res.end(JSON.stringify({ error: { message: e.message } }));
+	}
+}
+
+async function handleConfigAiApply(req, res) {
+	const body = JSON.parse(await readBody(req));
+	const proposed = body.config;
+	if (!proposed || typeof proposed !== "object") {
+		res.writeHead(400, json());
+		res.end(JSON.stringify({ error: { message: "proposed config required" } }));
+		return;
+	}
+	try {
+		// Backup current config first
+		const backupPath = CONFIG_PATH + ".ai-bak-" + Date.now();
+		if (existsSync(CONFIG_PATH)) {
+			writeFileSync(backupPath, readFileSync(CONFIG_PATH, "utf-8"), "utf-8");
+		}
+		saveConfig(normalizeConfig(proposed));
+		res.writeHead(200, json());
+		res.end(JSON.stringify({ saved: true, backup: backupPath }));
+	} catch (e) {
+		res.writeHead(500, json());
+		res.end(JSON.stringify({ error: { message: e.message } }));
+	}
+}
+
 // Granular: pools
 async function handlePoolsGet(req, res) {
 	res.writeHead(200, json());
@@ -2112,6 +2377,145 @@ async function routeViaV2(modelOrPresetId, ctx) {
 		}
 	}
 	return result;
+}
+
+/**
+ * Run the v2 routing pipeline in dry-run mode and return a detailed trace.
+ * Doesn't call any LLM. Used by /v1/routing/simulate for debugging routing
+ * rules and previewing decisions for hypothetical contexts.
+ */
+async function simulateRoute(modelOrPresetId, ctx) {
+	const trace = {
+		input: { model: modelOrPresetId, now: ctx.now?.toISOString() || new Date().toISOString(), userTag: ctx.userTag, prompt: ctx.prompt },
+		resolution: null,
+		expansion: null,
+		filtered: null,
+		ruleSteps: [],
+		finalOrder: [],
+		picked: null,
+		modelChoice: null,
+		errors: [],
+	};
+
+	// 1. Resolve to a v2 route (preset or mode)
+	const route = resolveV2Route(modelOrPresetId);
+	if (!route) {
+		trace.errors.push(`No v2 mode or preset found for "${modelOrPresetId}". Falls through to legacy routing.`);
+		return trace;
+	}
+	const { config, preset, mode } = route;
+	trace.resolution = { preset: preset?.id || null, mode: mode.id, modeDescription: mode.description };
+
+	// 2. Expand candidates
+	let candidates = expandModeCandidates(mode.candidates, config);
+	trace.expansion = {
+		candidates: candidates.map((c) => ({ id: c.id, kind: c.account?.kind, poolId: c.poolId, modeId: c.modeId })),
+		total: candidates.length,
+	};
+	if (candidates.length === 0) {
+		trace.errors.push("No candidates after expansion -- mode.candidates is empty or all references are invalid.");
+		return trace;
+	}
+
+	// 3. Filter exhausted (cooldown)
+	const beforeFilter = candidates.length;
+	const exhausted = candidates.filter((c) => isExhausted(c.id)).map((c) => c.id);
+	candidates = candidates.filter((c) => !isExhausted(c.id));
+	trace.filtered = { exhausted, before: beforeFilter, after: candidates.length };
+
+	// 4. Apply rules in order, capturing each step
+	const scores = {};
+	for (const ruleId of (mode.rules || [])) {
+		const ruleConfig = config.routingRules.find((r) => r.id === ruleId);
+		if (!ruleConfig) {
+			trace.ruleSteps.push({ rule: ruleId, type: "missing", error: "rule not found in config" });
+			continue;
+		}
+		const before = candidates.map((c) => c.id);
+		const apply = compileRoutingRule(ruleConfig);
+		if (!apply) {
+			trace.ruleSteps.push({ rule: ruleId, type: ruleConfig.type, error: "rule failed to compile" });
+			continue;
+		}
+
+		const stepScores = {};
+		try {
+			const result = await apply(candidates, ctx);
+			if (result?.candidates) candidates = result.candidates;
+			if (result?.scores) {
+				for (const [id, s] of Object.entries(result.scores)) {
+					stepScores[id] = s;
+					scores[id] = (scores[id] || 0) + s;
+				}
+			}
+		} catch (e) {
+			trace.ruleSteps.push({ rule: ruleId, type: ruleConfig.type, error: e.message });
+			continue;
+		}
+
+		const after = candidates.map((c) => c.id);
+		trace.ruleSteps.push({
+			rule: ruleId,
+			type: ruleConfig.type,
+			description: ruleConfig.description,
+			removed: before.filter((id) => !after.includes(id)),
+			scoresAdded: stepScores,
+			runningScores: { ...scores },
+		});
+	}
+
+	// 5. Sort by accumulated score
+	candidates.sort((a, b) => (scores[b.id] || 0) - (scores[a.id] || 0));
+	trace.finalOrder = candidates.map((c) => ({
+		id: c.id,
+		score: scores[c.id] || 0,
+		kind: c.account?.kind,
+		poolId: c.poolId,
+	}));
+
+	// 6. Pick top + best model
+	const top = candidates[0];
+	if (top) {
+		const preferredModels = preset?.preferredModels || [];
+		const fallbackModels = preset?.fallbackModels || [];
+		const modelOrder = [...preferredModels, ...fallbackModels];
+		const providerName = top.account?.id || top.id;
+
+		let pickedModel = null;
+		const modelTries = [];
+		const tries = modelOrder.length > 0 ? modelOrder : [null];
+		for (const wantedModel of tries) {
+			let modelId = wantedModel;
+			if (!modelId) {
+				try {
+					const base = getBaseProvider(providerName) || top.account?.provider;
+					if (base) modelId = getModels(base)[0]?.id;
+				} catch {}
+			}
+			if (!modelId) continue;
+			const model = tryGetModel(providerName, modelId);
+			modelTries.push({ model: modelId, ok: !!model });
+			if (model) { pickedModel = modelId; break; }
+		}
+
+		trace.picked = { provider: providerName, score: scores[top.id] || 0 };
+		trace.modelChoice = { tries: modelTries, picked: pickedModel };
+	}
+
+	return trace;
+}
+
+async function handleRoutingSimulate(req, res) {
+	const body = JSON.parse(await readBody(req));
+	const ctx = {
+		now: body.now ? new Date(body.now) : new Date(),
+		userTag: body.userTag,
+		prompt: body.prompt,
+		history: [],
+	};
+	const trace = await simulateRoute(body.model, ctx);
+	res.writeHead(200, json());
+	res.end(JSON.stringify(trace));
 }
 
 // ─── Model resolution ─────────────────────────────────────────────────────────
@@ -3142,6 +3546,7 @@ const server = createServer(async (req, res) => {
 		if (path === "/v1/chat/completions" && req.method === "POST") await handleChatCompletions(req, res);
 		else if (path === "/v1/models" && req.method === "GET") handleModels(req, res);
 		else if (path === "/v1/routing" && req.method === "GET") handleRouting(req, res);
+		else if (path === "/v1/routing/simulate" && req.method === "POST") { if (!adminOnly()) await handleRoutingSimulate(req, res); }
 		// Admin-only endpoints
 		else if (path === "/v1/quota" && req.method === "GET") { if (!adminOnly()) await handleQuota(req, res); }
 		else if (path === "/v1/stats" && req.method === "GET") { if (!adminOnly()) handleStats(req, res); }
@@ -3158,6 +3563,8 @@ const server = createServer(async (req, res) => {
 		else if (path.startsWith("/v1/auth/logout/") && req.method === "POST") { if (!adminOnly()) await handleAuthLogout(req, res, decodeURIComponent(path.split("/v1/auth/logout/")[1])); }
 		else if (path === "/v1/config" && req.method === "GET") { if (!adminOnly()) handleConfigGet(req, res); }
 		else if (path === "/v1/config" && req.method === "PUT") { if (!adminOnly()) await handleConfigPut(req, res); }
+		else if (path === "/v1/config/ai-edit" && req.method === "POST") { if (!adminOnly()) await handleConfigAiEdit(req, res); }
+		else if (path === "/v1/config/ai-apply" && req.method === "POST") { if (!adminOnly()) await handleConfigAiApply(req, res); }
 		else if (path === "/v1/config/pools" && req.method === "GET") { if (!adminOnly()) await handlePoolsGet(req, res); }
 		else if (path === "/v1/config/pools" && req.method === "POST") { if (!adminOnly()) await handlePoolCreate(req, res); }
 		else if (path.startsWith("/v1/config/pools/") && req.method === "PUT") { if (!adminOnly()) await handlePoolUpdate(req, res, decodeURIComponent(path.split("/v1/config/pools/")[1])); }

--- a/leeloo.js
+++ b/leeloo.js
@@ -1,0 +1,499 @@
+#!/usr/bin/env node
+/**
+ * leeloo.js -- OpenAI-compatible proxy powered by pi-multi-pass
+ *
+ * "Leeloo Dallas Multi Pass!"
+ *
+ * Reads pi-multi-pass config and pi's auth storage, then exposes a local
+ * OpenAI-compatible API that routes requests through your configured
+ * subscriptions with pool failover.
+ *
+ * Usage:
+ *   ./leeloo.js [--port 4000]
+ *
+ * Then point your tools at:
+ *   OPENAI_BASE_URL=http://localhost:4000/v1
+ *
+ * Endpoints:
+ *   GET  /v1/models             List all available models
+ *   POST /v1/chat/completions   Chat completions (streaming + non-streaming)
+ *   GET  /health                Proxy status
+ *
+ * Requires pi to be installed globally (npm i -g @mariozechner/pi-coding-agent).
+ * Symlink the SDK into node_modules/:
+ *   mkdir -p node_modules/@mariozechner
+ *   ln -s $(npm root -g)/@mariozechner/pi-coding-agent node_modules/@mariozechner/pi-coding-agent
+ *   ln -s $(npm root -g)/@mariozechner/pi-coding-agent/node_modules/@mariozechner/pi-ai node_modules/@mariozechner/pi-ai
+ */
+
+import { createServer } from "node:http";
+import { readFileSync, existsSync, mkdirSync, symlinkSync } from "node:fs";
+import { join } from "node:path";
+import { execSync } from "node:child_process";
+import {
+	AuthStorage,
+	getAgentDir,
+} from "@mariozechner/pi-coding-agent";
+import {
+	getModel,
+	getModels,
+	stream,
+} from "@mariozechner/pi-ai";
+
+// ─── CLI args ─────────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+let PORT = parseInt(process.env.LEELOO_PORT || "4000", 10);
+for (let i = 0; i < args.length; i++) {
+	if (args[i] === "--port" && args[i + 1]) PORT = parseInt(args[i + 1], 10);
+}
+
+// ─── Config loading ───────────────────────────────────────────────────────────
+
+const AGENT_DIR = getAgentDir();
+const CONFIG_PATH = join(AGENT_DIR, "multi-pass.json");
+
+function loadMultiPassConfig() {
+	if (!existsSync(CONFIG_PATH)) return { subscriptions: [], pools: [], chains: [], presets: [] };
+	try {
+		const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+		return {
+			subscriptions: Array.isArray(raw.subscriptions) ? raw.subscriptions : [],
+			pools: Array.isArray(raw.pools) ? raw.pools : [],
+			chains: Array.isArray(raw.chains) ? raw.chains : [],
+			presets: Array.isArray(raw.presets) ? raw.presets : [],
+		};
+	} catch {
+		return { subscriptions: [], pools: [], chains: [], presets: [] };
+	}
+}
+
+// ─── Auth ─────────────────────────────────────────────────────────────────────
+
+const authStorage = AuthStorage.create();
+
+// ─── Model registry ───────────────────────────────────────────────────────────
+
+const SUPPORTED_PROVIDERS = [
+	"anthropic",
+	"openai-codex",
+	"github-copilot",
+	"google-gemini-cli",
+	"google-antigravity",
+];
+
+/**
+ * Build a flat list of all servable models with their provider info.
+ * Includes base providers + extra subscriptions from multi-pass config.
+ */
+function buildModelList() {
+	const config = loadMultiPassConfig();
+	const models = [];
+	const seen = new Set();
+
+	for (const provider of SUPPORTED_PROVIDERS) {
+		if (!authStorage.hasAuth(provider)) continue;
+		try {
+			const providerModels = getModels(provider);
+			for (const m of providerModels) {
+				const key = `${provider}/${m.id}`;
+				if (seen.has(key)) continue;
+				seen.add(key);
+				models.push({ ...m, provider });
+			}
+		} catch {
+			// Provider not available
+		}
+	}
+
+	// Extra subscriptions (e.g. openai-codex-2, anthropic-3)
+	for (const sub of config.subscriptions) {
+		const provName = `${sub.provider}-${sub.index}`;
+		if (!authStorage.hasAuth(provName)) continue;
+		try {
+			const providerModels = getModels(sub.provider);
+			for (const m of providerModels) {
+				const key = `${provName}/${m.id}`;
+				if (seen.has(key)) continue;
+				seen.add(key);
+				models.push({ ...m, provider: provName });
+			}
+		} catch {
+			// Provider not available
+		}
+	}
+
+	return models;
+}
+
+/**
+ * Find the best provider for a model ID, considering pools and auth.
+ */
+function resolveModel(modelId) {
+	const config = loadMultiPassConfig();
+	const candidates = [];
+
+	for (const provider of SUPPORTED_PROVIDERS) {
+		if (!authStorage.hasAuth(provider)) continue;
+		try {
+			const m = getModel(provider, modelId);
+			if (m) candidates.push({ model: m, provider });
+		} catch { /* not found */ }
+	}
+
+	for (const sub of config.subscriptions) {
+		const provName = `${sub.provider}-${sub.index}`;
+		if (!authStorage.hasAuth(provName)) continue;
+		try {
+			const m = getModel(sub.provider, modelId);
+			if (m) candidates.push({ model: { ...m, provider: provName }, provider: provName });
+		} catch { /* not found */ }
+	}
+
+	if (candidates.length === 0) return null;
+
+	// Prefer pool member ordering
+	for (const pool of config.pools) {
+		if (!pool.enabled) continue;
+		for (const member of pool.members) {
+			const match = candidates.find((c) => c.provider === member);
+			if (match) return match;
+		}
+	}
+
+	return candidates[0];
+}
+
+/**
+ * Get failover candidate, excluding already-tried providers.
+ */
+function getFailoverCandidate(modelId, triedProviders) {
+	const config = loadMultiPassConfig();
+	const tried = new Set(triedProviders);
+
+	for (const pool of config.pools) {
+		if (!pool.enabled) continue;
+		for (const member of pool.members) {
+			if (tried.has(member)) continue;
+			if (!authStorage.hasAuth(member)) continue;
+			const base = getBaseProvider(member);
+			if (!base) continue;
+			try {
+				const m = getModel(base, modelId);
+				if (m) return { model: { ...m, provider: member }, provider: member };
+			} catch { continue; }
+		}
+	}
+
+	for (const provider of SUPPORTED_PROVIDERS) {
+		if (tried.has(provider)) continue;
+		if (!authStorage.hasAuth(provider)) continue;
+		try {
+			const m = getModel(provider, modelId);
+			if (m) return { model: m, provider };
+		} catch { continue; }
+	}
+
+	return null;
+}
+
+function getBaseProvider(providerName) {
+	if (SUPPORTED_PROVIDERS.includes(providerName)) return providerName;
+	const match = providerName.match(/^(.+)-(\d+)$/);
+	if (match && SUPPORTED_PROVIDERS.includes(match[1])) return match[1];
+	return null;
+}
+
+// ─── Rate limit detection ─────────────────────────────────────────────────────
+
+const RATE_LIMIT_PATTERNS = [
+	/usage.?limit/i, /rate.?limit/i, /limit.*reached/i,
+	/too many requests/i, /overloaded/i, /capacity/i, /429/, /quota/i,
+];
+
+function isRateLimitError(msg) {
+	return RATE_LIMIT_PATTERNS.some((p) => p.test(msg));
+}
+
+// ─── OpenAI format helpers ────────────────────────────────────────────────────
+
+function makeCompletionChunk(id, model, delta, finishReason) {
+	return {
+		id,
+		object: "chat.completion.chunk",
+		created: Math.floor(Date.now() / 1000),
+		model,
+		choices: [{
+			index: 0,
+			delta,
+			finish_reason: finishReason || null,
+		}],
+	};
+}
+
+function makeCompletionResponse(id, model, content, usage) {
+	return {
+		id,
+		object: "chat.completion",
+		created: Math.floor(Date.now() / 1000),
+		model,
+		choices: [{
+			index: 0,
+			message: { role: "assistant", content },
+			finish_reason: "stop",
+		}],
+		usage: usage ? {
+			prompt_tokens: usage.input,
+			completion_tokens: usage.output,
+			total_tokens: usage.totalTokens,
+		} : undefined,
+	};
+}
+
+// ─── Request handler ──────────────────────────────────────────────────────────
+
+async function handleChatCompletions(req, res) {
+	const body = await readBody(req);
+	let parsed;
+	try {
+		parsed = JSON.parse(body);
+	} catch {
+		res.writeHead(400, { "Content-Type": "application/json" });
+		res.end(JSON.stringify({ error: { message: "Invalid JSON body" } }));
+		return;
+	}
+
+	const { model: modelId, messages, stream: doStream, temperature, max_tokens } = parsed;
+	if (!modelId || !messages) {
+		res.writeHead(400, { "Content-Type": "application/json" });
+		res.end(JSON.stringify({ error: { message: "model and messages are required" } }));
+		return;
+	}
+
+	const triedProviders = [];
+	let lastError = null;
+	const maxAttempts = 5;
+
+	for (let attempt = 0; attempt < maxAttempts; attempt++) {
+		const resolved = attempt === 0
+			? resolveModel(modelId)
+			: getFailoverCandidate(modelId, triedProviders);
+
+		if (!resolved) {
+			const msg = triedProviders.length > 0
+				? `All providers exhausted for model "${modelId}" (tried: ${triedProviders.join(", ")})`
+				: `No provider found for model "${modelId}"`;
+			res.writeHead(404, { "Content-Type": "application/json" });
+			res.end(JSON.stringify({ error: { message: msg } }));
+			return;
+		}
+
+		triedProviders.push(resolved.provider);
+
+		try {
+			const apiKey = await authStorage.getApiKey(resolved.provider);
+			if (!apiKey) {
+				log(`[${resolved.provider}] no API key, skipping`);
+				continue;
+			}
+
+			// Build pi-ai context from OpenAI messages
+			const context = { messages: [] };
+			const systemMsg = messages.find((m) => m.role === "system");
+			if (systemMsg) {
+				context.systemPrompt = typeof systemMsg.content === "string"
+					? systemMsg.content
+					: systemMsg.content.map((c) => c.text || "").join("");
+			}
+			context.messages = messages
+				.filter((m) => m.role !== "system")
+				.map((m) => ({ role: m.role, content: m.content, timestamp: Date.now() }));
+
+			const streamOpts = { apiKey, temperature, maxTokens: max_tokens };
+			log(`[${resolved.provider}] routing ${modelId} (attempt ${attempt + 1})`);
+
+			if (doStream) {
+				await handleStreamingResponse(res, resolved.model, context, streamOpts, modelId);
+			} else {
+				await handleNonStreamingResponse(res, resolved.model, context, streamOpts, modelId);
+			}
+			return;
+
+		} catch (err) {
+			const errMsg = err?.message || String(err);
+			log(`[${resolved.provider}] error: ${errMsg}`);
+			lastError = errMsg;
+
+			if (isRateLimitError(errMsg) && attempt < maxAttempts - 1) {
+				log(`[${resolved.provider}] rate limited, failover...`);
+				continue;
+			}
+			if (attempt < maxAttempts - 1) continue;
+
+			if (!res.headersSent) {
+				res.writeHead(502, { "Content-Type": "application/json" });
+				res.end(JSON.stringify({ error: { message: `Provider error: ${errMsg}` } }));
+			}
+			return;
+		}
+	}
+
+	if (!res.headersSent) {
+		res.writeHead(502, { "Content-Type": "application/json" });
+		res.end(JSON.stringify({ error: { message: lastError || "All providers failed" } }));
+	}
+}
+
+async function handleStreamingResponse(res, model, context, opts, modelId) {
+	res.writeHead(200, {
+		"Content-Type": "text/event-stream",
+		"Cache-Control": "no-cache",
+		Connection: "keep-alive",
+	});
+
+	const id = `chatcmpl-${Date.now()}`;
+	const eventStream = stream(model, context, opts);
+
+	for await (const event of eventStream) {
+		if (res.destroyed) break;
+
+		if (event.type === "text_delta") {
+			const chunk = makeCompletionChunk(id, modelId, { content: event.delta }, null);
+			res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+		} else if (event.type === "done") {
+			const chunk = makeCompletionChunk(id, modelId, {}, "stop");
+			res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+			res.write("data: [DONE]\n\n");
+		} else if (event.type === "error") {
+			const errMsg = event.error?.errorMessage || "Unknown error";
+			if (isRateLimitError(errMsg)) throw new Error(errMsg);
+			const chunk = makeCompletionChunk(id, modelId, { content: `\n\n[Error: ${errMsg}]` }, "stop");
+			res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+			res.write("data: [DONE]\n\n");
+		}
+	}
+
+	res.end();
+}
+
+async function handleNonStreamingResponse(res, model, context, opts, modelId) {
+	const eventStream = stream(model, context, opts);
+	let fullText = "";
+	let usage = null;
+
+	for await (const event of eventStream) {
+		if (event.type === "text_delta") {
+			fullText += event.delta;
+		} else if (event.type === "done") {
+			usage = event.message?.usage;
+		} else if (event.type === "error") {
+			const errMsg = event.error?.errorMessage || "Unknown error";
+			if (isRateLimitError(errMsg)) throw new Error(errMsg);
+			throw new Error(errMsg);
+		}
+	}
+
+	const id = `chatcmpl-${Date.now()}`;
+	const response = makeCompletionResponse(id, modelId, fullText, usage);
+	res.writeHead(200, { "Content-Type": "application/json" });
+	res.end(JSON.stringify(response));
+}
+
+function handleModels(req, res) {
+	const models = buildModelList();
+	const unique = new Map();
+	for (const m of models) {
+		if (!unique.has(m.id)) unique.set(m.id, {
+			id: m.id, object: "model", created: 0, owned_by: m.provider,
+		});
+	}
+	res.writeHead(200, { "Content-Type": "application/json" });
+	res.end(JSON.stringify({ object: "list", data: [...unique.values()] }));
+}
+
+function handleHealth(req, res) {
+	const config = loadMultiPassConfig();
+	const authed = SUPPORTED_PROVIDERS.filter((p) => authStorage.hasAuth(p));
+	const extraSubs = config.subscriptions
+		.map((s) => `${s.provider}-${s.index}`)
+		.filter((p) => authStorage.hasAuth(p));
+
+	res.writeHead(200, { "Content-Type": "application/json" });
+	res.end(JSON.stringify({
+		status: "ok",
+		providers: [...authed, ...extraSubs],
+		pools: config.pools.filter((p) => p.enabled).map((p) => p.name),
+		presets: config.presets.filter((p) => p.enabled).map((p) => p.name),
+	}));
+}
+
+// ─── HTTP plumbing ────────────────────────────────────────────────────────────
+
+function readBody(req) {
+	return new Promise((resolve, reject) => {
+		const chunks = [];
+		req.on("data", (chunk) => chunks.push(chunk));
+		req.on("end", () => resolve(Buffer.concat(chunks).toString()));
+		req.on("error", reject);
+	});
+}
+
+function log(...args) {
+	const ts = new Date().toISOString().slice(11, 19);
+	console.log(`[${ts}]`, ...args);
+}
+
+// ─── Server ───────────────────────────────────────────────────────────────────
+
+const server = createServer(async (req, res) => {
+	res.setHeader("Access-Control-Allow-Origin", "*");
+	res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+	res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+	if (req.method === "OPTIONS") { res.writeHead(204); res.end(); return; }
+
+	const path = new URL(req.url, `http://localhost:${PORT}`).pathname;
+
+	try {
+		if (path === "/v1/chat/completions" && req.method === "POST") {
+			await handleChatCompletions(req, res);
+		} else if (path === "/v1/models" && req.method === "GET") {
+			handleModels(req, res);
+		} else if (path === "/health" && req.method === "GET") {
+			handleHealth(req, res);
+		} else {
+			res.writeHead(404, { "Content-Type": "application/json" });
+			res.end(JSON.stringify({ error: { message: "Not found" } }));
+		}
+	} catch (err) {
+		log("Unhandled error:", err?.message || err);
+		if (!res.headersSent) {
+			res.writeHead(500, { "Content-Type": "application/json" });
+			res.end(JSON.stringify({ error: { message: "Internal server error" } }));
+		}
+	}
+});
+
+server.listen(PORT, () => {
+	const config = loadMultiPassConfig();
+	const authed = SUPPORTED_PROVIDERS.filter((p) => authStorage.hasAuth(p));
+	const extras = config.subscriptions.map((s) => `${s.provider}-${s.index}`).filter((p) => authStorage.hasAuth(p));
+	const pools = config.pools.filter((p) => p.enabled);
+
+	console.log(`
+  ╔══════════════════════════════════════════╗
+  ║         LEELOO DALLAS MULTI PASS         ║
+  ╚══════════════════════════════════════════╝
+
+  OpenAI-compatible proxy powered by pi-multi-pass
+
+  Listening:  http://localhost:${PORT}
+  Base URL:   http://localhost:${PORT}/v1
+
+  Providers:  ${[...authed, ...extras].join(", ") || "none (login via pi first)"}
+  Pools:      ${pools.map((p) => `${p.name} (${p.members.length} members)`).join(", ") || "none"}
+  Presets:    ${config.presets.filter((p) => p.enabled).map((p) => p.name).join(", ") || "none"}
+
+  Usage:
+    OPENAI_BASE_URL=http://localhost:${PORT}/v1
+`);
+});

--- a/leeloo.js
+++ b/leeloo.js
@@ -2135,8 +2135,14 @@ const ROUTING_RULE_REGISTRY = {
 	},
 
 	"quota-burn": (params) => async (candidates, ctx) => {
+		const targets = new Set(params.targets || []);
+		const scoreMax = params.maxBoost ?? 100;
 		const scores = {};
-		await Promise.all(candidates.map(async (c) => {
+		// Filter to targeted candidates only when targets is set
+		const eligible = targets.size > 0
+			? candidates.filter((c) => targets.has(c.id) || (c.poolId && targets.has(c.poolId)))
+			: candidates;
+		await Promise.all(eligible.map(async (c) => {
 			try {
 				const detail = await checkQuotaDetailed(c.id);
 				if (detail?.windows?.length) {
@@ -2146,7 +2152,7 @@ const ROUTING_RULE_REGISTRY = {
 					if (earliest !== Infinity) {
 						const hoursUntilReset = (earliest - Date.now()) / (60 * 60 * 1000);
 						// Smaller hoursUntilReset = higher boost (use it before you lose it)
-						scores[c.id] = Math.max(0, 100 - hoursUntilReset);
+						scores[c.id] = Math.max(0, scoreMax - hoursUntilReset);
 					}
 				}
 			} catch {}

--- a/leeloo.js
+++ b/leeloo.js
@@ -390,6 +390,43 @@ function tryGetModel(providerName, modelId) {
 async function resolveCandidates(modelId) {
 	const config = loadConfig();
 
+	// ── 0. Pool-scoped: "pool:<name>/<model>" ──
+	const poolMatch = modelId.match(/^pool:([^/]+)\/(.+)$/);
+	if (poolMatch) {
+		const [, poolName, actualModel] = poolMatch;
+		const pool = config.pools.find((p) => p.name === poolName && p.enabled);
+		if (!pool) return [];
+		const candidates = [];
+		const members = pool.members.filter((m) => isAvailable(m));
+
+		// Apply pool strategy
+		const strategy = pool.strategy || "round-robin";
+		let ordered = members;
+		if (strategy === "scheduled" && pool.memberSchedule) {
+			ordered = getScheduledOrder(pool, members);
+		} else if (strategy === "custom" && pool.selectorScript) {
+			const best = await runCustomSelector(pool, members, "", actualModel);
+			if (best) ordered = [best, ...members.filter((m) => m !== best)];
+		} else if (strategy === "quota-first") {
+			ordered = await sortByQuota(members);
+		}
+
+		for (const member of ordered) {
+			const m = tryGetModel(member, actualModel);
+			if (m) candidates.push({ model: m, provider: member, modelId: actualModel });
+		}
+		return candidates;
+	}
+
+	// ── 0b. Provider-scoped: "provider:<name>/<model>" ──
+	const provMatch = modelId.match(/^provider:([^/]+)\/(.+)$/);
+	if (provMatch) {
+		const [, provName, actualModel] = provMatch;
+		if (!isAvailable(provName)) return [];
+		const m = tryGetModel(provName, actualModel);
+		return m ? [{ model: m, provider: provName, modelId: actualModel }] : [];
+	}
+
 	// ── 1. Preset resolution ──
 	const preset = config.presets.find(
 		(p) => p.enabled && p.name.toLowerCase() === modelId.toLowerCase(),
@@ -975,7 +1012,7 @@ function handleRouting(req, res) {
 		});
 	}
 
-	// Pools -- show models available from each pool's base provider
+	// Pools -- models scoped to pool via "pool:<name>/<model>" ID
 	for (const pool of config.pools) {
 		if (!pool.enabled) continue;
 		try {
@@ -985,15 +1022,15 @@ function handleRouting(req, res) {
 			groups.push({
 				label: `${pool.name} [${pool.strategy || "round-robin"}] (${available.length} members)`,
 				items: models.map((m) => ({
-					id: m.id,
+					id: `pool:${pool.name}/${m.id}`,
 					name: m.id,
-					detail: `${pool.baseProvider} via ${available.join(", ")}`,
+					detail: `via ${available.join(", ")}`,
 				})),
 			});
 		} catch { /* skip */ }
 	}
 
-	// Non-pool providers (authenticated but not in any pool)
+	// Non-pool providers scoped via "provider:<name>/<model>" ID
 	const pooled = new Set(config.pools.flatMap((p) => p.members));
 	const standalone = getAllProviders().filter((p) => !pooled.has(p));
 	for (const prov of standalone) {
@@ -1003,7 +1040,11 @@ function handleRouting(req, res) {
 			const models = getModels(base);
 			groups.push({
 				label: prov,
-				items: models.map((m) => ({ id: m.id, name: m.id, detail: prov })),
+				items: models.map((m) => ({
+					id: `provider:${prov}/${m.id}`,
+					name: m.id,
+					detail: prov,
+				})),
 			});
 		} catch { /* skip */ }
 	}
@@ -1312,13 +1353,15 @@ async function sendMessage() {
   let smdParser = null;
   let mdBody = null;
   const t0 = Date.now();
-  const selectedModel = sel.value;
+  const rawSelection = sel.value;
+  // Clean display: "pool:codex-pool/gpt-5.1" -> "codex-pool / gpt-5.1"
+  const selectedModel = rawSelection.replace(/^pool:([^/]+)\/(.+)$/, "$1 / $2").replace(/^provider:([^/]+)\/(.+)$/, "$1 / $2");
 
   try {
     const resp = await fetch(BASE + "/v1/chat/completions", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ model: selectedModel, messages, stream: true }),
+      body: JSON.stringify({ model: rawSelection, messages, stream: true }),
     });
 
     if (!resp.ok) {

--- a/leeloo.js
+++ b/leeloo.js
@@ -31,7 +31,7 @@
  */
 
 import { createServer } from "node:http";
-import { readFileSync, existsSync } from "node:fs";
+import { readFileSync, existsSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { AuthStorage, getAgentDir } from "@mariozechner/pi-coding-agent";
 import { getModel, getModels, stream } from "@mariozechner/pi-ai";
@@ -50,7 +50,7 @@ const AGENT_DIR = getAgentDir();
 const CONFIG_PATH = join(AGENT_DIR, "multi-pass.json");
 
 function loadConfig() {
-	if (!existsSync(CONFIG_PATH)) return { subscriptions: [], pools: [], chains: [], presets: [] };
+	if (!existsSync(CONFIG_PATH)) return { subscriptions: [], pools: [], chains: [], presets: [], rules: [] };
 	try {
 		const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 		return {
@@ -58,10 +58,17 @@ function loadConfig() {
 			pools: Array.isArray(raw.pools) ? raw.pools : [],
 			chains: Array.isArray(raw.chains) ? raw.chains : [],
 			presets: Array.isArray(raw.presets) ? raw.presets : [],
+			rules: Array.isArray(raw.rules) ? raw.rules : [],
 		};
 	} catch {
-		return { subscriptions: [], pools: [], chains: [], presets: [] };
+		return { subscriptions: [], pools: [], chains: [], presets: [], rules: [] };
 	}
+}
+
+function saveConfig(config) {
+	const dir = join(AGENT_DIR);
+	if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+	writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2), "utf-8");
 }
 
 const authStorage = AuthStorage.create();
@@ -400,6 +407,272 @@ function trackRequest(provider, modelId, usage, durationMs, error) {
 	s.tokens_out += entry.tokens_out;
 	if (error) s.errors++;
 	s.last_used = entry.timestamp;
+}
+
+// ─── Rule engine (DLP / policy enforcement) ─────────────────────────────────
+//
+// Rule types:
+//   block    - reject request/response if pattern matches
+//   redact   - replace pattern matches with placeholder text
+//   warn     - log but allow (audit trail)
+//   model    - restrict allowed models (allow/deny list)
+//   limit    - rate limiting per time window
+//   custom   - run a JS function for custom logic
+//
+// Each rule has: name, enabled, type, scope (request|response|both), patterns, action config
+
+const auditLog = [];
+const AUDIT_LOG_MAX = 1000;
+const rateLimitCounters = {}; // { ruleName: { count, windowStart } }
+
+function auditEvent(rule, action, detail, content) {
+	const entry = {
+		timestamp: new Date().toISOString(),
+		rule: rule.name,
+		type: rule.type,
+		action,
+		detail,
+		snippet: content ? content.slice(0, 200) : null,
+	};
+	auditLog.push(entry);
+	if (auditLog.length > AUDIT_LOG_MAX) auditLog.shift();
+	log(`[rule:${rule.name}] ${action}: ${detail}`);
+}
+
+/**
+ * Extract all text from OpenAI-format messages for pattern matching.
+ */
+function extractText(messages) {
+	const parts = [];
+	for (const m of messages) {
+		if (typeof m.content === "string") parts.push(m.content);
+		else if (Array.isArray(m.content)) {
+			for (const p of m.content) {
+				if (p.type === "text") parts.push(p.text);
+			}
+		}
+		if (m.tool_calls) {
+			for (const tc of m.tool_calls) {
+				parts.push(tc.function?.name || "");
+				parts.push(tc.function?.arguments || "");
+			}
+		}
+	}
+	return parts.join("\n");
+}
+
+/**
+ * Run content rules (block/redact/warn) against text.
+ * Returns { blocked, message, redacted } where redacted is the
+ * potentially modified messages array.
+ */
+function evaluateContentRules(rules, messages, scope) {
+	let text = extractText(messages);
+	let blocked = false;
+	let blockMessage = "";
+	let modified = false;
+
+	for (const rule of rules) {
+		if (!rule.enabled) continue;
+		if (rule.type !== "block" && rule.type !== "redact" && rule.type !== "warn") continue;
+		const ruleScope = rule.scope || "request";
+		if (ruleScope !== "both" && ruleScope !== scope) continue;
+
+		const patterns = (rule.patterns || []).map((p) => {
+			try { return new RegExp(p, "gi"); } catch { return null; }
+		}).filter(Boolean);
+
+		for (const re of patterns) {
+			if (re.test(text)) {
+				if (rule.type === "block") {
+					blocked = true;
+					blockMessage = rule.message || `Blocked by rule: ${rule.name}`;
+					auditEvent(rule, "blocked", blockMessage, text.match(re)?.[0]);
+				} else if (rule.type === "warn") {
+					auditEvent(rule, "warned", `Pattern matched: ${re.source}`, text.match(re)?.[0]);
+				} else if (rule.type === "redact") {
+					const replacement = rule.replacement || "[REDACTED]";
+					// Redact in all message contents
+					messages = messages.map((m) => {
+						if (typeof m.content === "string") {
+							return { ...m, content: m.content.replace(re, replacement) };
+						}
+						if (Array.isArray(m.content)) {
+							return { ...m, content: m.content.map((p) =>
+								p.type === "text" ? { ...p, text: p.text.replace(re, replacement) } : p
+							)};
+						}
+						return m;
+					});
+					modified = true;
+					auditEvent(rule, "redacted", `Pattern replaced: ${re.source}`, replacement);
+				}
+			}
+			re.lastIndex = 0; // reset global regex
+		}
+	}
+
+	return { blocked, message: blockMessage, messages: modified ? messages : messages };
+}
+
+/**
+ * Check model access rules. Returns { allowed, message }.
+ */
+function evaluateModelRules(rules, modelId) {
+	for (const rule of rules) {
+		if (!rule.enabled || rule.type !== "model") continue;
+		const allowList = rule.allow || [];
+		const denyList = rule.deny || [];
+
+		if (denyList.length > 0) {
+			for (const pattern of denyList) {
+				const re = new RegExp("^" + pattern.replace(/\*/g, ".*") + "$", "i");
+				if (re.test(modelId)) {
+					auditEvent(rule, "denied", `Model ${modelId} denied by ${pattern}`);
+					return { allowed: false, message: rule.message || `Model "${modelId}" is not allowed by policy "${rule.name}"` };
+				}
+			}
+		}
+		if (allowList.length > 0) {
+			const matched = allowList.some((pattern) => {
+				const re = new RegExp("^" + pattern.replace(/\*/g, ".*") + "$", "i");
+				return re.test(modelId);
+			});
+			if (!matched) {
+				auditEvent(rule, "denied", `Model ${modelId} not in allow list`);
+				return { allowed: false, message: rule.message || `Model "${modelId}" is not in the allowed list for policy "${rule.name}"` };
+			}
+		}
+	}
+	return { allowed: true };
+}
+
+/**
+ * Check rate limit rules. Returns { allowed, message, retryAfter }.
+ */
+function evaluateRateLimitRules(rules) {
+	const now = Date.now();
+	for (const rule of rules) {
+		if (!rule.enabled || rule.type !== "limit") continue;
+		const windowMs = (rule.windowSeconds || 60) * 1000;
+		const maxRequests = rule.maxRequests || 60;
+
+		if (!rateLimitCounters[rule.name]) {
+			rateLimitCounters[rule.name] = { count: 0, windowStart: now };
+		}
+		const counter = rateLimitCounters[rule.name];
+		if (now - counter.windowStart >= windowMs) {
+			counter.count = 0;
+			counter.windowStart = now;
+		}
+		counter.count++;
+		if (counter.count > maxRequests) {
+			const retryAfter = Math.ceil((counter.windowStart + windowMs - now) / 1000);
+			auditEvent(rule, "rate-limited", `${counter.count}/${maxRequests} in ${rule.windowSeconds || 60}s window`);
+			return { allowed: false, message: rule.message || `Rate limit exceeded: ${maxRequests} requests per ${rule.windowSeconds || 60}s`, retryAfter };
+		}
+	}
+	return { allowed: true };
+}
+
+/**
+ * Redact patterns in response text (for response-scoped rules).
+ */
+function redactResponse(rules, text) {
+	for (const rule of rules) {
+		if (!rule.enabled || rule.type !== "redact") continue;
+		const scope = rule.scope || "request";
+		if (scope !== "response" && scope !== "both") continue;
+		const replacement = rule.replacement || "[REDACTED]";
+		for (const p of (rule.patterns || [])) {
+			try {
+				const re = new RegExp(p, "gi");
+				if (re.test(text)) {
+					auditEvent(rule, "redacted-response", `Pattern replaced: ${re.source}`);
+					re.lastIndex = 0;
+					text = text.replace(re, replacement);
+				}
+			} catch {}
+		}
+	}
+	return text;
+}
+
+/**
+ * Check response text against block rules.
+ */
+function checkResponseBlock(rules, text) {
+	for (const rule of rules) {
+		if (!rule.enabled || rule.type !== "block") continue;
+		const scope = rule.scope || "request";
+		if (scope !== "response" && scope !== "both") continue;
+		for (const p of (rule.patterns || [])) {
+			try {
+				const re = new RegExp(p, "gi");
+				if (re.test(text)) {
+					auditEvent(rule, "blocked-response", `Pattern matched: ${re.source}`, text.match(re)?.[0]);
+					return { blocked: true, message: rule.message || `Response blocked by rule: ${rule.name}` };
+				}
+			} catch {}
+		}
+	}
+	return { blocked: false };
+}
+
+// ─── Rules API handlers ──────────────────────────────────────────────────────
+
+function handleRulesList(req, res) {
+	const config = loadConfig();
+	res.writeHead(200, json());
+	res.end(JSON.stringify({ rules: config.rules || [] }));
+}
+
+async function handleRulesCreate(req, res) {
+	const body = JSON.parse(await readBody(req));
+	const config = loadConfig();
+	const rule = {
+		name: body.name || `rule-${Date.now()}`,
+		enabled: body.enabled !== false,
+		type: body.type || "warn",
+		scope: body.scope || "request",
+		patterns: body.patterns || [],
+		replacement: body.replacement,
+		message: body.message,
+		allow: body.allow,
+		deny: body.deny,
+		maxRequests: body.maxRequests,
+		windowSeconds: body.windowSeconds,
+	};
+	config.rules.push(rule);
+	saveConfig(config);
+	res.writeHead(201, json());
+	res.end(JSON.stringify({ rule }));
+}
+
+async function handleRulesUpdate(req, res, ruleName) {
+	const body = JSON.parse(await readBody(req));
+	const config = loadConfig();
+	const idx = config.rules.findIndex((r) => r.name === ruleName);
+	if (idx < 0) { res.writeHead(404, json()); res.end(JSON.stringify({ error: { message: "Rule not found" } })); return; }
+	config.rules[idx] = { ...config.rules[idx], ...body };
+	saveConfig(config);
+	res.writeHead(200, json());
+	res.end(JSON.stringify({ rule: config.rules[idx] }));
+}
+
+function handleRulesDelete(req, res, ruleName) {
+	const config = loadConfig();
+	config.rules = config.rules.filter((r) => r.name !== ruleName);
+	saveConfig(config);
+	res.writeHead(200, json());
+	res.end(JSON.stringify({ deleted: ruleName }));
+}
+
+function handleAuditLog(req, res) {
+	const url = new URL(req.url, `http://localhost:${PORT}`);
+	const limit = parseInt(url.searchParams.get("limit") || "100", 10);
+	res.writeHead(200, json());
+	res.end(JSON.stringify({ entries: auditLog.slice(-limit).reverse() }));
 }
 
 /** Sort providers by quota (best first). Providers with unknown quota go last. */
@@ -967,6 +1240,18 @@ async function handleNonStreaming(res, model, context, opts, requestModelId, act
 		}
 	}
 
+	// ── Response-side rule evaluation ──
+	const respRules = loadConfig().rules || [];
+	if (respRules.length > 0 && fullText) {
+		const respBlock = checkResponseBlock(respRules, fullText);
+		if (respBlock.blocked) {
+			res.writeHead(403, json());
+			res.end(JSON.stringify({ error: { message: respBlock.message } }));
+			return;
+		}
+		fullText = redactResponse(respRules, fullText);
+	}
+
 	const message = { role: "assistant" };
 	if (toolCalls.length > 0) {
 		message.content = fullText || null;
@@ -1016,6 +1301,33 @@ async function handleChatCompletions(req, res) {
 		res.writeHead(400, json());
 		res.end(JSON.stringify({ error: { message: "model and messages are required" } }));
 		return;
+	}
+
+	// ── Rule evaluation: pre-flight ──
+	const rules = loadConfig().rules || [];
+	if (rules.length > 0) {
+		// Rate limits
+		const rateCheck = evaluateRateLimitRules(rules);
+		if (!rateCheck.allowed) {
+			res.writeHead(429, { ...json(), ...(rateCheck.retryAfter ? { "Retry-After": String(rateCheck.retryAfter) } : {}) });
+			res.end(JSON.stringify({ error: { message: rateCheck.message } }));
+			return;
+		}
+		// Model access
+		const modelCheck = evaluateModelRules(rules, requestModelId);
+		if (!modelCheck.allowed) {
+			res.writeHead(403, json());
+			res.end(JSON.stringify({ error: { message: modelCheck.message } }));
+			return;
+		}
+		// Content: block/redact/warn on request
+		const contentCheck = evaluateContentRules(rules, parsed.messages, "request");
+		if (contentCheck.blocked) {
+			res.writeHead(403, json());
+			res.end(JSON.stringify({ error: { message: contentCheck.message } }));
+			return;
+		}
+		parsed.messages = contentCheck.messages; // may be redacted
 	}
 
 	const candidates = await resolveCandidates(requestModelId);
@@ -1288,6 +1600,248 @@ function json() { return { "Content-Type": "application/json" }; }
 function log(...a) { console.log(`[${new Date().toISOString().slice(11, 19)}]`, ...a); }
 
 // ─── Chat UI ──────────────────────────────────────────────────────────────────
+
+function handleAdmin(req, res) {
+	res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+	res.end(ADMIN_UI_HTML);
+}
+
+const ADMIN_UI_HTML = `<!DOCTYPE html>
+<html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Leeloo Admin</title>
+<style>
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:#0a0a0a;color:#e0e0e0;height:100vh;display:flex;flex-direction:column}
+header{background:#111;border-bottom:1px solid #222;padding:12px 20px;display:flex;align-items:center;gap:16px}
+header h1{font-size:15px;color:#f90;font-weight:700}
+header a{color:#666;text-decoration:none;font-size:12px;padding:4px 10px;border:1px solid #333;border-radius:5px}
+header a:hover{color:#aaa;border-color:#666}
+.tabs{display:flex;gap:0;border-bottom:1px solid #222;background:#111}
+.tab{padding:10px 20px;font-size:13px;color:#888;cursor:pointer;border-bottom:2px solid transparent}
+.tab:hover{color:#ccc}
+.tab.active{color:#f90;border-color:#f90}
+.panel{flex:1;overflow-y:auto;padding:20px;display:none}
+.panel.active{display:block}
+h2{font-size:14px;color:#999;margin:0 0 12px;text-transform:uppercase;letter-spacing:1px}
+.card{background:#111;border:1px solid #222;border-radius:8px;padding:14px;margin-bottom:10px}
+.card .name{font-weight:600;color:#eee;font-size:14px}
+.card .meta{font-size:11px;color:#666;margin-top:4px}
+.card .badge{display:inline-block;padding:1px 6px;border-radius:3px;font-size:10px;font-weight:600}
+.badge.on{background:#1a3a1a;color:#4a4;border:1px solid #2a4a2a}
+.badge.off{background:#3a1a1a;color:#a44;border:1px solid #4a2a2a}
+.badge.block{background:#3a1a1a;color:#f66}
+.badge.redact{background:#3a2a1a;color:#fa0}
+.badge.warn{background:#1a2a3a;color:#6af}
+.badge.model{background:#2a1a3a;color:#a6f}
+.badge.limit{background:#1a1a2a;color:#66f}
+table{width:100%;border-collapse:collapse;font-size:13px}
+th,td{text-align:left;padding:6px 10px;border-bottom:1px solid #1a1a1a}
+th{color:#888;font-weight:600;font-size:11px;text-transform:uppercase}
+td{color:#ccc}
+.bar{display:inline-block;width:50px;height:8px;background:#222;border-radius:4px;overflow:hidden;vertical-align:middle}
+.bar-fill{height:100%;border-radius:4px}
+.btn{background:#1a1a1a;color:#ccc;border:1px solid #333;border-radius:5px;padding:5px 12px;font-size:12px;cursor:pointer}
+.btn:hover{border-color:#666;color:#fff}
+.btn.danger{border-color:#4a2a2a;color:#f66}
+.btn.danger:hover{background:#3a1a1a}
+.btn.primary{background:#f90;color:#000;border-color:#f90;font-weight:600}
+.form{display:flex;flex-direction:column;gap:8px;max-width:500px}
+.form label{font-size:12px;color:#888}
+.form input,.form select,.form textarea{background:#1a1a1a;color:#eee;border:1px solid #333;border-radius:5px;padding:6px 10px;font-size:13px;font-family:inherit}
+.form input:focus,.form select:focus,.form textarea:focus{border-color:#f90;outline:none}
+.stat-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:10px;margin-bottom:20px}
+.stat-card{background:#111;border:1px solid #222;border-radius:8px;padding:14px;text-align:center}
+.stat-card .num{font-size:24px;font-weight:700;color:#f90}
+.stat-card .label{font-size:11px;color:#666;margin-top:4px}
+.empty{color:#555;font-style:italic;padding:20px;text-align:center}
+</style>
+</head><body>
+<header>
+  <h1>Leeloo Admin</h1>
+  <a href="/ui">Chat UI</a>
+  <a href="/health">Health API</a>
+</header>
+<div class="tabs">
+  <div class="tab active" onclick="showTab('dashboard')">Dashboard</div>
+  <div class="tab" onclick="showTab('rules')">Rules</div>
+  <div class="tab" onclick="showTab('audit')">Audit Log</div>
+  <div class="tab" onclick="showTab('config')">Config</div>
+</div>
+
+<div id="dashboard" class="panel active"></div>
+<div id="rules" class="panel"></div>
+<div id="audit" class="panel"></div>
+<div id="config" class="panel"></div>
+
+<script>
+const BASE = location.origin;
+function esc(s){return String(s).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;")}
+function showTab(id){document.querySelectorAll(".tab").forEach((t,i)=>{t.classList.toggle("active",t.textContent.toLowerCase().replace(" ","")===id)});document.querySelectorAll(".panel").forEach(p=>{p.classList.toggle("active",p.id===id)});loaders[id]?.()}
+function qc(pct){return pct==null?"#555":pct>50?"#4a4":pct>20?"#ca0":"#e44"}
+function bar(pct){if(pct==null)return"--";return'<span class="bar"><span class="bar-fill" style="width:'+pct+"%;background:"+qc(pct)+'"></span></span> '+pct+"%"}
+function ago(ts){if(!ts)return"--";const d=Date.now()-new Date(ts).getTime();if(d<60000)return Math.round(d/1000)+"s ago";if(d<3600000)return Math.round(d/60000)+"m ago";return Math.round(d/3600000)+"h ago"}
+
+const loaders = {
+  async dashboard() {
+    const [stats,quota,health] = await Promise.all([
+      fetch(BASE+"/v1/stats").then(r=>r.json()),
+      fetch(BASE+"/v1/quota").then(r=>r.json()),
+      fetch(BASE+"/health").then(r=>r.json()),
+    ]);
+    const s = stats.session||{};
+    let h = '<h2>Session Overview</h2><div class="stat-grid">';
+    h += '<div class="stat-card"><div class="num">'+s.total_requests+'</div><div class="label">Requests</div></div>';
+    h += '<div class="stat-card"><div class="num">'+s.total_tokens_in+'</div><div class="label">Tokens In</div></div>';
+    h += '<div class="stat-card"><div class="num">'+s.total_tokens_out+'</div><div class="label">Tokens Out</div></div>';
+    h += '<div class="stat-card"><div class="num">'+s.total_errors+'</div><div class="label">Errors</div></div>';
+    h += '</div>';
+
+    h += '<h2>Provider Health</h2><table><tr><th>Provider</th><th>Quota</th><th>Status</th><th>Requests</th><th>Tokens</th><th>Last Used</th></tr>';
+    for(const p of quota.providers||[]){
+      const ps = (stats.providers||[]).find(x=>x.provider===p.provider)||{};
+      const exh = (health.exhausted||[]).includes(p.provider);
+      h+='<tr><td>'+esc(p.label||p.provider)+'</td><td>'+bar(p.score)+'</td>';
+      h+='<td>'+(exh?'<span class="badge off">exhausted</span>':'<span class="badge on">'+esc(p.status)+'</span>')+'</td>';
+      h+='<td>'+(ps.requests||0)+'</td><td>'+(ps.tokens_in||0)+' / '+(ps.tokens_out||0)+'</td>';
+      h+='<td>'+ago(ps.last_used)+'</td></tr>';
+    }
+    h+='</table>';
+
+    h+='<h2>Recent Requests</h2><table><tr><th>Time</th><th>Provider</th><th>Model</th><th>Tokens</th><th>Duration</th><th>Error</th></tr>';
+    for(const r of (stats.recent||[]).slice(0,20)){
+      h+='<tr><td>'+ago(r.timestamp)+'</td><td>'+esc(r.provider)+'</td><td>'+esc(r.model)+'</td>';
+      h+='<td>'+r.tokens_in+' / '+r.tokens_out+'</td><td>'+r.duration_ms+'ms</td>';
+      h+='<td>'+(r.error?'<span class="badge off">'+esc(r.error).slice(0,40)+'</span>':'--')+'</td></tr>';
+    }
+    h+='</table>';
+    document.getElementById("dashboard").innerHTML = h;
+  },
+
+  async rules() {
+    const data = await fetch(BASE+"/v1/rules").then(r=>r.json());
+    let h = '<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:16px"><h2 style="margin:0">Policy Rules</h2><button class="btn primary" onclick="showRuleForm()">+ Add Rule</button></div>';
+    h += '<div id="rule-form-area"></div>';
+    if(!data.rules||data.rules.length===0){h+='<div class="empty">No rules configured. Add rules to enforce DLP policies, model restrictions, or rate limits.</div>';}
+    else{for(const r of data.rules){
+      h+='<div class="card"><div style="display:flex;justify-content:space-between;align-items:center"><div>';
+      h+='<span class="name">'+esc(r.name)+'</span> ';
+      h+='<span class="badge '+esc(r.type)+'">'+esc(r.type)+'</span> ';
+      h+='<span class="badge '+(r.enabled?"on":"off")+'">'+(r.enabled?"enabled":"disabled")+'</span>';
+      h+='</div><div>';
+      h+='<button class="btn" onclick="toggleRule(\''+esc(r.name)+'\','+(!r.enabled)+')">'+(r.enabled?"Disable":"Enable")+'</button> ';
+      h+='<button class="btn danger" onclick="deleteRule(\''+esc(r.name)+'\')">Delete</button>';
+      h+='</div></div>';
+      h+='<div class="meta">';
+      if(r.scope)h+='scope: '+esc(r.scope)+' | ';
+      if(r.patterns?.length)h+='patterns: '+r.patterns.map(p=>esc(p)).join(", ")+' | ';
+      if(r.allow?.length)h+='allow: '+r.allow.join(", ")+' | ';
+      if(r.deny?.length)h+='deny: '+r.deny.join(", ")+' | ';
+      if(r.maxRequests)h+=r.maxRequests+' req/'+r.windowSeconds+'s | ';
+      if(r.replacement)h+='replacement: '+esc(r.replacement)+' | ';
+      if(r.message)h+='message: '+esc(r.message);
+      h+='</div></div>';
+    }}
+    document.getElementById("rules").innerHTML = h;
+  },
+
+  async audit() {
+    const data = await fetch(BASE+"/v1/audit").then(r=>r.json());
+    let h = '<h2>Audit Log</h2>';
+    if(!data.entries?.length){h+='<div class="empty">No audit events yet. Events appear when rules match requests or responses.</div>';}
+    else{h+='<table><tr><th>Time</th><th>Rule</th><th>Type</th><th>Action</th><th>Detail</th><th>Snippet</th></tr>';
+    for(const e of data.entries){
+      h+='<tr><td>'+ago(e.timestamp)+'</td><td>'+esc(e.rule)+'</td>';
+      h+='<td><span class="badge '+esc(e.type)+'">'+esc(e.type)+'</span></td>';
+      h+='<td>'+esc(e.action)+'</td><td>'+esc(e.detail)+'</td>';
+      h+='<td>'+(e.snippet?esc(e.snippet):'--')+'</td></tr>';
+    }h+='</table>';}
+    document.getElementById("audit").innerHTML = h;
+  },
+
+  async config() {
+    const [health,routing] = await Promise.all([
+      fetch(BASE+"/health").then(r=>r.json()),
+      fetch(BASE+"/v1/routing").then(r=>r.json()),
+    ]);
+    let h = '<h2>Active Configuration</h2>';
+    h+='<h2 style="font-size:12px;margin-top:16px">Pools</h2>';
+    for(const p of health.pools||[]){
+      h+='<div class="card"><span class="name">'+esc(p.name)+'</span> <span class="badge on">'+esc(p.strategy)+'</span>';
+      h+='<div class="meta">Members: '+p.members.map(m=>esc(m)).join(", ")+'</div></div>';
+    }
+    h+='<h2 style="font-size:12px;margin-top:16px">Chains</h2>';
+    if(!health.chains?.length)h+='<div class="empty">No chains</div>';
+    else for(const c of health.chains){h+='<div class="card"><span class="name">'+esc(c)+'</span></div>';}
+    h+='<h2 style="font-size:12px;margin-top:16px">Presets</h2>';
+    for(const p of health.presets||[]){
+      h+='<div class="card"><span class="name">'+esc(p.name)+'</span>';
+      h+='<div class="meta">'+p.entries.map(e=>esc(e)).join(" -> ")+'</div></div>';
+    }
+    h+='<h2 style="font-size:12px;margin-top:16px">Providers</h2>';
+    for(const p of health.providers||[]){
+      const exh=(health.exhausted||[]).includes(p);
+      h+='<div class="card"><span class="name">'+esc(p)+'</span> <span class="badge '+(exh?"off":"on")+'">'+(exh?"exhausted":"ok")+'</span></div>';
+    }
+    document.getElementById("config").innerHTML = h;
+  }
+};
+
+async function toggleRule(name,enabled){
+  await fetch(BASE+"/v1/rules/"+encodeURIComponent(name),{method:"PUT",headers:{"Content-Type":"application/json"},body:JSON.stringify({enabled})});
+  loaders.rules();
+}
+async function deleteRule(name){
+  if(!confirm("Delete rule "+name+"?"))return;
+  await fetch(BASE+"/v1/rules/"+encodeURIComponent(name),{method:"DELETE"});
+  loaders.rules();
+}
+function showRuleForm(){
+  const area=document.getElementById("rule-form-area");
+  if(area.innerHTML){area.innerHTML="";return;}
+  area.innerHTML='<div class="card"><div class="form">'
+    +'<label>Name</label><input id="rf-name" placeholder="e.g. block-secrets">'
+    +'<label>Type</label><select id="rf-type"><option value="block">block</option><option value="redact">redact</option><option value="warn">warn</option><option value="model">model (allow/deny)</option><option value="limit">rate limit</option></select>'
+    +'<label>Scope</label><select id="rf-scope"><option value="request">request</option><option value="response">response</option><option value="both">both</option></select>'
+    +'<label>Patterns (one per line, regex)</label><textarea id="rf-patterns" rows="3" placeholder="AKIA[0-9A-Z]{16}\\nsk-[a-zA-Z0-9]{48}"></textarea>'
+    +'<label>Replacement (for redact)</label><input id="rf-replacement" placeholder="[REDACTED]">'
+    +'<label>Message (shown when blocked)</label><input id="rf-message" placeholder="Request blocked: contains secrets">'
+    +'<label>Model allow list (comma-separated, for model type)</label><input id="rf-allow" placeholder="claude-*, gpt-5*">'
+    +'<label>Model deny list</label><input id="rf-deny" placeholder="gpt-4o*">'
+    +'<label>Max requests (for limit type)</label><input id="rf-max" type="number" placeholder="60">'
+    +'<label>Window seconds</label><input id="rf-window" type="number" placeholder="60">'
+    +'<div style="display:flex;gap:8px;margin-top:8px"><button class="btn primary" onclick="createRule()">Create Rule</button><button class="btn" onclick="document.getElementById(\'rule-form-area\').innerHTML=\'\'">Cancel</button></div>'
+    +'</div></div>';
+}
+async function createRule(){
+  const type=document.getElementById("rf-type").value;
+  const rule={
+    name:document.getElementById("rf-name").value||"rule-"+Date.now(),
+    type,
+    enabled:true,
+    scope:document.getElementById("rf-scope").value,
+    patterns:document.getElementById("rf-patterns").value.split("\\n").filter(Boolean),
+    replacement:document.getElementById("rf-replacement").value||undefined,
+    message:document.getElementById("rf-message").value||undefined,
+  };
+  if(type==="model"){
+    const allow=document.getElementById("rf-allow").value;
+    const deny=document.getElementById("rf-deny").value;
+    if(allow)rule.allow=allow.split(",").map(s=>s.trim()).filter(Boolean);
+    if(deny)rule.deny=deny.split(",").map(s=>s.trim()).filter(Boolean);
+  }
+  if(type==="limit"){
+    rule.maxRequests=parseInt(document.getElementById("rf-max").value)||60;
+    rule.windowSeconds=parseInt(document.getElementById("rf-window").value)||60;
+  }
+  await fetch(BASE+"/v1/rules",{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify(rule)});
+  document.getElementById("rule-form-area").innerHTML="";
+  loaders.rules();
+}
+
+loaders.dashboard();
+</script>
+</body></html>`;
 
 function handleUI(req, res) {
 	res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
@@ -1664,7 +2218,13 @@ const server = createServer(async (req, res) => {
 		else if (path === "/v1/routing" && req.method === "GET") handleRouting(req, res);
 		else if (path === "/v1/quota" && req.method === "GET") await handleQuota(req, res);
 		else if (path === "/v1/stats" && req.method === "GET") handleStats(req, res);
+		else if (path === "/v1/rules" && req.method === "GET") handleRulesList(req, res);
+		else if (path === "/v1/rules" && req.method === "POST") await handleRulesCreate(req, res);
+		else if (path.startsWith("/v1/rules/") && req.method === "PUT") await handleRulesUpdate(req, res, decodeURIComponent(path.split("/v1/rules/")[1]));
+		else if (path.startsWith("/v1/rules/") && req.method === "DELETE") handleRulesDelete(req, res, decodeURIComponent(path.split("/v1/rules/")[1]));
+		else if (path === "/v1/audit" && req.method === "GET") handleAuditLog(req, res);
 		else if (path === "/health" && req.method === "GET") handleHealth(req, res);
+		else if (path === "/admin") handleAdmin(req, res);
 		else if (path === "/ui" || path === "/") handleUI(req, res);
 		else { res.writeHead(404, json()); res.end(JSON.stringify({ error: { message: "Not found" } })); }
 	} catch (err) {
@@ -1697,7 +2257,10 @@ server.listen(PORT, () => {
   GET  /v1/models             (all models + preset names)
   GET  /v1/quota              (detailed quota per provider)
   GET  /v1/stats              (usage stats + request log)
+  GET  /v1/rules              (policy rules CRUD)
+  GET  /v1/audit              (rule violation audit log)
   GET  /health
+  GET  /admin                 Admin dashboard + rule editor
   GET  /ui                    Chat UI
 
   OPENAI_BASE_URL=http://localhost:${PORT}/v1

--- a/leeloo.js
+++ b/leeloo.js
@@ -954,14 +954,64 @@ const pendingLogins = new Map(); // provider -> { resolve, reject, authUrl, stat
 
 function handleAuthProviders(req, res) {
 	const provs = authStorage.getOAuthProviders();
-	const authed = getAllProviders();
-	const result = provs.map((p) => ({
-		id: p.id,
-		name: p.name,
-		authenticated: authed.includes(p.id) && authStorage.hasAuth(p.id),
-	}));
+	const config = loadConfig();
+	const result = [];
+
+	// Built-in providers
+	for (const p of provs) {
+		result.push({
+			id: p.id,
+			name: p.name,
+			baseProvider: p.id,
+			authenticated: authStorage.hasAuth(p.id),
+			isBuiltin: true,
+		});
+	}
+
+	// Extra subscription accounts
+	for (const sub of config.subscriptions) {
+		const subId = `${sub.provider}-${sub.index || sub.name}`;
+		if (result.some((r) => r.id === subId)) continue;
+		const baseProv = provs.find((p) => p.id === sub.provider);
+		result.push({
+			id: subId,
+			name: `${baseProv?.name || sub.provider} #${sub.index || sub.name}`,
+			baseProvider: sub.provider,
+			authenticated: authStorage.hasAuth(subId),
+			isBuiltin: false,
+			subscription: sub.name,
+		});
+	}
+
 	res.writeHead(200, json());
 	res.end(JSON.stringify({ providers: result }));
+}
+
+/** Returns all known provider/subscription names for use in dropdowns. */
+function handleKnownNames(req, res) {
+	const config = loadConfig();
+	const provs = authStorage.getOAuthProviders();
+
+	// All provider IDs that exist (authenticated or not)
+	const allNames = [];
+	for (const p of provs) {
+		allNames.push({ id: p.id, label: p.name, type: "provider", authenticated: authStorage.hasAuth(p.id) });
+	}
+	for (const sub of config.subscriptions) {
+		const subId = `${sub.provider}-${sub.index || sub.name}`;
+		if (allNames.some((n) => n.id === subId)) continue;
+		const baseProv = provs.find((p) => p.id === sub.provider);
+		allNames.push({ id: subId, label: `${baseProv?.name || sub.provider} #${sub.index || sub.name}`, type: "subscription", authenticated: authStorage.hasAuth(subId) });
+	}
+
+	// Pool names
+	const poolNames = config.pools.filter((p) => p.enabled).map((p) => ({ id: `pool:${p.name}`, label: p.name, type: "pool" }));
+
+	// Chain names
+	const chainNames = config.chains.filter((c) => c.enabled).map((c) => ({ id: `chain:${c.name}`, label: c.name, type: "chain" }));
+
+	res.writeHead(200, json());
+	res.end(JSON.stringify({ providers: allNames, pools: poolNames, chains: chainNames }));
 }
 
 function handleAuthStatus(req, res) {
@@ -2069,6 +2119,7 @@ const server = createServer(async (req, res) => {
 		else if (path === "/v1/audit" && req.method === "GET") handleAuditLog(req, res);
 		else if (path === "/v1/auth/providers" && req.method === "GET") handleAuthProviders(req, res);
 		else if (path === "/v1/auth/status" && req.method === "GET") handleAuthStatus(req, res);
+		else if (path === "/v1/auth/names" && req.method === "GET") handleKnownNames(req, res);
 		else if (path.startsWith("/v1/auth/login/") && req.method === "POST") await handleAuthLogin(req, res, decodeURIComponent(path.split("/v1/auth/login/")[1]));
 		else if (path.startsWith("/v1/auth/login/") && req.method === "GET") handleAuthLoginStatus(req, res, decodeURIComponent(path.split("/v1/auth/login/")[1]));
 		else if (path.startsWith("/v1/auth/logout/") && req.method === "POST") await handleAuthLogout(req, res, decodeURIComponent(path.split("/v1/auth/logout/")[1]));

--- a/leeloo.js
+++ b/leeloo.js
@@ -229,16 +229,20 @@ function decodeJwtPayload(token) {
 }
 
 /** Check Codex (ChatGPT) quota. Returns 0-100 remaining percentage or null. */
-async function checkCodexQuota(provider) {
+// ── Detailed quota result format ──
+// { score: 0-100, status: "ready"|"low"|"blocked"|"unknown",
+//   windows: [...], models: [...], plan?: string, email?: string }
+
+async function checkCodexQuotaDetailed(provider) {
 	const cred = authStorage.get(provider);
-	if (!cred || cred.type !== "oauth" || !cred.access) return null;
+	if (!cred || cred.type !== "oauth" || !cred.access) return { score: null, status: "no-auth" };
 
 	const apiKey = await authStorage.getApiKey(provider);
-	if (!apiKey) return null;
+	if (!apiKey) return { score: null, status: "no-auth" };
 
-	// Extract account ID from JWT or stored credential
 	const payload = decodeJwtPayload(apiKey);
 	const authClaim = payload["https://api.openai.com/auth"];
+	const profileClaim = payload["https://api.openai.com/profile"];
 	const accountId = cred.accountId || authClaim?.chatgpt_account_id;
 
 	const headers = { Authorization: `Bearer ${apiKey}`, Accept: "application/json" };
@@ -246,20 +250,41 @@ async function checkCodexQuota(provider) {
 
 	try {
 		const resp = await fetch(`${CODEX_USAGE_URL.replace(/\/+$/, "")}/wham/usage`, { headers });
-		if (!resp.ok) return null;
+		if (!resp.ok) return { score: null, status: "error", error: `HTTP ${resp.status}` };
 		const data = await resp.json();
 		const rl = data?.rate_limit;
-		const windows = [rl?.primary_window, rl?.secondary_window]
-			.filter(Boolean)
-			.map((w) => Math.max(0, 100 - (w.used_percent || 0)));
-		return windows.length > 0 ? Math.min(...windows) : null;
-	} catch { return null; }
+
+		const parseWindow = (w, name) => {
+			if (!w) return null;
+			const used = w.used_percent || 0;
+			const remaining = Math.max(0, 100 - used);
+			const windowSec = w.limit_window_seconds || 0;
+			const resetAt = w.reset_at ? new Date(w.reset_at * 1000).toISOString() : null;
+			return { name, used: Math.round(used), remaining: Math.round(remaining), windowSeconds: windowSec, resetAt };
+		};
+
+		const windows = [
+			parseWindow(rl?.primary_window, "5-hour"),
+			parseWindow(rl?.secondary_window, "7-day"),
+		].filter(Boolean);
+
+		const scores = windows.map((w) => w.remaining);
+		const score = scores.length > 0 ? Math.min(...scores) : null;
+		const status = score === null ? "unknown" : score > 30 ? "ready" : score > 5 ? "low" : "blocked";
+
+		return {
+			score,
+			status,
+			plan: data?.plan_type || authClaim?.chatgpt_plan_type || "unknown",
+			email: profileClaim?.email || data?.email || null,
+			windows,
+		};
+	} catch (e) { return { score: null, status: "error", error: e.message }; }
 }
 
-/** Check Google Gemini CLI quota. Returns 0-100 remaining percentage or null. */
-async function checkGeminiQuota(provider) {
+async function checkGeminiQuotaDetailed(provider) {
 	const apiKey = await authStorage.getApiKey(provider);
-	if (!apiKey) return null;
+	if (!apiKey) return { score: null, status: "no-auth" };
 
 	let token;
 	try { const p = JSON.parse(apiKey); token = p.token; } catch { token = apiKey; }
@@ -275,20 +300,25 @@ async function checkGeminiQuota(provider) {
 			},
 			body: "{}",
 		});
-		if (!resp.ok) return null;
+		if (!resp.ok) return { score: null, status: "error", error: `HTTP ${resp.status}` };
 		const data = await resp.json();
-		const fractions = (data?.buckets || [])
-			.map((b) => b?.remainingFraction)
-			.filter((f) => typeof f === "number")
-			.map((f) => Math.round(f * 100));
-		return fractions.length > 0 ? Math.min(...fractions) : null;
-	} catch { return null; }
+		const models = (data?.buckets || []).map((b) => {
+			const id = b?.modelId || "unknown";
+			const remaining = typeof b?.remainingFraction === "number" ? Math.round(b.remainingFraction * 100) : null;
+			const resetAt = b?.resetTime || null;
+			return { model: id, remaining, resetAt };
+		}).filter((m) => m.remaining !== null);
+
+		const scores = models.map((m) => m.remaining);
+		const score = scores.length > 0 ? Math.min(...scores) : null;
+		const status = score === null ? "unknown" : score > 30 ? "ready" : score > 5 ? "low" : "blocked";
+		return { score, status, models };
+	} catch (e) { return { score: null, status: "error", error: e.message }; }
 }
 
-/** Check Google Antigravity quota. Returns 0-100 remaining percentage or null. */
-async function checkAntigravityQuota(provider) {
+async function checkAntigravityQuotaDetailed(provider) {
 	const apiKey = await authStorage.getApiKey(provider);
-	if (!apiKey) return null;
+	if (!apiKey) return { score: null, status: "no-auth" };
 
 	let token;
 	try { const p = JSON.parse(apiKey); token = p.token; } catch { token = apiKey; }
@@ -307,27 +337,69 @@ async function checkAntigravityQuota(provider) {
 			});
 			if (!resp.ok) continue;
 			const data = await resp.json();
-			const models = data?.models ? Object.values(data.models) : [];
-			const fractions = models
-				.filter((m) => !m.isInternal)
-				.map((m) => m?.quotaInfo?.remainingFraction)
-				.filter((f) => typeof f === "number")
-				.map((f) => Math.round(f * 100));
-			return fractions.length > 0 ? Math.min(...fractions) : null;
+			const entries = data?.models ? Object.entries(data.models) : [];
+			const models = entries
+				.filter(([, v]) => !v.isInternal)
+				.map(([k, v]) => ({
+					model: v.displayName || v.model || k,
+					remaining: typeof v?.quotaInfo?.remainingFraction === "number" ? Math.round(v.quotaInfo.remainingFraction * 100) : null,
+					resetAt: v?.quotaInfo?.resetTime || null,
+				}))
+				.filter((m) => m.remaining !== null);
+
+			const scores = models.map((m) => m.remaining);
+			const score = scores.length > 0 ? Math.min(...scores) : null;
+			const status = score === null ? "unknown" : score > 30 ? "ready" : score > 5 ? "low" : "blocked";
+			return { score, status, models };
 		} catch { continue; }
 	}
-	return null;
+	return { score: null, status: "error", error: "all endpoints failed" };
 }
 
-/** Get remaining quota score (0-100) for a provider. null = unknown. */
-async function checkQuota(provider) {
+async function checkQuotaDetailed(provider) {
 	const base = getBaseProvider(provider);
 	switch (base) {
-		case "openai-codex": return checkCodexQuota(provider);
-		case "google-gemini-cli": return checkGeminiQuota(provider);
-		case "google-antigravity": return checkAntigravityQuota(provider);
-		default: return null;
+		case "openai-codex": return checkCodexQuotaDetailed(provider);
+		case "google-gemini-cli": return checkGeminiQuotaDetailed(provider);
+		case "google-antigravity": return checkAntigravityQuotaDetailed(provider);
+		default: return { score: null, status: "unsupported" };
 	}
+}
+
+/** Simple score-only wrapper (used by sortByQuota). */
+async function checkQuota(provider) {
+	const detail = await checkQuotaDetailed(provider);
+	return detail.score;
+}
+
+// ─── Request usage tracking ──────────────────────────────────────────────────
+
+const usageLog = [];       // Recent requests (ring buffer)
+const USAGE_LOG_MAX = 500;
+const providerStats = {};  // { provider: { requests, tokens_in, tokens_out, errors, last_used } }
+
+function trackRequest(provider, modelId, usage, durationMs, error) {
+	const entry = {
+		timestamp: new Date().toISOString(),
+		provider,
+		model: modelId,
+		tokens_in: usage?.input || 0,
+		tokens_out: usage?.output || 0,
+		duration_ms: durationMs,
+		error: error || null,
+	};
+	usageLog.push(entry);
+	if (usageLog.length > USAGE_LOG_MAX) usageLog.shift();
+
+	if (!providerStats[provider]) {
+		providerStats[provider] = { requests: 0, tokens_in: 0, tokens_out: 0, errors: 0, last_used: null };
+	}
+	const s = providerStats[provider];
+	s.requests++;
+	s.tokens_in += entry.tokens_in;
+	s.tokens_out += entry.tokens_out;
+	if (error) s.errors++;
+	s.last_used = entry.timestamp;
 }
 
 /** Sort providers by quota (best first). Providers with unknown quota go last. */
@@ -722,6 +794,7 @@ function formatUsage(u) {
 // ─── Streaming handler ────────────────────────────────────────────────────────
 
 async function handleStreaming(res, model, context, opts, requestModelId, actualProvider) {
+	const t0 = Date.now();
 	res.writeHead(200, {
 		"Content-Type": "text/event-stream",
 		"Cache-Control": "no-cache",
@@ -813,6 +886,7 @@ async function handleStreaming(res, model, context, opts, requestModelId, actual
 			case "done": {
 				const finish = toolCalls.size > 0 ? "tool_calls" : mapFinishReason(event.reason);
 				const usage = formatUsage(event.message?.usage);
+				trackRequest(actualProvider, model.id, event.message?.usage, Date.now() - t0, null);
 				const finalChunk = chunk(id, requestModelId, {}, finish, usage);
 				finalChunk.x_provider = actualProvider;
 				finalChunk.x_model = model.id;
@@ -824,8 +898,8 @@ async function handleStreaming(res, model, context, opts, requestModelId, actual
 
 			case "error": {
 				const errMsg = event.error?.errorMessage || "Unknown error";
+				trackRequest(actualProvider, model.id, null, Date.now() - t0, errMsg);
 				if (isRateLimit(errMsg)) throw new Error(errMsg);
-				// Send error as final text delta + stop
 				if (!sentRole) {
 					write(chunk(id, requestModelId, { role: "assistant", content: `[Error: ${errMsg}]` }, null));
 				} else {
@@ -844,6 +918,7 @@ async function handleStreaming(res, model, context, opts, requestModelId, actual
 // ─── Non-streaming handler ────────────────────────────────────────────────────
 
 async function handleNonStreaming(res, model, context, opts, requestModelId, actualProvider) {
+	const t0 = Date.now();
 	const eventStream = stream(model, context, opts);
 	let fullText = "";
 	const toolCalls = [];
@@ -868,9 +943,11 @@ async function handleNonStreaming(res, model, context, opts, requestModelId, act
 			case "done":
 				usage = event.message?.usage;
 				finishReason = event.reason;
+				trackRequest(actualProvider, model.id, usage, Date.now() - t0, null);
 				break;
 			case "error": {
 				const errMsg = event.error?.errorMessage || "Unknown error";
+				trackRequest(actualProvider, model.id, null, Date.now() - t0, errMsg);
 				if (isRateLimit(errMsg)) throw new Error(errMsg);
 				throw new Error(errMsg);
 			}
@@ -1110,15 +1187,56 @@ function handleRouting(req, res) {
 	res.end(JSON.stringify({ groups }));
 }
 
-/** Returns live quota scores for all providers that support it. */
+/** Detailed quota for all providers: windows, models, reset times. */
 async function handleQuota(req, res) {
 	const providers = getAllProviders();
 	const results = await Promise.all(providers.map(async (prov) => {
-		const score = await checkQuota(prov);
-		return { provider: prov, quota: score, exhausted: isExhausted(prov) };
+		const detail = await checkQuotaDetailed(prov);
+		return {
+			provider: prov,
+			label: getProviderLabel(prov),
+			baseProvider: getBaseProvider(prov),
+			exhausted: isExhausted(prov),
+			...detail,
+		};
 	}));
 	res.writeHead(200, json());
-	res.end(JSON.stringify({ providers: results }));
+	res.end(JSON.stringify({
+		timestamp: new Date().toISOString(),
+		providers: results,
+	}));
+}
+
+/** Usage stats: per-provider aggregates + recent request log. */
+function handleStats(req, res) {
+	const url = new URL(req.url, `http://localhost:${PORT}`);
+	const limit = parseInt(url.searchParams.get("limit") || "50", 10);
+
+	// Compute session totals
+	let totalRequests = 0, totalTokensIn = 0, totalTokensOut = 0, totalErrors = 0;
+	for (const s of Object.values(providerStats)) {
+		totalRequests += s.requests;
+		totalTokensIn += s.tokens_in;
+		totalTokensOut += s.tokens_out;
+		totalErrors += s.errors;
+	}
+
+	res.writeHead(200, json());
+	res.end(JSON.stringify({
+		timestamp: new Date().toISOString(),
+		session: {
+			total_requests: totalRequests,
+			total_tokens_in: totalTokensIn,
+			total_tokens_out: totalTokensOut,
+			total_errors: totalErrors,
+		},
+		providers: Object.entries(providerStats).map(([prov, s]) => ({
+			provider: prov,
+			label: getProviderLabel(prov),
+			...s,
+		})),
+		recent: usageLog.slice(-limit).reverse(),
+	}));
 }
 
 function handleHealth(req, res) {
@@ -1532,6 +1650,7 @@ const server = createServer(async (req, res) => {
 		else if (path === "/v1/models" && req.method === "GET") handleModels(req, res);
 		else if (path === "/v1/routing" && req.method === "GET") handleRouting(req, res);
 		else if (path === "/v1/quota" && req.method === "GET") await handleQuota(req, res);
+		else if (path === "/v1/stats" && req.method === "GET") handleStats(req, res);
 		else if (path === "/health" && req.method === "GET") handleHealth(req, res);
 		else if (path === "/ui" || path === "/") handleUI(req, res);
 		else { res.writeHead(404, json()); res.end(JSON.stringify({ error: { message: "Not found" } })); }
@@ -1563,6 +1682,8 @@ server.listen(PORT, () => {
 
   POST /v1/chat/completions   (streaming, tools, images, failover)
   GET  /v1/models             (all models + preset names)
+  GET  /v1/quota              (detailed quota per provider)
+  GET  /v1/stats              (usage stats + request log)
   GET  /health
   GET  /ui                    Chat UI
 

--- a/leeloo.js
+++ b/leeloo.js
@@ -2,7 +2,7 @@
 /**
  * leeloo.js -- OpenAI-compatible proxy powered by pi-multi-pass
  *
- * "Leeloo Dallas Multi Pass!"
+ * "Leeloo on multi-pass!"
  *
  * Reads pi-multi-pass config and pi's auth storage, then exposes a local
  * OpenAI-compatible API that routes requests through your configured
@@ -1059,7 +1059,7 @@ function handleUI(req, res) {
 const CHAT_UI_HTML = `<!DOCTYPE html>
 <html lang="en"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Leeloo Dallas Multi Pass</title>
+<title>Leeloo on multi-pass</title>
 
 <style>
 *{box-sizing:border-box;margin:0;padding:0}
@@ -1138,7 +1138,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;b
 
 <div id="topbar">
   <div id="bar-main">
-    <h1>LEELOO DALLAS MULTI PASS</h1>
+    <h1>Leeloo on multi-pass</h1>
     <select id="model-select"><option>Loading...</option></select>
     <div class="bar-actions">
       <button class="bar-btn" onclick="clearChat()">Clear</button>
@@ -1152,7 +1152,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;b
 
 <div id="chat">
   <div class="welcome">
-    <h2>LEELOO DALLAS MULTI PASS</h2>
+    <h2>Leeloo on multi-pass</h2>
     Select a preset or model above and start chatting.<br>
     Requests route through your multi-pass pools with automatic failover.
   </div>
@@ -1235,7 +1235,7 @@ async function loadRouting() {
 
 function clearChat() {
   messages = [];
-  chat.innerHTML = '<div class="welcome"><h2>LEELOO DALLAS MULTI PASS</h2>Chat cleared.</div>';
+  chat.innerHTML = '<div class="welcome"><h2>Leeloo on multi-pass</h2>Chat cleared.</div>';
 }
 
 function esc(s) { return String(s).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;"); }
@@ -1395,9 +1395,9 @@ server.listen(PORT, () => {
 	const presets = config.presets.filter((p) => p.enabled);
 
 	console.log(`
-  ╔══════════════════════════════════════════╗
-  ║         LEELOO DALLAS MULTI PASS         ║
-  ╚══════════════════════════════════════════╝
+  ╔════════════════════════════════════╗
+  ║       Leeloo on multi-pass       ║
+  ╚════════════════════════════════════╝
 
   OpenAI-compatible proxy powered by pi-multi-pass
 

--- a/leeloo.js
+++ b/leeloo.js
@@ -535,7 +535,7 @@ async function resolveCandidates(modelId) {
  * Convert OpenAI-format messages to pi-ai Context.
  */
 function toContext(messages, tools) {
-	const ctx = { messages: [], systemPrompt: undefined, tools: undefined };
+	const ctx = { messages: [], systemPrompt: "You are a helpful assistant.", tools: undefined };
 
 	// System prompt
 	const sysMessages = messages.filter((m) => m.role === "system");

--- a/leeloo.js
+++ b/leeloo.js
@@ -31,9 +31,10 @@
  */
 
 import { createServer } from "node:http";
-import { readFileSync, existsSync, writeFileSync, mkdirSync } from "node:fs";
+import { readFileSync, existsSync, writeFileSync, mkdirSync, appendFileSync, createReadStream } from "node:fs";
 import { join, extname, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { createInterface } from "node:readline";
 import { AuthStorage, getAgentDir } from "@mariozechner/pi-coding-agent";
 import { getModel, getModels, stream } from "@mariozechner/pi-ai";
 
@@ -51,9 +52,16 @@ const AGENT_DIR = getAgentDir();
 const ROOT_DIR = dirname(fileURLToPath(import.meta.url));
 const WEB_DIR = join(ROOT_DIR, "web");
 const CONFIG_PATH = join(AGENT_DIR, "multi-pass.json");
+const RULES_PATH = join(AGENT_DIR, "multi-pass-rules.json");
+const AUDIT_PATH = join(AGENT_DIR, "leeloo-audit.jsonl");
+const AUDIT_MAX_LINES = 5000; // max lines in JSONL file before rotation
+
+function ensureDir() {
+	if (!existsSync(AGENT_DIR)) mkdirSync(AGENT_DIR, { recursive: true });
+}
 
 function loadConfig() {
-	if (!existsSync(CONFIG_PATH)) return { subscriptions: [], pools: [], chains: [], presets: [], rules: [] };
+	if (!existsSync(CONFIG_PATH)) return { subscriptions: [], pools: [], chains: [], presets: [] };
 	try {
 		const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 		return {
@@ -61,17 +69,87 @@ function loadConfig() {
 			pools: Array.isArray(raw.pools) ? raw.pools : [],
 			chains: Array.isArray(raw.chains) ? raw.chains : [],
 			presets: Array.isArray(raw.presets) ? raw.presets : [],
-			rules: Array.isArray(raw.rules) ? raw.rules : [],
 		};
 	} catch {
-		return { subscriptions: [], pools: [], chains: [], presets: [], rules: [] };
+		return { subscriptions: [], pools: [], chains: [], presets: [] };
 	}
 }
 
 function saveConfig(config) {
-	const dir = join(AGENT_DIR);
-	if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-	writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2), "utf-8");
+	ensureDir();
+	// Strip rules from config if they were accidentally included
+	const { rules, ...clean } = config;
+	writeFileSync(CONFIG_PATH, JSON.stringify(clean, null, 2), "utf-8");
+}
+
+function loadRules() {
+	// Migrate: if rules exist in multi-pass.json, move them to multi-pass-rules.json
+	if (!existsSync(RULES_PATH)) {
+		if (existsSync(CONFIG_PATH)) {
+			try {
+				const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+				if (Array.isArray(raw.rules) && raw.rules.length > 0) {
+					ensureDir();
+					writeFileSync(RULES_PATH, JSON.stringify({ rules: raw.rules }, null, 2), "utf-8");
+					delete raw.rules;
+					writeFileSync(CONFIG_PATH, JSON.stringify(raw, null, 2), "utf-8");
+					log("[rules] migrated rules from multi-pass.json to multi-pass-rules.json");
+					return raw.rules;
+				}
+			} catch {}
+		}
+		return [];
+	}
+	try {
+		const raw = JSON.parse(readFileSync(RULES_PATH, "utf-8"));
+		return Array.isArray(raw.rules) ? raw.rules : [];
+	} catch {
+		return [];
+	}
+}
+
+function saveRules(rules) {
+	ensureDir();
+	writeFileSync(RULES_PATH, JSON.stringify({ rules }, null, 2), "utf-8");
+}
+
+// ─── Persistent audit log (JSONL) ───────────────────────────────────────────
+
+function appendAuditLine(entry) {
+	try {
+		ensureDir();
+		appendFileSync(AUDIT_PATH, JSON.stringify(entry) + "\n", "utf-8");
+	} catch (e) {
+		log("[audit] write error:", e.message);
+	}
+}
+
+async function loadAuditFromDisk(maxLines = 1000) {
+	if (!existsSync(AUDIT_PATH)) return [];
+	const entries = [];
+	try {
+		const rl = createInterface({ input: createReadStream(AUDIT_PATH, "utf-8"), crlfDelay: Infinity });
+		for await (const line of rl) {
+			if (!line.trim()) continue;
+			try { entries.push(JSON.parse(line)); } catch {}
+		}
+	} catch (e) {
+		log("[audit] load error:", e.message);
+	}
+	// Keep only the most recent entries
+	return entries.slice(-maxLines);
+}
+
+function rotateAuditFile() {
+	if (!existsSync(AUDIT_PATH)) return;
+	try {
+		const content = readFileSync(AUDIT_PATH, "utf-8");
+		const lines = content.split("\n").filter(Boolean);
+		if (lines.length <= AUDIT_MAX_LINES) return;
+		const keep = lines.slice(-Math.floor(AUDIT_MAX_LINES * 0.8));
+		writeFileSync(AUDIT_PATH, keep.join("\n") + "\n", "utf-8");
+		log(`[audit] rotated: ${lines.length} -> ${keep.length} lines`);
+	} catch {}
 }
 
 const authStorage = AuthStorage.create();
@@ -434,9 +512,18 @@ function trackRequest(provider, modelId, usage, durationMs, error, requestText, 
 //
 // Each rule has: name, enabled, type, scope (request|response|both), patterns, action config
 
-const auditLog = [];
+let auditLog = [];
 const AUDIT_LOG_MAX = 1000;
 const rateLimitCounters = {}; // { ruleName: { count, windowStart } }
+
+// Load persisted audit log on startup
+(async () => {
+	try {
+		auditLog = await loadAuditFromDisk(AUDIT_LOG_MAX);
+		if (auditLog.length > 0) log(`[audit] loaded ${auditLog.length} entries from disk`);
+		rotateAuditFile();
+	} catch {}
+})();
 
 function auditEvent(rule, action, detail, matchedText, fullMessage, source, redactedMessage) {
 	const matched = typeof matchedText === "string" ? matchedText : null;
@@ -457,6 +544,7 @@ function auditEvent(rule, action, detail, matchedText, fullMessage, source, reda
 	};
 	auditLog.push(entry);
 	if (auditLog.length > AUDIT_LOG_MAX) auditLog.shift();
+	appendAuditLine(entry);
 	log(`[rule:${rule.name}] ${action}: ${detail}`);
 }
 
@@ -650,14 +738,13 @@ function checkResponseBlock(rules, text) {
 // ─── Rules API handlers ──────────────────────────────────────────────────────
 
 function handleRulesList(req, res) {
-	const config = loadConfig();
 	res.writeHead(200, json());
-	res.end(JSON.stringify({ rules: config.rules || [] }));
+	res.end(JSON.stringify({ rules: loadRules() }));
 }
 
 async function handleRulesCreate(req, res) {
 	const body = JSON.parse(await readBody(req));
-	const config = loadConfig();
+	const rules = loadRules();
 	const rule = {
 		name: body.name || `rule-${Date.now()}`,
 		enabled: body.enabled !== false,
@@ -671,29 +758,194 @@ async function handleRulesCreate(req, res) {
 		maxRequests: body.maxRequests,
 		windowSeconds: body.windowSeconds,
 	};
-	config.rules.push(rule);
-	saveConfig(config);
+	rules.push(rule);
+	saveRules(rules);
 	res.writeHead(201, json());
 	res.end(JSON.stringify({ rule }));
 }
 
 async function handleRulesUpdate(req, res, ruleName) {
 	const body = JSON.parse(await readBody(req));
-	const config = loadConfig();
-	const idx = config.rules.findIndex((r) => r.name === ruleName);
+	const rules = loadRules();
+	const idx = rules.findIndex((r) => r.name === ruleName);
 	if (idx < 0) { res.writeHead(404, json()); res.end(JSON.stringify({ error: { message: "Rule not found" } })); return; }
-	config.rules[idx] = { ...config.rules[idx], ...body };
-	saveConfig(config);
+	rules[idx] = { ...rules[idx], ...body };
+	saveRules(rules);
 	res.writeHead(200, json());
-	res.end(JSON.stringify({ rule: config.rules[idx] }));
+	res.end(JSON.stringify({ rule: rules[idx] }));
 }
 
 function handleRulesDelete(req, res, ruleName) {
-	const config = loadConfig();
-	config.rules = config.rules.filter((r) => r.name !== ruleName);
-	saveConfig(config);
+	const rules = loadRules().filter((r) => r.name !== ruleName);
+	saveRules(rules);
 	res.writeHead(200, json());
 	res.end(JSON.stringify({ deleted: ruleName }));
+}
+
+// ─── Config CRUD API ─────────────────────────────────────────────────────────
+
+function handleConfigGet(req, res) {
+	res.writeHead(200, json());
+	res.end(JSON.stringify(loadConfig()));
+}
+
+async function handleConfigPut(req, res) {
+	const body = JSON.parse(await readBody(req));
+	const config = loadConfig();
+	// Merge only known keys
+	if (body.subscriptions !== undefined) config.subscriptions = body.subscriptions;
+	if (body.pools !== undefined) config.pools = body.pools;
+	if (body.chains !== undefined) config.chains = body.chains;
+	if (body.presets !== undefined) config.presets = body.presets;
+	saveConfig(config);
+	res.writeHead(200, json());
+	res.end(JSON.stringify(config));
+}
+
+// Granular: pools
+async function handlePoolsGet(req, res) {
+	res.writeHead(200, json());
+	res.end(JSON.stringify({ pools: loadConfig().pools }));
+}
+
+async function handlePoolCreate(req, res) {
+	const body = JSON.parse(await readBody(req));
+	const config = loadConfig();
+	const pool = {
+		name: body.name || `pool-${Date.now()}`,
+		enabled: body.enabled !== false,
+		baseProvider: body.baseProvider || "",
+		members: body.members || [],
+		strategy: body.strategy || "round-robin",
+		memberSchedule: body.memberSchedule || undefined,
+		selectorScript: body.selectorScript || undefined,
+	};
+	config.pools.push(pool);
+	saveConfig(config);
+	res.writeHead(201, json());
+	res.end(JSON.stringify({ pool }));
+}
+
+async function handlePoolUpdate(req, res, poolName) {
+	const body = JSON.parse(await readBody(req));
+	const config = loadConfig();
+	const idx = config.pools.findIndex((p) => p.name === poolName);
+	if (idx < 0) { res.writeHead(404, json()); res.end(JSON.stringify({ error: { message: "Pool not found" } })); return; }
+	config.pools[idx] = { ...config.pools[idx], ...body };
+	saveConfig(config);
+	res.writeHead(200, json());
+	res.end(JSON.stringify({ pool: config.pools[idx] }));
+}
+
+function handlePoolDelete(req, res, poolName) {
+	const config = loadConfig();
+	config.pools = config.pools.filter((p) => p.name !== poolName);
+	saveConfig(config);
+	res.writeHead(200, json());
+	res.end(JSON.stringify({ deleted: poolName }));
+}
+
+// Granular: chains
+async function handleChainCreate(req, res) {
+	const body = JSON.parse(await readBody(req));
+	const config = loadConfig();
+	const chain = {
+		name: body.name || `chain-${Date.now()}`,
+		enabled: body.enabled !== false,
+		steps: body.steps || [],
+	};
+	config.chains.push(chain);
+	saveConfig(config);
+	res.writeHead(201, json());
+	res.end(JSON.stringify({ chain }));
+}
+
+async function handleChainUpdate(req, res, chainName) {
+	const body = JSON.parse(await readBody(req));
+	const config = loadConfig();
+	const idx = config.chains.findIndex((c) => c.name === chainName);
+	if (idx < 0) { res.writeHead(404, json()); res.end(JSON.stringify({ error: { message: "Chain not found" } })); return; }
+	config.chains[idx] = { ...config.chains[idx], ...body };
+	saveConfig(config);
+	res.writeHead(200, json());
+	res.end(JSON.stringify({ chain: config.chains[idx] }));
+}
+
+function handleChainDelete(req, res, chainName) {
+	const config = loadConfig();
+	config.chains = config.chains.filter((c) => c.name !== chainName);
+	saveConfig(config);
+	res.writeHead(200, json());
+	res.end(JSON.stringify({ deleted: chainName }));
+}
+
+// Granular: presets
+async function handlePresetCreate(req, res) {
+	const body = JSON.parse(await readBody(req));
+	const config = loadConfig();
+	const preset = {
+		name: body.name || `preset-${Date.now()}`,
+		enabled: body.enabled !== false,
+		entries: body.entries || [],
+	};
+	config.presets.push(preset);
+	saveConfig(config);
+	res.writeHead(201, json());
+	res.end(JSON.stringify({ preset }));
+}
+
+async function handlePresetUpdate(req, res, presetName) {
+	const body = JSON.parse(await readBody(req));
+	const config = loadConfig();
+	const idx = config.presets.findIndex((p) => p.name === presetName);
+	if (idx < 0) { res.writeHead(404, json()); res.end(JSON.stringify({ error: { message: "Preset not found" } })); return; }
+	config.presets[idx] = { ...config.presets[idx], ...body };
+	saveConfig(config);
+	res.writeHead(200, json());
+	res.end(JSON.stringify({ preset: config.presets[idx] }));
+}
+
+function handlePresetDelete(req, res, presetName) {
+	const config = loadConfig();
+	config.presets = config.presets.filter((p) => p.name !== presetName);
+	saveConfig(config);
+	res.writeHead(200, json());
+	res.end(JSON.stringify({ deleted: presetName }));
+}
+
+// Granular: subscriptions
+async function handleSubCreate(req, res) {
+	const body = JSON.parse(await readBody(req));
+	const config = loadConfig();
+	const sub = {
+		name: body.name || `sub-${Date.now()}`,
+		provider: body.provider,
+		enabled: body.enabled !== false,
+		alias: body.alias || body.name || `sub-${Date.now()}`,
+	};
+	config.subscriptions.push(sub);
+	saveConfig(config);
+	res.writeHead(201, json());
+	res.end(JSON.stringify({ subscription: sub }));
+}
+
+async function handleSubUpdate(req, res, subName) {
+	const body = JSON.parse(await readBody(req));
+	const config = loadConfig();
+	const idx = config.subscriptions.findIndex((s) => s.name === subName);
+	if (idx < 0) { res.writeHead(404, json()); res.end(JSON.stringify({ error: { message: "Subscription not found" } })); return; }
+	config.subscriptions[idx] = { ...config.subscriptions[idx], ...body };
+	saveConfig(config);
+	res.writeHead(200, json());
+	res.end(JSON.stringify({ subscription: config.subscriptions[idx] }));
+}
+
+function handleSubDelete(req, res, subName) {
+	const config = loadConfig();
+	config.subscriptions = config.subscriptions.filter((s) => s.name !== subName);
+	saveConfig(config);
+	res.writeHead(200, json());
+	res.end(JSON.stringify({ deleted: subName }));
 }
 
 function handleAuditLog(req, res) {
@@ -1306,7 +1558,7 @@ async function handleNonStreaming(res, model, context, opts, requestModelId, act
 	}
 
 	// ── Response-side rule evaluation ──
-	const respRules = loadConfig().rules || [];
+	const respRules = loadRules();
 	if (respRules.length > 0 && fullText) {
 		const respBlock = checkResponseBlock(respRules, fullText);
 		if (respBlock.blocked) {
@@ -1373,7 +1625,7 @@ async function handleChatCompletions(req, res) {
 	}
 
 	// ── Rule evaluation: pre-flight ──
-	const rules = loadConfig().rules || [];
+	const rules = loadRules();
 	if (rules.length > 0) {
 		// Rate limits
 		const rateCheck = evaluateRateLimitRules(rules);
@@ -1702,6 +1954,21 @@ const server = createServer(async (req, res) => {
 		else if (path.startsWith("/v1/rules/") && req.method === "PUT") await handleRulesUpdate(req, res, decodeURIComponent(path.split("/v1/rules/")[1]));
 		else if (path.startsWith("/v1/rules/") && req.method === "DELETE") handleRulesDelete(req, res, decodeURIComponent(path.split("/v1/rules/")[1]));
 		else if (path === "/v1/audit" && req.method === "GET") handleAuditLog(req, res);
+		else if (path === "/v1/config" && req.method === "GET") handleConfigGet(req, res);
+		else if (path === "/v1/config" && req.method === "PUT") await handleConfigPut(req, res);
+		else if (path === "/v1/config/pools" && req.method === "GET") await handlePoolsGet(req, res);
+		else if (path === "/v1/config/pools" && req.method === "POST") await handlePoolCreate(req, res);
+		else if (path.startsWith("/v1/config/pools/") && req.method === "PUT") await handlePoolUpdate(req, res, decodeURIComponent(path.split("/v1/config/pools/")[1]));
+		else if (path.startsWith("/v1/config/pools/") && req.method === "DELETE") handlePoolDelete(req, res, decodeURIComponent(path.split("/v1/config/pools/")[1]));
+		else if (path === "/v1/config/chains" && req.method === "POST") await handleChainCreate(req, res);
+		else if (path.startsWith("/v1/config/chains/") && req.method === "PUT") await handleChainUpdate(req, res, decodeURIComponent(path.split("/v1/config/chains/")[1]));
+		else if (path.startsWith("/v1/config/chains/") && req.method === "DELETE") handleChainDelete(req, res, decodeURIComponent(path.split("/v1/config/chains/")[1]));
+		else if (path === "/v1/config/presets" && req.method === "POST") await handlePresetCreate(req, res);
+		else if (path.startsWith("/v1/config/presets/") && req.method === "PUT") await handlePresetUpdate(req, res, decodeURIComponent(path.split("/v1/config/presets/")[1]));
+		else if (path.startsWith("/v1/config/presets/") && req.method === "DELETE") handlePresetDelete(req, res, decodeURIComponent(path.split("/v1/config/presets/")[1]));
+		else if (path === "/v1/config/subscriptions" && req.method === "POST") await handleSubCreate(req, res);
+		else if (path.startsWith("/v1/config/subscriptions/") && req.method === "PUT") await handleSubUpdate(req, res, decodeURIComponent(path.split("/v1/config/subscriptions/")[1]));
+		else if (path.startsWith("/v1/config/subscriptions/") && req.method === "DELETE") handleSubDelete(req, res, decodeURIComponent(path.split("/v1/config/subscriptions/")[1]));
 		else if (path === "/health" && req.method === "GET") handleHealth(req, res);
 		else if (path.startsWith("/web/") && req.method === "GET") handleWebAsset(req, res, path);
 		else if (path === "/admin") handleAdmin(req, res);

--- a/leeloo.js
+++ b/leeloo.js
@@ -195,6 +195,143 @@ function getScheduledOrder(pool, available) {
 	return [...preferred, ...defaults, ...overflow].map((x) => x.prov);
 }
 
+// ─── Quota checkers (ported from extension) ──────────────────────────────────
+
+const CODEX_USAGE_URL = process.env.CHATGPT_BASE_URL || "https://chatgpt.com/backend-api";
+const GEMINI_QUOTA_URL = "https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota";
+const ANTIGRAVITY_QUOTA_URLS = [
+	"https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal:fetchAvailableModels",
+	"https://cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels",
+];
+
+function decodeJwtPayload(token) {
+	try {
+		const parts = token.split(".");
+		if (parts.length < 2) return {};
+		return JSON.parse(Buffer.from(parts[1], "base64url").toString("utf8"));
+	} catch { return {}; }
+}
+
+/** Check Codex (ChatGPT) quota. Returns 0-100 remaining percentage or null. */
+async function checkCodexQuota(provider) {
+	const cred = authStorage.get(provider);
+	if (!cred || cred.type !== "oauth" || !cred.access) return null;
+
+	const apiKey = await authStorage.getApiKey(provider);
+	if (!apiKey) return null;
+
+	// Extract account ID from JWT or stored credential
+	const payload = decodeJwtPayload(apiKey);
+	const authClaim = payload["https://api.openai.com/auth"];
+	const accountId = cred.accountId || authClaim?.chatgpt_account_id;
+
+	const headers = { Authorization: `Bearer ${apiKey}`, Accept: "application/json" };
+	if (accountId) headers["chatgpt-account-id"] = accountId;
+
+	try {
+		const resp = await fetch(`${CODEX_USAGE_URL.replace(/\/+$/, "")}/wham/usage`, { headers });
+		if (!resp.ok) return null;
+		const data = await resp.json();
+		const rl = data?.rate_limit;
+		const windows = [rl?.primary_window, rl?.secondary_window]
+			.filter(Boolean)
+			.map((w) => Math.max(0, 100 - (w.used_percent || 0)));
+		return windows.length > 0 ? Math.min(...windows) : null;
+	} catch { return null; }
+}
+
+/** Check Google Gemini CLI quota. Returns 0-100 remaining percentage or null. */
+async function checkGeminiQuota(provider) {
+	const apiKey = await authStorage.getApiKey(provider);
+	if (!apiKey) return null;
+
+	let token;
+	try { const p = JSON.parse(apiKey); token = p.token; } catch { token = apiKey; }
+
+	try {
+		const resp = await fetch(GEMINI_QUOTA_URL, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${token}`,
+				"Content-Type": "application/json",
+				"User-Agent": "google-api-nodejs-client/9.15.1",
+				"X-Goog-Api-Client": "gl-node/22.17.0",
+			},
+			body: "{}",
+		});
+		if (!resp.ok) return null;
+		const data = await resp.json();
+		const fractions = (data?.buckets || [])
+			.map((b) => b?.remainingFraction)
+			.filter((f) => typeof f === "number")
+			.map((f) => Math.round(f * 100));
+		return fractions.length > 0 ? Math.min(...fractions) : null;
+	} catch { return null; }
+}
+
+/** Check Google Antigravity quota. Returns 0-100 remaining percentage or null. */
+async function checkAntigravityQuota(provider) {
+	const apiKey = await authStorage.getApiKey(provider);
+	if (!apiKey) return null;
+
+	let token;
+	try { const p = JSON.parse(apiKey); token = p.token; } catch { token = apiKey; }
+
+	for (const url of ANTIGRAVITY_QUOTA_URLS) {
+		try {
+			const resp = await fetch(url, {
+				method: "POST",
+				headers: {
+					Authorization: `Bearer ${token}`,
+					"Content-Type": "application/json",
+					"User-Agent": "antigravity/1.11.9 windows/amd64",
+					"X-Goog-Api-Client": "google-cloud-sdk vscode_cloudshelleditor/0.1",
+				},
+				body: "{}",
+			});
+			if (!resp.ok) continue;
+			const data = await resp.json();
+			const models = data?.models ? Object.values(data.models) : [];
+			const fractions = models
+				.filter((m) => !m.isInternal)
+				.map((m) => m?.quotaInfo?.remainingFraction)
+				.filter((f) => typeof f === "number")
+				.map((f) => Math.round(f * 100));
+			return fractions.length > 0 ? Math.min(...fractions) : null;
+		} catch { continue; }
+	}
+	return null;
+}
+
+/** Get remaining quota score (0-100) for a provider. null = unknown. */
+async function checkQuota(provider) {
+	const base = getBaseProvider(provider);
+	switch (base) {
+		case "openai-codex": return checkCodexQuota(provider);
+		case "google-gemini-cli": return checkGeminiQuota(provider);
+		case "google-antigravity": return checkAntigravityQuota(provider);
+		default: return null;
+	}
+}
+
+/** Sort providers by quota (best first). Providers with unknown quota go last. */
+async function sortByQuota(providers) {
+	const results = await Promise.all(
+		providers.map(async (prov) => ({ prov, score: await checkQuota(prov) })),
+	);
+	results.sort((a, b) => {
+		if (a.score === null && b.score === null) return 0;
+		if (a.score === null) return 1;
+		if (b.score === null) return -1;
+		return b.score - a.score;
+	});
+	const best = results[0];
+	if (best?.score !== null) {
+		log(`[quota-first] scores: ${results.map((r) => `${r.prov}=${r.score ?? "?"}%`).join(", ")}`);
+	}
+	return results.map((r) => r.prov);
+}
+
 // ─── Custom selector script loader ────────────────────────────────────────────
 
 const selectorCache = new Map();
@@ -309,10 +446,12 @@ async function resolveCandidates(modelId) {
 				log(`[pool:${pool.name}] custom: selector chose ${best}`);
 			}
 		}
-		// quota-first: would need provider-specific quota APIs (Codex, Google).
-		// Fall back to pool member order -- the extension's quota checkers
-		// aren't available outside pi's runtime, but rate-limit failover
-		// still rotates through all members.
+		if (strategy === "quota-first") {
+			memberOrder = await sortByQuota(poolMembers);
+			if (memberOrder.length > 0) {
+				log(`[pool:${pool.name}] quota-first: ${memberOrder[0]} preferred`);
+			}
+		}
 
 		for (const member of memberOrder) {
 			const match = raw.find((c) => c.provider === member);
@@ -855,6 +994,175 @@ function readBody(req) {
 function json() { return { "Content-Type": "application/json" }; }
 function log(...a) { console.log(`[${new Date().toISOString().slice(11, 19)}]`, ...a); }
 
+// ─── Chat UI ──────────────────────────────────────────────────────────────────
+
+function handleUI(req, res) {
+	res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+	res.end(CHAT_UI_HTML);
+}
+
+const CHAT_UI_HTML = `<!DOCTYPE html>
+<html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Leeloo Dallas Multi Pass</title>
+<style>
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:#0a0a0a;color:#e0e0e0;height:100vh;display:flex;flex-direction:column}
+header{background:#111;border-bottom:1px solid #222;padding:12px 20px;display:flex;align-items:center;gap:16px;flex-shrink:0}
+header h1{font-size:16px;color:#f90;font-weight:600;white-space:nowrap}
+header select{background:#1a1a1a;color:#e0e0e0;border:1px solid #333;border-radius:6px;padding:6px 12px;font-size:13px;min-width:200px}
+header .status{margin-left:auto;font-size:12px;color:#666}
+#chat{flex:1;overflow-y:auto;padding:20px;display:flex;flex-direction:column;gap:12px}
+.msg{max-width:85%;padding:10px 14px;border-radius:12px;line-height:1.5;font-size:14px;white-space:pre-wrap;word-wrap:break-word}
+.msg.user{align-self:flex-end;background:#1a3a5c;color:#cde;border-bottom-right-radius:4px}
+.msg.assistant{align-self:flex-start;background:#1a1a1a;border:1px solid #222;border-bottom-left-radius:4px}
+.msg .meta{font-size:11px;color:#666;margin-top:6px}
+.msg code{background:#0d0d0d;padding:1px 4px;border-radius:3px;font-size:13px}
+.msg pre{background:#0d0d0d;padding:8px;border-radius:6px;overflow-x:auto;margin:6px 0}
+.msg pre code{background:none;padding:0}
+#input-area{border-top:1px solid #222;padding:12px 20px;display:flex;gap:10px;flex-shrink:0;background:#111}
+#input-area textarea{flex:1;background:#1a1a1a;color:#e0e0e0;border:1px solid #333;border-radius:8px;padding:10px 14px;font-size:14px;font-family:inherit;resize:none;min-height:44px;max-height:120px}
+#input-area textarea:focus{outline:none;border-color:#f90}
+#input-area button{background:#f90;color:#000;border:none;border-radius:8px;padding:0 20px;font-weight:600;cursor:pointer;font-size:14px}
+#input-area button:hover{background:#fa0}
+#input-area button:disabled{opacity:.4;cursor:default}
+.typing{color:#888;font-style:italic;font-size:13px;padding:4px 14px}
+</style>
+</head><body>
+<header>
+  <h1>LEELOO DALLAS MULTI PASS</h1>
+  <select id="model-select"><option>Loading...</option></select>
+  <span class="status" id="status">connecting...</span>
+</header>
+<div id="chat"></div>
+<div id="input-area">
+  <textarea id="input" rows="1" placeholder="Type a message..." autofocus></textarea>
+  <button id="send" onclick="sendMessage()">Send</button>
+</div>
+<script>
+const BASE = location.origin;
+const chat = document.getElementById("chat");
+const input = document.getElementById("input");
+const modelSelect = document.getElementById("model-select");
+const sendBtn = document.getElementById("send");
+const statusEl = document.getElementById("status");
+let messages = [];
+let streaming = false;
+
+// Auto-resize textarea
+input.addEventListener("input", () => {
+  input.style.height = "auto";
+  input.style.height = Math.min(input.scrollHeight, 120) + "px";
+});
+input.addEventListener("keydown", (e) => {
+  if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); sendMessage(); }
+});
+
+// Load models
+async function loadModels() {
+  try {
+    const resp = await fetch(BASE + "/v1/models");
+    const data = await resp.json();
+    modelSelect.innerHTML = "";
+    const models = data.data || [];
+    // Group: presets first, then by provider
+    const presets = models.filter(m => m.owned_by === "pi-multi-pass");
+    const regular = models.filter(m => m.owned_by !== "pi-multi-pass");
+    if (presets.length > 0) {
+      const og = document.createElement("optgroup");
+      og.label = "Presets";
+      presets.forEach(m => { const o = document.createElement("option"); o.value = m.id; o.textContent = m.id; og.appendChild(o); });
+      modelSelect.appendChild(og);
+    }
+    // Group by provider
+    const byProvider = {};
+    regular.forEach(m => { (byProvider[m.owned_by] = byProvider[m.owned_by] || []).push(m); });
+    for (const [prov, pmodels] of Object.entries(byProvider)) {
+      const og = document.createElement("optgroup");
+      og.label = prov;
+      pmodels.forEach(m => { const o = document.createElement("option"); o.value = m.id; o.textContent = m.id; og.appendChild(o); });
+      modelSelect.appendChild(og);
+    }
+    statusEl.textContent = models.length + " models";
+  } catch (e) { statusEl.textContent = "error: " + e.message; }
+}
+
+function addMessage(role, content, meta) {
+  const div = document.createElement("div");
+  div.className = "msg " + role;
+  div.innerHTML = escapeHtml(content) + (meta ? '<div class="meta">' + escapeHtml(meta) + '</div>' : '');
+  chat.appendChild(div);
+  chat.scrollTop = chat.scrollHeight;
+  return div;
+}
+
+function escapeHtml(s) {
+  return s.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;");
+}
+
+async function sendMessage() {
+  const text = input.value.trim();
+  if (!text || streaming) return;
+  input.value = ""; input.style.height = "auto";
+  messages.push({ role: "user", content: text });
+  addMessage("user", text);
+  streaming = true; sendBtn.disabled = true;
+  statusEl.textContent = "streaming...";
+
+  const assistantDiv = addMessage("assistant", "");
+  let fullText = "";
+
+  try {
+    const resp = await fetch(BASE + "/v1/chat/completions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: modelSelect.value,
+        messages: messages,
+        stream: true,
+      }),
+    });
+    const reader = resp.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    let usage = null;
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\\n");
+      buffer = lines.pop() || "";
+      for (const line of lines) {
+        if (!line.startsWith("data: ")) continue;
+        const payload = line.slice(6).trim();
+        if (payload === "[DONE]") continue;
+        try {
+          const parsed = JSON.parse(payload);
+          const delta = parsed.choices?.[0]?.delta;
+          if (delta?.content) { fullText += delta.content; assistantDiv.innerHTML = escapeHtml(fullText); chat.scrollTop = chat.scrollHeight; }
+          if (delta?.tool_calls) { fullText += "[tool_call: " + (delta.tool_calls[0]?.function?.name || "?") + "]"; assistantDiv.innerHTML = escapeHtml(fullText); }
+          if (parsed.usage) usage = parsed.usage;
+          const fr = parsed.choices?.[0]?.finish_reason;
+          if (fr) {
+            const meta = (usage ? "tokens: " + usage.prompt_tokens + " in / " + usage.completion_tokens + " out" : "") + " | model: " + modelSelect.value;
+            assistantDiv.innerHTML = escapeHtml(fullText) + '<div class="meta">' + escapeHtml(meta) + '</div>';
+          }
+        } catch {}
+      }
+    }
+    messages.push({ role: "assistant", content: fullText });
+  } catch (e) {
+    assistantDiv.innerHTML = escapeHtml("[Error: " + e.message + "]");
+  }
+  streaming = false; sendBtn.disabled = false;
+  statusEl.textContent = "ready";
+}
+
+loadModels();
+</script>
+</body></html>`;
+
 // ─── Server ───────────────────────────────────────────────────────────────────
 
 const server = createServer(async (req, res) => {
@@ -868,6 +1176,7 @@ const server = createServer(async (req, res) => {
 		if (path === "/v1/chat/completions" && req.method === "POST") await handleChatCompletions(req, res);
 		else if (path === "/v1/models" && req.method === "GET") handleModels(req, res);
 		else if (path === "/health" && req.method === "GET") handleHealth(req, res);
+		else if (path === "/ui" || path === "/") handleUI(req, res);
 		else { res.writeHead(404, json()); res.end(JSON.stringify({ error: { message: "Not found" } })); }
 	} catch (err) {
 		log("Unhandled:", err?.message || err);
@@ -898,7 +1207,9 @@ server.listen(PORT, () => {
   POST /v1/chat/completions   (streaming, tools, images, failover)
   GET  /v1/models             (all models + preset names)
   GET  /health
+  GET  /ui                    Chat UI
 
   OPENAI_BASE_URL=http://localhost:${PORT}/v1
+  Chat UI: http://localhost:${PORT}/ui
 `);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3525 @@
+{
+  "name": "pi-multi-pass",
+  "version": "1.3.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pi-multi-pass",
+      "version": "1.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@mariozechner/pi-ai": ">=0.58.0",
+        "@mariozechner/pi-coding-agent": ">=0.58.0"
+      },
+      "bin": {
+        "leeloo": "leeloo.js"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.73.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.73.0.tgz",
+      "integrity": "sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1024.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1024.0.tgz",
+      "integrity": "sha512-nIhsn0/eYrL2fTh4kMO7Hpfmhv+AkkXl0KGNpD6+fdmotGvRBWcDv9/PmP/+sT6gvrKTYyzH3vu4efpTPzzP0Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/credential-provider-node": "^3.972.29",
+        "@aws-sdk/eventstream-handler-node": "^3.972.12",
+        "@aws-sdk/middleware-eventstream": "^3.972.8",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.9",
+        "@aws-sdk/middleware-user-agent": "^3.972.28",
+        "@aws-sdk/middleware-websocket": "^3.972.14",
+        "@aws-sdk/region-config-resolver": "^3.972.10",
+        "@aws-sdk/token-providers": "3.1024.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.14",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/core": "^3.23.13",
+        "@smithy/eventstream-serde-browser": "^4.2.12",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.12",
+        "@smithy/eventstream-serde-node": "^4.2.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.28",
+        "@smithy/middleware-retry": "^4.4.46",
+        "@smithy/middleware-serde": "^4.2.16",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.1",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.44",
+        "@smithy/util-defaults-mode-node": "^4.2.48",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.13",
+        "@smithy/util-stream": "^4.5.21",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.973.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.26.tgz",
+      "integrity": "sha512-A/E6n2W42ruU+sfWk+mMUOyVXbsSgGrY3MJ9/0Az5qUdG67y8I6HYzzoAa+e/lzxxl1uCYmEL6BTMi9ZiZnplQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/xml-builder": "^3.972.16",
+        "@smithy/core": "^3.23.13",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/signature-v4": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.24.tgz",
+      "integrity": "sha512-FWg8uFmT6vQM7VuzELzwVo5bzExGaKHdubn0StjgrcU5FvuLExUe+k06kn/40uKv59rYzhez8eFNM4yYE/Yb/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.26.tgz",
+      "integrity": "sha512-CY4ppZ+qHYqcXqBVi//sdHST1QK3KzOEiLtpLsc9W2k2vfZPKExGaQIsOwcyvjpjUEolotitmd3mUNY56IwDEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/node-http-handler": "^4.5.1",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-stream": "^4.5.21",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.28.tgz",
+      "integrity": "sha512-wXYvq3+uQcZV7k+bE4yDXCTBdzWTU9x/nMiKBfzInmv6yYK1veMK0AKvRfRBd72nGWYKcL6AxwiPg9z/pYlgpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/credential-provider-env": "^3.972.24",
+        "@aws-sdk/credential-provider-http": "^3.972.26",
+        "@aws-sdk/credential-provider-login": "^3.972.28",
+        "@aws-sdk/credential-provider-process": "^3.972.24",
+        "@aws-sdk/credential-provider-sso": "^3.972.28",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.28",
+        "@aws-sdk/nested-clients": "^3.996.18",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.28.tgz",
+      "integrity": "sha512-ZSTfO6jqUTCysbdBPtEX5OUR//3rbD0lN7jO3sQeS2Gjr/Y+DT6SbIJ0oT2cemNw3UzKu97sNONd1CwNMthuZQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/nested-clients": "^3.996.18",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.29.tgz",
+      "integrity": "sha512-clSzDcvndpFJAggLDnDb36sPdlZYyEs5Zm6zgZjjUhwsJgSWiWKwFIXUVBcbruidNyBdbpOv2tNDL9sX8y3/0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.24",
+        "@aws-sdk/credential-provider-http": "^3.972.26",
+        "@aws-sdk/credential-provider-ini": "^3.972.28",
+        "@aws-sdk/credential-provider-process": "^3.972.24",
+        "@aws-sdk/credential-provider-sso": "^3.972.28",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.28",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.24.tgz",
+      "integrity": "sha512-Q2k/XLrFXhEztPHqj4SLCNID3hEPdlhh1CDLBpNnM+1L8fq7P+yON9/9M1IGN/dA5W45v44ylERfXtDAlmMNmw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.28.tgz",
+      "integrity": "sha512-IoUlmKMLEITFn1SiCTjPfR6KrE799FBo5baWyk/5Ppar2yXZoUdaRqZzJzK6TcJxx450M8m8DbpddRVYlp5R/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/nested-clients": "^3.996.18",
+        "@aws-sdk/token-providers": "3.1021.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1021.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1021.0.tgz",
+      "integrity": "sha512-TKY6h9spUk3OLs5v1oAgW9mAeBE3LAGNBwJokLy96wwmd4W2v/tYlXseProyed9ValDj2u1jK/4Rg1T+1NXyJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/nested-clients": "^3.996.18",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.28.tgz",
+      "integrity": "sha512-d+6h0SD8GGERzKe27v5rOzNGKOl0D+l0bWJdqrxH8WSQzHzjsQFIAPgIeOTUwBHVsKKwtSxc91K/SWax6XgswQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/nested-clients": "^3.996.18",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.12.tgz",
+      "integrity": "sha512-ruyc/MNR6e+cUrGCth7fLQ12RXBZDy/bV06tgqB9Z5n/0SN/C0m6bsQEV8FF9zPI6VSAOaRd0rNgmpYVnGawrQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/eventstream-codec": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.8.tgz",
+      "integrity": "sha512-r+oP+tbCxgqXVC3pu3MUVePgSY0ILMjA+aEwOosS77m3/DRbtvHrHwqvMcw+cjANMeGzJ+i0ar+n77KXpRA8RQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.8.tgz",
+      "integrity": "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.8.tgz",
+      "integrity": "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.9.tgz",
+      "integrity": "sha512-/Wt5+CT8dpTFQxEJ9iGy/UGrXr7p2wlIOEHvIr/YcHYByzoLjrqkYqXdJjd9UIgWjv7eqV2HnFJen93UTuwfTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.28.tgz",
+      "integrity": "sha512-cfWZFlVh7Va9lRay4PN2A9ARFzaBYcA097InT5M2CdRS05ECF5yaz86jET8Wsl2WcyKYEvVr/QNmKtYtafUHtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@smithy/core": "^3.23.13",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-retry": "^4.2.13",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.14.tgz",
+      "integrity": "sha512-qnfDlIHjm6DrTYNvWOUbnZdVKgtoKbO/Qzj+C0Wp5Y7VUrsvBRQtGKxD+hc+mRTS4N0kBJ6iZ3+zxm4N1OSyjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-format-url": "^3.972.8",
+        "@smithy/eventstream-codec": "^4.2.12",
+        "@smithy/eventstream-serde-browser": "^4.2.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/signature-v4": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.996.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.18.tgz",
+      "integrity": "sha512-c7ZSIXrESxHKx2Mcopgd8AlzZgoXMr20fkx5ViPWPOLBvmyhw9VwJx/Govg8Ef/IhEon5R9l53Z8fdYSEmp6VA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.9",
+        "@aws-sdk/middleware-user-agent": "^3.972.28",
+        "@aws-sdk/region-config-resolver": "^3.972.10",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.14",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/core": "^3.23.13",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.28",
+        "@smithy/middleware-retry": "^4.4.46",
+        "@smithy/middleware-serde": "^4.2.16",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.1",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.44",
+        "@smithy/util-defaults-mode-node": "^4.2.48",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.13",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.10.tgz",
+      "integrity": "sha512-1dq9ToC6e070QvnVhhbAs3bb5r6cQ10gTVc6cyRV5uvQe7P138TV2uG2i6+Yok4bAkVAcx5AqkTEBUvWEtBlsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1024.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1024.0.tgz",
+      "integrity": "sha512-eoyTMgd6OzoE1dq50um5Y53NrosEkWsjH0W6pswi7vrv1W9hY/7hR43jDcPevqqj+OQksf/5lc++FTqRlb8Y1Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/nested-clients": "^3.996.18",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
+      "integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.996.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
+      "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-endpoints": "^3.3.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.8.tgz",
+      "integrity": "sha512-J6DS9oocrgxM8xlUTTmQOuwRF6rnAGEujAN9SAzllcrQmwn5iJ58ogxy3SEhD0Q7JZvlA5jvIXBkpQRqEqlE9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/querystring-builder": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.8.tgz",
+      "integrity": "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.973.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.14.tgz",
+      "integrity": "sha512-vNSB/DYaPOyujVZBg/zUznH9QC142MaTHVmaFlF7uzzfg3CgT9f/l4C0Yi+vU/tbBhxVcXVB90Oohk5+o+ZbWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "^3.972.28",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.16.tgz",
+      "integrity": "sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "fast-xml-parser": "5.5.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@google/genai": {
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.48.0.tgz",
+      "integrity": "sha512-plonYK4ML2PrxsRD9SeqmFt76eREWkQdPCglOA6aYDzL1AAbE+7PUnT54SvpWGfws13L0AZEqGSpL7+1IPnTxQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mariozechner/clipboard": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.2.tgz",
+      "integrity": "sha512-IHQpksNjo7EAtGuHFU+tbWDp5LarH3HU/8WiB9O70ZEoBPHOg0/6afwSLK0QyNMMmx4Bpi/zl6+DcBXe95nWYA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard-darwin-arm64": "0.3.2",
+        "@mariozechner/clipboard-darwin-universal": "0.3.2",
+        "@mariozechner/clipboard-darwin-x64": "0.3.2",
+        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.2",
+        "@mariozechner/clipboard-linux-arm64-musl": "0.3.2",
+        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.2",
+        "@mariozechner/clipboard-linux-x64-gnu": "0.3.2",
+        "@mariozechner/clipboard-linux-x64-musl": "0.3.2",
+        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.2",
+        "@mariozechner/clipboard-win32-x64-msvc": "0.3.2"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-darwin-arm64": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.2.tgz",
+      "integrity": "sha512-uBf6K7Je1ihsgvmWxA8UCGCeI+nbRVRXoarZdLjl6slz94Zs1tNKFZqx7aCI5O1i3e0B6ja82zZ06BWrl0MCVw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-darwin-universal": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.2.tgz",
+      "integrity": "sha512-mxSheKTW2U9LsBdXy0SdmdCAE5HqNS9QUmpNHLnfJ+SsbFKALjEZc5oRrVMXxGQSirDvYf5bjmRyT0QYYonnlg==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-darwin-x64": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.2.tgz",
+      "integrity": "sha512-U1BcVEoidvwIp95+HJswSW+xr28EQiHR7rZjH6pn8Sja5yO4Yoe3yCN0Zm8Lo72BbSOK/fTSq0je7CJpaPCspg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.2.tgz",
+      "integrity": "sha512-BsinwG3yWTIjdgNCxsFlip7LkfwPk+ruw/aFCXHUg/fb5XC/Ksp+YMQ7u0LUtiKzIv/7LMXgZInJQH6gxbAaqQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-linux-arm64-musl": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.2.tgz",
+      "integrity": "sha512-0/Gi5Xq2V6goXBop19ePoHvXsmJD9SzFlO3S+d6+T2b+BlPcpOu3Oa0wTjl+cZrLAAEzA86aPNBI+VVAFDFPKw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.2.tgz",
+      "integrity": "sha512-2AFFiXB24qf0zOZsxI1GJGb9wQGlOJyN6UwoXqmKS3dpQi/l6ix30IzDDA4c4ZcCcx4D+9HLYXhC1w7Sov8pXA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-linux-x64-gnu": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.2.tgz",
+      "integrity": "sha512-v6fVnsn7WMGg73Dab8QMwyFce7tzGfgEixKgzLP8f1GJqkJZi5zO4k4FOHzSgUufgLil63gnxvMpjWkgfeQN7A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-linux-x64-musl": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.2.tgz",
+      "integrity": "sha512-xVUtnoMQ8v2JVyfJLKKXACA6avdnchdbBkTsZs8BgJQo29qwCp5NIHAUO8gbJ40iaEGToW5RlmVk2M9V0HsHEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.2.tgz",
+      "integrity": "sha512-AEgg95TNi8TGgak2wSXZkXKCvAUTjWoU1Pqb0ON7JHrX78p616XUFNTJohtIon3e0w6k0pYPZeCuqRCza/Tqeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-win32-x64-msvc": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.2.tgz",
+      "integrity": "sha512-tGRuYpZwDOD7HBrCpyRuhGnHHSCknELvqwKKUG4JSfSB7JIU7LKRh6zx6fMUOQd8uISK35TjFg5UcNih+vJhFA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/jiti": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/@mariozechner/jiti/-/jiti-2.6.5.tgz",
+      "integrity": "sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==",
+      "license": "MIT",
+      "dependencies": {
+        "std-env": "^3.10.0",
+        "yoctocolors": "^2.1.2"
+      },
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/@mariozechner/pi-agent-core": {
+      "version": "0.65.0",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.65.0.tgz",
+      "integrity": "sha512-QCDqkgxvCkizCgJOl0aFekT1gURppznzuBIGXS8dXWZMour/xX6YF7chxX56mZ0p0DXkILM1ixf5jXYBfDsP5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@mariozechner/pi-ai": "^0.65.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@mariozechner/pi-ai": {
+      "version": "0.65.0",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.65.0.tgz",
+      "integrity": "sha512-MsCsCHlHIlBYbg6jB2PJBeCNKbjzVZge7ddBNUJN2gsFY8sdjFh482+GB+r5Ou6k9Fnhi3nO779YDymo5+t89w==",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.73.0",
+        "@aws-sdk/client-bedrock-runtime": "^3.983.0",
+        "@google/genai": "^1.40.0",
+        "@mistralai/mistralai": "1.14.1",
+        "@sinclair/typebox": "^0.34.41",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "chalk": "^5.6.2",
+        "openai": "6.26.0",
+        "partial-json": "^0.1.7",
+        "proxy-agent": "^6.5.0",
+        "undici": "^7.19.1",
+        "zod-to-json-schema": "^3.24.6"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@mariozechner/pi-coding-agent": {
+      "version": "0.65.0",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.65.0.tgz",
+      "integrity": "sha512-IEBZ74n17w8NxnG/X2ixErsSYcvLm/h5WKALNbPgPWJZqvafNtJ0GcrCfLCS6RVIq2o+O/a2QwsbSI6bgJ6W/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@mariozechner/jiti": "^2.6.2",
+        "@mariozechner/pi-agent-core": "^0.65.0",
+        "@mariozechner/pi-ai": "^0.65.0",
+        "@mariozechner/pi-tui": "^0.65.0",
+        "@silvia-odwyer/photon-node": "^0.3.4",
+        "ajv": "^8.17.1",
+        "chalk": "^5.5.0",
+        "cli-highlight": "^2.1.11",
+        "diff": "^8.0.2",
+        "extract-zip": "^2.0.1",
+        "file-type": "^21.1.1",
+        "glob": "^13.0.1",
+        "hosted-git-info": "^9.0.2",
+        "ignore": "^7.0.5",
+        "marked": "^15.0.12",
+        "minimatch": "^10.2.3",
+        "proper-lockfile": "^4.1.2",
+        "strip-ansi": "^7.1.0",
+        "undici": "^7.19.1",
+        "yaml": "^2.8.2"
+      },
+      "bin": {
+        "pi": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20.6.0"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard": "^0.3.2"
+      }
+    },
+    "node_modules/@mariozechner/pi-tui": {
+      "version": "0.65.0",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.65.0.tgz",
+      "integrity": "sha512-P5Uuf4x1sTplMNQw8NrC1Hyz0N/tZq9kC6CDRkTT7rZuxZEeXl9uhKvlLEGigdKVOVrWnPE7ip0jrO81POYy3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime-types": "^2.1.4",
+        "chalk": "^5.5.0",
+        "get-east-asian-width": "^1.3.0",
+        "marked": "^15.0.12",
+        "mime-types": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "koffi": "^2.9.0"
+      }
+    },
+    "node_modules/@mistralai/mistralai": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-1.14.1.tgz",
+      "integrity": "sha512-IiLmmZFCCTReQgPAT33r7KQ1nYo5JPdvGkrkZqA8qQ2qB1GHgs5LoP5K2ICyrjnpw2n8oSxMM/VP+liiKcGNlQ==",
+      "dependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "^3.24.1"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@silvia-odwyer/photon-node": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
+      "integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+      "license": "MIT"
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.4.13",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.13.tgz",
+      "integrity": "sha512-iIzMC5NmOUP6WL6o8iPBjFhUhBZ9pPjpUpQYWMUFQqKyXXzOftbfK8zcQCz/jFV1Psmf05BK5ypx4K2r4Tnwdg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.23.13",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.13.tgz",
+      "integrity": "sha512-J+2TT9D6oGsUVXVEMvz8h2EmdVnkBiy2auCie4aSJMvKlzUtO5hqjEzXhoCUkIMo7gAYjbQcN0g/MMSXEhDs1Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-stream": "^4.5.21",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.12.tgz",
+      "integrity": "sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.12.tgz",
+      "integrity": "sha512-FE3bZdEl62ojmy8x4FHqxq2+BuOHlcxiH5vaZ6aqHJr3AIZzwF5jfx8dEiU/X0a8RboyNDjmXjlbr8AdEyLgiA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-browser": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.12.tgz",
+      "integrity": "sha512-XUSuMxlTxV5pp4VpqZf6Sa3vT/Q75FVkLSpSSE3KkWBvAQWeuWt1msTv8fJfgA4/jcJhrbrbMzN1AC/hvPmm5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver": {
+      "version": "4.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.12.tgz",
+      "integrity": "sha512-7epsAZ3QvfHkngz6RXQYseyZYHlmWXSTPOfPmXkiS+zA6TBNo1awUaMFL9vxyXlGdoELmCZyZe1nQE+imbmV+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.12.tgz",
+      "integrity": "sha512-D1pFuExo31854eAvg89KMn9Oab/wEeJR6Buy32B49A9Ogdtx5fwZPqBHUlDzaCDpycTFk2+fSQgX689Qsk7UGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.12.tgz",
+      "integrity": "sha512-+yNuTiyBACxOJUTvbsNsSOfH9G9oKbaJE1lNL3YHpGcuucl6rPZMi3nrpehpVOVR2E07YqFFmtwpImtpzlouHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.3.15",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.15.tgz",
+      "integrity": "sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/querystring-builder": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.12.tgz",
+      "integrity": "sha512-QhBYbGrbxTkZ43QoTPrK72DoYviDeg6YKDrHTMJbbC+A0sml3kSjzFtXP7BtbyJnXojLfTQldGdUR0RGD8dA3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.12.tgz",
+      "integrity": "sha512-/4F1zb7Z8LOu1PalTdESFHR0RbPwHd3FcaG1sI3UEIriQTWakysgJr65lc1jj6QY5ye7aFsisajotH6UhWfm/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.12.tgz",
+      "integrity": "sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.4.28",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.28.tgz",
+      "integrity": "sha512-p1gfYpi91CHcs5cBq982UlGlDrxoYUX6XdHSo91cQ2KFuz6QloHosO7Jc60pJiVmkWrKOV8kFYlGFFbQ2WUKKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.13",
+        "@smithy/middleware-serde": "^4.2.16",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-middleware": "^4.2.12",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.4.46",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.46.tgz",
+      "integrity": "sha512-SpvWNNOPOrKQGUqZbEPO+es+FRXMWvIyzUKUOYdDgdlA6BdZj/R58p4umoQ76c2oJC44PiM7mKizyyex1IJzow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/service-error-classification": "^4.2.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.13",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.2.16",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.16.tgz",
+      "integrity": "sha512-beqfV+RZ9RSv+sQqor3xroUUYgRFCGRw6niGstPG8zO9LgTl0B0MCucxjmrH/2WwksQN7UUgI7KNANoZv+KALA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.13",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.12.tgz",
+      "integrity": "sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.12.tgz",
+      "integrity": "sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.1.tgz",
+      "integrity": "sha512-ejjxdAXjkPIs9lyYyVutOGNOraqUE9v/NjGMKwwFrfOM354wfSD8lmlj8hVwUzQmlLLF4+udhfCX9Exnbmvfzw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/querystring-builder": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.12.tgz",
+      "integrity": "sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.12.tgz",
+      "integrity": "sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.12.tgz",
+      "integrity": "sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.12.tgz",
+      "integrity": "sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.12.tgz",
+      "integrity": "sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.7.tgz",
+      "integrity": "sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.12.tgz",
+      "integrity": "sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.12.8",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.8.tgz",
+      "integrity": "sha512-aJaAX7vHe5i66smoSSID7t4rKY08PbD8EBU7DOloixvhOozfYWdcSYE4l6/tjkZ0vBZhGjheWzB2mh31sLgCMA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.13",
+        "@smithy/middleware-endpoint": "^4.4.28",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-stream": "^4.5.21",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
+      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.12.tgz",
+      "integrity": "sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.3.44",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.44.tgz",
+      "integrity": "sha512-eZg6XzaCbVr2S5cAErU5eGBDaOVTuTo1I65i4tQcHENRcZ8rMWhQy1DaIYUSLyZjsfXvmCqZrstSMYyGFocvHA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.2.48",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.48.tgz",
+      "integrity": "sha512-FqOKTlqSaoV3nzO55pMs5NBnZX8EhoI0DGmn9kbYeXWppgHD6dchyuj2HLqp4INJDJbSrj6OFYJkAh/WhSzZPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.3.tgz",
+      "integrity": "sha512-VACQVe50j0HZPjpwWcjyT51KUQ4AnsvEaQ2lKHOSL4mNLD0G9BjEniQ+yCt1qqfKfiAHRAts26ud7hBjamrwig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.12.tgz",
+      "integrity": "sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.13.tgz",
+      "integrity": "sha512-qQQsIvL0MGIbUjeSrg0/VlQ3jGNKyM3/2iU3FPNgy01z+Sp4OvcaxbgIoFOTvB61ZoohtutuOvOcgmhbD0katQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "4.5.21",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.21.tgz",
+      "integrity": "sha512-KzSg+7KKywLnkoKejRtIBXDmwBfjGvg1U1i/etkC7XSWUyFCoLno1IohV2c74IzQqdhX5y3uE44r/8/wuK+A7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/node-http-handler": "^4.5.1",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/uuid": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/mime-types": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
+      "integrity": "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
+      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "license": "MIT"
+    },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
+      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cli-highlight": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
+      "integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
+      "license": "ISC",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "highlight.js": "^10.7.1",
+        "mz": "^2.4.0",
+        "parse5": "^5.1.1",
+        "parse5-htmlparser2-tree-adapter": "^6.0.0",
+        "yargs": "^16.0.0"
+      },
+      "bin": {
+        "highlight": "bin/highlight"
+      },
+      "engines": {
+        "node": ">=8.0.0",
+        "npm": ">=5.0.0"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.5.8",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
+      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.2.0",
+        "strnum": "^2.2.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/get-uri/node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
+      "integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/koffi": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.15.4.tgz",
+      "integrity": "sha512-6l7xxt8heHWQ63WyGd8ofne4TrzhqeKHhvSlI3GnxMIHp3PlDrOPyZbW5YNINXNma1qrKkpM/PGLY8U0V8Hxbw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+      "license": "MIT"
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^6.0.1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+      "license": "MIT"
+    },
+    "node_modules/partial-json": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "license": "MIT"
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.1.tgz",
+      "integrity": "sha512-d7gQQmLvAKXKXE2GeP9apIGbMYKz88zWdsn/BN2HRWVQsDFdUY36WSLTY0Jvd4HWi7Fb30gQ62oAOzdgJA6fZw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
+    },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/proper-lockfile/node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
+      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/strtok3": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
+      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "bin": {
     "leeloo": "./leeloo.js"
   },
+  "dependencies": {
+    "@mariozechner/pi-coding-agent": ">=0.58.0",
+    "@mariozechner/pi-ai": ">=0.58.0"
+  },
   "description": "Multi-subscription extension for pi -- use multiple OAuth accounts per provider (Anthropic, Codex, Copilot, Gemini, Antigravity)",
   "keywords": [
     "pi-package",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "pi-multi-pass",
   "version": "1.3.0",
+  "type": "module",
+  "bin": {
+    "leeloo": "./leeloo.js"
+  },
   "description": "Multi-subscription extension for pi -- use multiple OAuth accounts per provider (Anthropic, Codex, Copilot, Gemini, Antigravity)",
   "keywords": [
     "pi-package",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "bin": {
     "leeloo": "./leeloo.js"
   },
+  "scripts": {
+    "start": "node leeloo.js",
+    "web-dev": "node --watch --watch-path=leeloo.js --watch-path=web --watch-preserve-output leeloo.js --port 4000"
+  },
   "dependencies": {
     "@mariozechner/pi-coding-agent": ">=0.58.0",
     "@mariozechner/pi-ai": ">=0.58.0"

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,453 @@
+# pi-multi-pass: routing v2 architecture plan
+
+Status: **draft**
+Date: 2026-04-06
+
+## Context
+
+This plan responds to Gabriel's feedback in PR #11. Quoting the gist:
+
+> One thing I noticed is that pools, at least in the way I understood them while testing, seem to be mostly centered around accounts of the same provider. That is definitely useful, but I am still unsure whether that is enough for the kind of routing I would want to do in practice.
+>
+> The simpler mental model I keep coming back to is something like this:
+> - **accounts**: the real access points
+> - **usage modes**: coding-premium, planning-budget, testing, ...
+> - **rules**: small reusable decision pieces (time windows, quota burn, context fit, ...)
+>
+> Then on each request the router would: start from the mode -> gather eligible candidates -> run rules -> rank -> try the best one -> on error re-evaluate.
+
+He's right. The current model is great at same-provider failover (10 OpenAI keys in a pool) but terrible at *cross-provider intent routing* (mix Anthropic + OpenAI + OpenRouter in one mode, prefer Anthropic during evening hours, burn expiring quotas first).
+
+We're not doing YAML. We are going to add a `.js` config option for power users while keeping JSON + admin UI for everyone else.
+
+## Current model vs target model
+
+### Current (v1)
+
+```
+subscriptions (extra OAuth accounts per provider)
+    │
+    ├─> pools (same-provider rotation, strategy: round-robin/quota-first/scheduled/custom)
+    │       │
+    │       └─> chains (ordered list of pools, static failover)
+    │               │
+    │               └─> presets (ordered list of provider/model entries)
+    │
+    └─> apiKeys (raw API keys, not grouped by provider)
+```
+
+Strategies are scoped to pools. Chains are static. Presets are dumb ordered lists.
+
+### Target (v2)
+
+```
+accounts (unified: subscriptions + apiKeys, any provider)
+    │
+    ├─> pools (still useful for same-provider rotation -- keep)
+    │
+    ├─> rules (reusable decision functions: time, quota, context, cost, custom JS)
+    │
+    ├─> modes (cross-provider intent routing: candidates + rules + onError)
+    │       │
+    │       └─> client-side virtual models
+    │
+    └─> presets (alias: mode + optional model preferences for clients)
+```
+
+Key shifts:
+1. **`accounts` is the new primitive** -- unifies subscriptions and apiKeys into one concept. A pool is a special case of "candidates that share a provider".
+2. **`rules` are first-class and reusable** -- not coupled to pools. A rule is a pure function that takes a list of candidates + context and returns a filtered/ranked list.
+3. **`modes` are the routing engine** -- they declare candidates (accounts, pools, or other modes) and a rule pipeline. The router walks the pipeline per request.
+4. **`presets` become client-facing aliases** -- they map a virtual model name (`coding-premium`) to a mode + optional preferred model list.
+
+## New concepts
+
+### Account
+
+Unifies `subscription` and `apiKey`:
+
+```js
+{
+  id: 'openai-main',          // unique ID, used everywhere
+  provider: 'openai-codex',   // base provider type
+  kind: 'subscription',       // 'subscription' (OAuth) or 'apiKey' (raw key)
+  label: 'My Codex Pro',      // human label
+  enabled: true,
+  // for kind=subscription: pi-multi-pass handles OAuth via authStorage
+  // for kind=apiKey:
+  key: 'sk-...',
+  baseUrl: 'https://api.openai.com/v1',  // optional, auto-inferred
+}
+```
+
+### Pool
+
+Same as today, but `members` reference `account.id` (not raw provider names):
+
+```js
+{
+  id: 'openai-shared',
+  members: ['openai-main', 'openai-alt'],
+  strategy: 'round-robin' | 'quota-first' | 'scheduled' | 'custom',
+  // strategy stays useful for same-provider failover
+}
+```
+
+### Rule
+
+A rule is a pure function that takes `(candidates, context)` and returns a list of candidates with optional ordering hints (priority scores). Rules can:
+
+- **filter**: remove candidates from the list
+- **rank**: assign scores to reorder candidates
+- **annotate**: add metadata used by other rules
+
+```js
+{
+  id: 'prefer-anthropic-evening',
+  type: 'time-window',           // built-in type
+  description: 'Prefer Anthropic during evening hours',
+  params: {
+    targets: ['anthropic-shared'],
+    windows: [
+      { days: ['mon','tue','wed','thu','fri'], hours: [18, 23], tz: 'Europe/Vienna' },
+    ],
+    boost: 100,                  // priority boost when active
+  },
+}
+```
+
+### Built-in rule types (proposed)
+
+| Type | Purpose | Params |
+|---|---|---|
+| `time-window` | Boost certain accounts during time windows (discount hours, off-peak, etc.) | targets, windows, boost |
+| `quota-burn` | Prefer accounts whose quota window expires sooner (use it before you lose it) | targets? |
+| `quota-first` | Prefer accounts with the most remaining quota | targets? |
+| `cost-tier` | Prefer cheap/free options for simple work | targets, costMap |
+| `model-fit` | Demote candidates that can't handle the request size or capability | minContext, requireTools, requireVision |
+| `context-fit` | Demote candidates whose context window is too small for the prompt | -- |
+| `error-blacklist` | Skip candidates that errored in the recent history | window |
+| `cooldown` | Skip exhausted candidates (current behavior) | -- |
+| `custom` | Run a JS function | code (path) or fn (inline in JS config) |
+
+### Mode
+
+A mode declares a routing pipeline:
+
+```js
+{
+  id: 'coding-premium',
+  description: 'Best quality coding mode',
+  candidates: ['openai-shared', 'anthropic-shared', 'copilot-main', 'openrouter-main'],
+  // candidates can reference: account.id, pool.id, or other mode.id
+  rules: [
+    'avoid-bad-context-fit',
+    'prefer-anthropic-evening',
+    'burn-expiring-quotas-first',
+  ],
+  onError: 're-evaluate',  // 're-evaluate' | 'next-in-order' | 'fail-fast'
+}
+```
+
+The router pipeline for each request:
+
+```
+1. Resolve mode.candidates -> flat list of accounts (expand pools and nested modes)
+2. Filter out unavailable (no auth, exhausted, disabled)
+3. For each rule in mode.rules (in order):
+     candidates = rule.apply(candidates, context)
+4. Sort by score (descending)
+5. Try the top candidate
+6. On error:
+     - record error in context.history
+     - if onError === 're-evaluate': go to step 3 (rules see the new error)
+     - if onError === 'next-in-order': try next candidate from step 4 list
+     - if onError === 'fail-fast': return error
+```
+
+### Preset
+
+Becomes a client-facing alias:
+
+```js
+{
+  id: 'coding-premium',                   // virtual model name in OpenAI API
+  mode: 'coding-premium',                 // which mode to use for routing
+  preferredModels: [                       // optional: ranked list of model IDs
+    'gpt-5.4',
+    'claude-opus',
+    'gemini-3-pro',
+  ],
+  fallbackModels: [                        // try these if no preferred is available
+    'claude-sonnet-4',
+    'o3',
+  ],
+}
+```
+
+When a client sends `model: "coding-premium"`:
+1. Resolve preset -> mode
+2. Run mode pipeline to get top candidate (account)
+3. Pick the highest-priority preferred model that the candidate supports
+4. Send the request
+
+This is the cross-provider intent routing Gabriel wants.
+
+## Config formats
+
+We support **two equivalent formats** with the same loader:
+
+### Format 1: JSON (existing, admin UI editable)
+
+`~/.pi/agent/multi-pass.json` -- new shape:
+
+```json
+{
+  "accounts": [
+    { "id": "openai-main", "provider": "openai-codex", "kind": "subscription" },
+    { "id": "openrouter-main", "provider": "openrouter", "kind": "apiKey", "key": "sk-or-..." }
+  ],
+  "pools": [
+    { "id": "openai-shared", "members": ["openai-main", "openai-alt"], "strategy": "round-robin" }
+  ],
+  "rules": [
+    {
+      "id": "prefer-anthropic-evening",
+      "type": "time-window",
+      "params": { "targets": ["anthropic-shared"], "windows": [{ "days": ["mon-fri"], "hours": [18, 23] }], "boost": 100 }
+    }
+  ],
+  "modes": [
+    {
+      "id": "coding-premium",
+      "candidates": ["openai-shared", "anthropic-shared"],
+      "rules": ["prefer-anthropic-evening", "burn-expiring-quotas-first"],
+      "onError": "re-evaluate"
+    }
+  ],
+  "presets": [
+    { "id": "coding-premium", "mode": "coding-premium", "preferredModels": ["claude-opus", "gpt-5.4"] }
+  ]
+}
+```
+
+Migration: existing `subscriptions` + `apiKeys` are auto-converted to `accounts` on first load. Existing `pools` keep working but `members` references switch to account IDs.
+
+### Format 2: JavaScript (new, power user)
+
+`~/.pi/agent/multi-pass.config.js` -- if present, used instead of JSON:
+
+```js
+import { defineConfig, rule, mode, preset, account, pool } from "pi-multi-pass/config";
+
+export default defineConfig({
+  accounts: [
+    account("openai-main", { provider: "openai-codex", kind: "subscription" }),
+    account("openrouter", {
+      provider: "openrouter",
+      kind: "apiKey",
+      key: process.env.OPENROUTER_KEY,  // computed at startup
+    }),
+  ],
+
+  pools: [
+    pool("openai-shared", { members: ["openai-main", "openai-alt"], strategy: "round-robin" }),
+  ],
+
+  rules: [
+    rule.timeWindow("prefer-anthropic-evening", {
+      targets: ["anthropic-shared"],
+      windows: [{ days: ["mon-fri"], hours: [18, 23], tz: "Europe/Vienna" }],
+      boost: 100,
+    }),
+
+    rule.quotaBurn("burn-expiring-first"),
+
+    rule.costTier("prefer-cheap", {
+      targets: ["openrouter", "copilot-main"],
+      costMap: { "gpt-4o": 0.005, "claude-haiku": 0.001 },
+    }),
+
+    // Inline custom rule -- no separate file needed
+    rule.custom("avoid-personal-models", async (candidates, ctx) => {
+      if (ctx.userTag === "team") return candidates;
+      return candidates.filter((c) => !c.id.includes("personal"));
+    }),
+  ],
+
+  modes: [
+    mode("coding-premium", {
+      candidates: ["openai-shared", "anthropic-shared", "copilot-main"],
+      rules: ["avoid-bad-context-fit", "prefer-anthropic-evening", "burn-expiring-first"],
+      onError: "re-evaluate",
+    }),
+
+    mode("coding-budget", {
+      candidates: ["openrouter", "copilot-main", "openai-shared"],
+      rules: ["prefer-cheap", "burn-expiring-first"],
+      onError: "re-evaluate",
+    }),
+  ],
+
+  presets: [
+    preset("coding-premium", {
+      mode: "coding-premium",
+      preferredModels: ["claude-opus", "gpt-5.4", "gemini-3-pro"],
+      fallbackModels: ["claude-sonnet-4", "o3"],
+    }),
+  ],
+});
+```
+
+**Why JS over YAML:**
+- Native types and IntelliSense (`.d.ts` for the helpers)
+- Computed values (env vars, conditionals, imports)
+- Custom rules can be inline functions (no separate `code: ./path` files)
+- Composability via JS imports (split rules across files, share between projects)
+- Validation at module load (errors caught immediately)
+- No new parser dependency (Node already runs JS)
+
+**Loader behavior:**
+1. If `multi-pass.config.js` exists -> import it, use the exported config
+2. Else if `multi-pass.json` exists -> load JSON
+3. Resolve to a normalized in-memory shape (same internal type for both)
+4. Compile rules: built-in types -> built-in implementations; `rule.custom()` -> store the function reference
+
+**Admin UI behavior with JS config:**
+- JSON config: full read/write in admin
+- JS config detected: admin shows banner "JS config detected at ~/.pi/agent/multi-pass.config.js -- editing disabled". Tabs become read-only viewers.
+- Power users own their config, casual users get the GUI.
+
+## Routing pipeline implementation
+
+Replace the current `resolveCandidates` function with a new `routeRequest`:
+
+```js
+async function routeRequest(modelOrPresetId, requestContext) {
+  // requestContext: { messages, tools, user, request, history: [], lastError? }
+
+  // 1. Resolve preset -> mode (or treat as direct mode/pool/account ref)
+  const mode = resolveMode(modelOrPresetId);
+  if (!mode) return resolveLegacyCandidates(modelOrPresetId);
+
+  // 2. Gather candidates (expand pools and nested modes recursively)
+  let candidates = expandCandidates(mode.candidates);
+
+  // 3. Filter unavailable
+  candidates = candidates.filter((c) => isAccountAvailable(c.id));
+
+  // 4. Apply rule pipeline
+  for (const ruleId of mode.rules) {
+    const rule = getRule(ruleId);
+    candidates = await rule.apply(candidates, requestContext);
+  }
+
+  // 5. Sort by score
+  candidates.sort((a, b) => (b.score || 0) - (a.score || 0));
+
+  // 6. Try in order, with error feedback
+  for (const candidate of candidates) {
+    try {
+      return await tryCandidate(candidate, requestContext);
+    } catch (err) {
+      requestContext.history.push({ candidate: candidate.id, error: err.message });
+      requestContext.lastError = err;
+
+      if (mode.onError === "re-evaluate") {
+        // restart from step 4 -- rules see the new error context
+        return routeRequest(modelOrPresetId, requestContext);
+      }
+      // 'next-in-order': just continue the loop
+      // 'fail-fast': throw
+      if (mode.onError === "fail-fast") throw err;
+    }
+  }
+
+  throw new Error(`All candidates exhausted for ${modelOrPresetId}`);
+}
+```
+
+## Migration path
+
+We don't break existing users. Phased rollout:
+
+### Phase A: parallel models (no breaking changes)
+- Add `accounts`, `rules`, `modes` to config schema
+- Existing `subscriptions` and `apiKeys` auto-convert to `accounts` at load time
+- New routing pipeline runs only for IDs that resolve as a `mode` or new-style `preset`
+- Old `chains` and old-style `presets` keep using current code path
+- New admin tab: **Routing** with rule/mode editor (separate from existing tabs)
+
+### Phase B: bridge old to new
+- Old pool strategies (`scheduled`, `quota-first`) become rule types under the hood
+- Old `chains` are auto-translated to a generated mode
+- Admin UI surfaces both old and new editors side by side
+- Docs encourage new model
+
+### Phase C: deprecate old shape
+- Show deprecation warning when old `subscriptions`/`chains` keys are used in JSON
+- Provide a `multi-pass migrate` CLI command that converts JSON to v2 shape
+- Old admin tabs marked "(legacy)"
+- Default new installs to v2 shape
+
+### Phase D: remove legacy (optional, far future)
+- Drop support for old `subscriptions`/`chains` keys
+- Loaders error out with migration instructions
+
+## Admin UI changes
+
+### New tabs / sections in `/admin -> Config`
+
+| Section | Replaces / adds |
+|---|---|
+| **Accounts** | Unified replacement for OAuth + API keys panels (unified list, kind dropdown) |
+| **Pools** | Existing, but member dropdowns reference account IDs |
+| **Rules** | NEW -- create rules from built-in types (time-window, quota-burn, cost-tier, etc.) with form per type |
+| **Modes** | NEW -- candidate picker (accounts/pools/modes), rule list (drag-to-reorder), onError dropdown |
+| **Presets** | Updated -- mode picker + preferredModels chip list + fallbackModels |
+
+### Read-only mode for JS config
+
+When `multi-pass.config.js` exists:
+- Banner at top: "Config from JS file. Edits disabled."
+- All edit/save/delete buttons hidden
+- Tabs work as visualizers showing the resolved config
+
+## Things I'm still unsure about
+
+These mirror Gabriel's open questions:
+
+1. **Mode vs preset overlap.** Should preferred/fallback models live in the mode or the preset? Right now the plan puts them in the preset (client-facing) but it's reasonable to argue they're a routing concern (mode).
+
+2. **Rule order matters.** Should rules be a sorted list (current plan) or should each rule declare its phase (filter/rank/annotate)? The phased approach is cleaner but more verbose.
+
+3. **Error context handover.** When `onError: re-evaluate` runs, how rich is the context the rules see? Do we expose the full error stack, the http status, the provider name, the prompt, the user history?
+
+4. **Custom rules in JSON config.** We can express most things via built-in rule types in JSON, but custom JS rules require... a path to a file (current pool selectorScript pattern). Is that good enough or do JS-config-only features become a real divergence?
+
+5. **Pools as a special case of modes.** Long term, do pools just become a built-in `same-provider-failover` rule? That would simplify the model.
+
+## Phased implementation checklist
+
+- [ ] **Phase 1 (this PR)**: design doc, no code yet. Get sign-off on shape.
+- [ ] **Phase 2**: implement loader for both JSON and JS config formats. Compile to internal normalized shape. No routing changes.
+- [ ] **Phase 3**: implement built-in rules (start with `time-window`, `quota-burn`, `cooldown`, `model-fit`, `cost-tier`).
+- [ ] **Phase 4**: implement mode + routing pipeline. Run alongside existing routing for backward compat.
+- [ ] **Phase 5**: implement custom JS rule support (in JS config: inline functions; in JSON: file path).
+- [ ] **Phase 6**: admin UI: Accounts panel (replaces OAuth + API keys).
+- [ ] **Phase 7**: admin UI: Rules panel with form per built-in type.
+- [ ] **Phase 8**: admin UI: Modes panel (candidates + rules + onError).
+- [ ] **Phase 9**: admin UI: updated Presets panel (mode picker, preferred/fallback models).
+- [ ] **Phase 10**: JS config detection + read-only admin mode.
+- [ ] **Phase 11**: migration helper (CLI + automatic on first load).
+- [ ] **Phase 12**: docs update + examples (v2 quickstart, JS config example, rule cookbook).
+
+## Open question for Gabriel
+
+Two things I'd like sanity-checked before we start coding:
+
+1. **Mode candidates can include other modes** (composition). Would you actually use this, or is it overkill? Example: a `coding-premium` mode could be `candidates: ['coding-premium-paid', 'coding-budget']` so it falls through to the cheaper mode if all paid candidates fail.
+
+2. **Rules return ranked candidates with scores, not just filtered lists.** This lets multiple rules cooperate (rule A boosts Anthropic, rule B boosts cheap, final score is sum). Is that the right primitive, or would `filter -> sort` (binary in/out) be simpler?
+
+If you have time to react before we start phase 2, that'd help shape the API surface.

--- a/plan.md
+++ b/plan.md
@@ -442,12 +442,45 @@ These mirror Gabriel's open questions:
 - [ ] **Phase 11**: migration helper (CLI + automatic on first load).
 - [ ] **Phase 12**: docs update + examples (v2 quickstart, JS config example, rule cookbook).
 
-## Open question for Gabriel
+## Decisions on the open questions
 
-Two things I'd like sanity-checked before we start coding:
+Both questions resolved without waiting -- the answers are clear and we can iterate later if real use shows otherwise.
 
-1. **Mode candidates can include other modes** (composition). Would you actually use this, or is it overkill? Example: a `coding-premium` mode could be `candidates: ['coding-premium-paid', 'coding-budget']` so it falls through to the cheaper mode if all paid candidates fail.
+### Q1: Mode composition -- YES
 
-2. **Rules return ranked candidates with scores, not just filtered lists.** This lets multiple rules cooperate (rule A boosts Anthropic, rule B boosts cheap, final score is sum). Is that the right primitive, or would `filter -> sort` (binary in/out) be simpler?
+`mode.candidates` accepts account IDs, pool IDs, AND other mode IDs.
 
-If you have time to react before we start phase 2, that'd help shape the API surface.
+Rules:
+- Inner mode's **candidates** flatten into the outer mode's candidate list
+- Inner mode's **rules** do NOT propagate (the outer mode owns the pipeline)
+- Cycles detected at config load time and rejected with a clear error
+- Max nesting depth: 5
+
+Example use case (Gabriel's pattern):
+```js
+mode("coding-premium", { candidates: ["openai-shared", "anthropic-shared", "coding-budget"], ... })
+mode("coding-budget", { candidates: ["openrouter", "copilot-main"], ... })
+```
+When `coding-premium` exhausts paid options, the outer pipeline reaches the candidates pulled in from `coding-budget`. No special "fallback chain" concept needed.
+
+### Q2: Scored rules + filtering -- BOTH
+
+Rules return `{ candidates, scores }`:
+- **Filter**: shrink the `candidates` array (binary in/out)
+- **Score**: add entries to the `scores` map (additive, multiple rules can boost the same candidate)
+- **Annotate**: attach metadata to a per-request context (other rules read it)
+
+The router accumulates scores across all rules, sorts the final candidates by total score (descending), then tries them in order.
+
+Default score for unscored candidates: 0. Negative scores allowed (deboost).
+
+Built-in rule defaults:
+- `time-window` -> scores (boosts targets)
+- `quota-burn` -> scores (higher score for sooner-expiring quota)
+- `cost-tier` -> scores (higher score for cheaper options)
+- `cooldown` -> filters (removes exhausted)
+- `model-fit` -> filters (removes too-small context)
+- `error-blacklist` -> filters (removes recent errors)
+- `custom` -> can do any combination
+
+This gives us simple filters when you want strict in/out and scoring when you want soft preferences. They compose without ceremony.

--- a/web/admin/app.js
+++ b/web/admin/app.js
@@ -740,7 +740,7 @@ function UsersPanel() {
   const { names } = useNames();
 
   // Form state (shared for create + edit)
-  const [draft, setDraft] = useState({ username: "", allowedPresets: [], allowedPools: [] });
+  const [draft, setDraft] = useState({ username: "", allowedPresets: [], allowedPools: [], budgets: {} });
 
   async function load() {
     try { setUsers((await api("/v1/users")).users || []); } catch {}
@@ -748,18 +748,25 @@ function UsersPanel() {
   }
   useEffect(() => { load(); }, []);
 
-  function startNew() { setEditing("__new__"); setDraft({ username: "", allowedPresets: [], allowedPools: [] }); setShowForm(true); }
-  function startEdit(u) { setEditing(u.username); setDraft({ username: u.username, allowedPresets: u.allowedPresets || [], allowedPools: u.allowedPools || [] }); setShowForm(true); }
+  function startNew() { setEditing("__new__"); setDraft({ username: "", allowedPresets: [], allowedPools: [], budgets: {} }); setShowForm(true); }
+  function startEdit(u) { setEditing(u.username); setDraft({ username: u.username, allowedPresets: u.allowedPresets || [], allowedPools: u.allowedPools || [], budgets: u.budgets || {} }); setShowForm(true); }
   function cancelForm() { setShowForm(false); setEditing(null); }
 
   async function save() {
     setBusy(true);
     try {
+      const payload = { allowedPresets: draft.allowedPresets, allowedPools: draft.allowedPools };
+      const b = {};
+      if (draft.budgets.daily_tokens) b.daily_tokens = parseInt(draft.budgets.daily_tokens) || 0;
+      if (draft.budgets.monthly_tokens) b.monthly_tokens = parseInt(draft.budgets.monthly_tokens) || 0;
+      if (Object.keys(b).length > 0) payload.budgets = b;
+      else payload.budgets = null;
+
       if (editing === "__new__") {
-        const res = await api("/v1/users", jpost({ username: draft.username || `user-${Date.now()}`, allowedPresets: draft.allowedPresets, allowedPools: draft.allowedPools }));
+        const res = await api("/v1/users", jpost({ username: draft.username || `user-${Date.now()}`, ...payload }));
         setRevealedKeys((k) => ({ ...k, [res.user.username]: res.user.key }));
       } else {
-        await api(`/v1/users/${encodeURIComponent(editing)}`, jput({ allowedPresets: draft.allowedPresets, allowedPools: draft.allowedPools }));
+        await api(`/v1/users/${encodeURIComponent(editing)}`, jput(payload));
       }
       cancelForm();
       await load();
@@ -834,6 +841,14 @@ function UsersPanel() {
             onChange=${(v) => setDraft({ ...draft, allowedPools: v })}
             emptyText="No restrictions -- all pools allowed"
           />
+          <div>
+            <label>Daily token budget (0 = unlimited)</label>
+            <input type="number" value=${draft.budgets?.daily_tokens || ""} onInput=${(e) => setDraft({ ...draft, budgets: { ...draft.budgets, daily_tokens: e.target.value } })} placeholder="e.g. 500000" />
+          </div>
+          <div>
+            <label>Monthly token budget (0 = unlimited)</label>
+            <input type="number" value=${draft.budgets?.monthly_tokens || ""} onInput=${(e) => setDraft({ ...draft, budgets: { ...draft.budgets, monthly_tokens: e.target.value } })} placeholder="e.g. 10000000" />
+          </div>
         </div>
         <div className="actions" style=${{ marginTop: "10px" }}><button className="btn primary" onClick=${save} disabled=${busy}>${isNew ? "Create" : "Save"}</button><button className="btn" onClick=${cancelForm}>Cancel</button></div>
       </div>
@@ -879,13 +894,31 @@ function UsersPanel() {
             </div>
           </div>
           ${us ? html`
-            <div className="meta" style=${{ marginTop: "6px", display: "flex", gap: "16px" }}>
+            <div className="meta" style=${{ marginTop: "6px", display: "flex", gap: "16px", flexWrap: "wrap", alignItems: "center" }}>
               <span>${us.requests} requests</span>
               <span>${us.tokens_in} tokens in</span>
               <span>${us.tokens_out} tokens out</span>
               <span>${us.errors} errors</span>
               <span>last: ${ago(us.last_used)}</span>
             </div>
+            ${us.budgets ? html`
+              <div style=${{ marginTop: "6px", display: "flex", gap: "12px", flexWrap: "wrap" }}>
+                ${us.budgets.daily_tokens ? html`
+                  <div style=${{ fontSize: "11px", display: "flex", alignItems: "center", gap: "6px" }}>
+                    <span style=${{ color: "#71717a" }}>daily:</span>
+                    <span className="q-bar" style=${{ width: "60px" }}><span className="q-fill" style=${{ width: `${Math.min(100, Math.round((us.daily_tokens || 0) / us.budgets.daily_tokens * 100))}%`, background: qColor(100 - Math.min(100, Math.round((us.daily_tokens || 0) / us.budgets.daily_tokens * 100))) }} /></span>
+                    <span style=${{ color: (us.daily_tokens || 0) >= us.budgets.daily_tokens ? "#ef4444" : "#a1a1aa" }}>${(us.daily_tokens || 0).toLocaleString()} / ${us.budgets.daily_tokens.toLocaleString()}</span>
+                  </div>
+                ` : null}
+                ${us.budgets.monthly_tokens ? html`
+                  <div style=${{ fontSize: "11px", display: "flex", alignItems: "center", gap: "6px" }}>
+                    <span style=${{ color: "#71717a" }}>monthly:</span>
+                    <span className="q-bar" style=${{ width: "60px" }}><span className="q-fill" style=${{ width: `${Math.min(100, Math.round((us.monthly_tokens || 0) / us.budgets.monthly_tokens * 100))}%`, background: qColor(100 - Math.min(100, Math.round((us.monthly_tokens || 0) / us.budgets.monthly_tokens * 100))) }} /></span>
+                    <span style=${{ color: (us.monthly_tokens || 0) >= us.budgets.monthly_tokens ? "#ef4444" : "#a1a1aa" }}>${(us.monthly_tokens || 0).toLocaleString()} / ${us.budgets.monthly_tokens.toLocaleString()}</span>
+                  </div>
+                ` : null}
+              </div>
+            ` : null}
           ` : null}
         </div>
       `;
@@ -969,10 +1002,10 @@ function LoginScreen({ onLogin }) {
 
   return html`
     <div style=${{ display: "flex", alignItems: "center", justifyContent: "center", height: "100vh", background: "#09090b" }}>
-      <div style=${{ width: "340px", padding: "32px", background: "#18181b", border: "1px solid #27272a", borderRadius: "16px" }}>
-        <h2 style=${{ color: "#f59e0b", fontSize: "18px", fontWeight: 700, marginBottom: "4px" }}>Leeloo Admin</h2>
-        <p style=${{ color: "#52525b", fontSize: "13px", marginBottom: "20px" }}>Enter the admin token to continue.</p>
-        <input type="password" value=${token} onInput=${(e) => setToken(e.target.value)} onKeyDown=${(e) => { if (e.key === "Enter") submit(); }} placeholder="Admin token..." style=${{ width: "100%", marginBottom: "10px" }} autoFocus />
+      <div className="login-card">
+        <h2>Leeloo Admin</h2>
+        <p>Enter the admin token to continue.</p>
+        <input type="password" value=${token} onInput=${(e) => setToken(e.target.value)} onKeyDown=${(e) => { if (e.key === "Enter") submit(); }} placeholder="Admin token..." style=${{ width: "100%", marginBottom: "12px" }} autoFocus />
         ${error ? html`<div style=${{ color: "#ef4444", fontSize: "12px", marginBottom: "8px" }}>${error}</div>` : null}
         <button className="btn primary" onClick=${submit} disabled=${busy} style=${{ width: "100%" }}>${busy ? "Verifying..." : "Login"}</button>
       </div>

--- a/web/admin/app.js
+++ b/web/admin/app.js
@@ -113,28 +113,34 @@ function AuthPanel({ onRefresh, reloadNames }) {
   }
   useEffect(() => { loadProviders(); }, []);
 
-  async function startLogin(providerId) {
-    setBusy((b) => ({ ...b, [providerId]: "connecting..." }));
+  // startLogin: oauthProvider = the base provider to run OAuth against
+  //             storeAs = the name to store credentials under (for new subscriptions)
+  async function startLogin(oauthProvider, storeAs) {
+    const trackId = storeAs || oauthProvider;
+    setBusy((b) => ({ ...b, [trackId]: "connecting..." }));
     try {
-      const res = await api(`/v1/auth/login/${encodeURIComponent(providerId)}`, { method: "POST" });
+      const qs = storeAs ? `?storeAs=${encodeURIComponent(storeAs)}` : "";
+      const res = await api(`/v1/auth/login/${encodeURIComponent(oauthProvider)}${qs}`, { method: "POST" });
       if (res.authUrl) {
         window.open(res.authUrl, "_blank");
-        setBusy((b) => ({ ...b, [providerId]: "waiting for browser..." }));
-        pollLogin(providerId);
+        setBusy((b) => ({ ...b, [trackId]: "waiting for browser..." }));
+        pollLogin(oauthProvider, storeAs);
       }
     } catch (e) {
-      setBusy((b) => ({ ...b, [providerId]: `error: ${e.message}` }));
-      setTimeout(() => setBusy((b) => { const n = { ...b }; delete n[providerId]; return n; }), 3000);
+      setBusy((b) => ({ ...b, [trackId]: `error: ${e.message}` }));
+      setTimeout(() => setBusy((b) => { const n = { ...b }; delete n[trackId]; return n; }), 3000);
     }
   }
 
-  async function pollLogin(providerId) {
+  async function pollLogin(oauthProvider, storeAs) {
+    const trackId = storeAs || oauthProvider;
     for (let i = 0; i < 120; i++) {
       await new Promise((r) => setTimeout(r, 2000));
       try {
-        const s = await api(`/v1/auth/login/${encodeURIComponent(providerId)}`);
+        const qs = storeAs ? `?storeAs=${encodeURIComponent(storeAs)}` : "";
+        const s = await api(`/v1/auth/login/${encodeURIComponent(oauthProvider)}${qs}`);
         if (s.status === "authenticated" || s.hasAuth) {
-          setBusy((b) => { const n = { ...b }; delete n[providerId]; return n; });
+          setBusy((b) => { const n = { ...b }; delete n[trackId]; return n; });
           await loadProviders();
           if (reloadNames) reloadNames();
           if (onRefresh) onRefresh();
@@ -142,7 +148,7 @@ function AuthPanel({ onRefresh, reloadNames }) {
         }
       } catch {}
     }
-    setBusy((b) => ({ ...b, [providerId]: "timed out" }));
+    setBusy((b) => ({ ...b, [trackId]: "timed out" }));
   }
 
   async function logout(providerId) {
@@ -156,19 +162,19 @@ function AuthPanel({ onRefresh, reloadNames }) {
   }
 
   async function addAccount() {
-    const name = newName.trim() || `${newBase}-${Date.now()}`;
+    const name = newName.trim() || `${newBase}-2`;
+    const subId = `${newBase}-${name}`;
     setBusy((b) => ({ ...b, __new__: "creating..." }));
     try {
       // 1. Create subscription entry
       await api("/v1/config/subscriptions", jpost({ name, provider: newBase, enabled: true, alias: name }));
-      // 2. Start OAuth login for the new subscription name
       setShowAdd(false);
       setNewName("");
       if (onRefresh) onRefresh();
       if (reloadNames) reloadNames();
       await loadProviders();
-      // 3. Auto-start login for the new account (use base provider OAuth since it shares the flow)
-      startLogin(newBase);
+      // 2. Start OAuth for base provider, store credentials under the subscription ID
+      startLogin(newBase, subId);
     } catch (e) {
       setBusy((b) => ({ ...b, __new__: `error: ${e.message}` }));
     }
@@ -206,7 +212,7 @@ function AuthPanel({ onRefresh, reloadNames }) {
             ${busy[p.id]
               ? html`<span style=${{ fontSize: "12px", color: "#f59e0b" }}>${busy[p.id]}</span>`
               : html`
-                <button className="btn primary" onClick=${() => startLogin(p.isBuiltin ? p.id : p.baseProvider)}>${p.authenticated ? "Re-login" : "Login"}</button>
+                <button className="btn primary" onClick=${() => startLogin(p.baseProvider || p.id, p.isBuiltin ? null : p.id)}>${p.authenticated ? "Re-login" : "Login"}</button>
                 ${p.authenticated ? html`<button className="btn danger" onClick=${() => logout(p.id)}>Logout</button>` : null}
               `}
           </div>

--- a/web/admin/app.js
+++ b/web/admin/app.js
@@ -7,9 +7,14 @@ const html = htm.bind(React.createElement);
 const BASE = location.origin;
 const STRATEGIES = ["round-robin", "quota-first", "scheduled", "custom"];
 const BASE_PROVIDERS = ["anthropic", "openai-codex", "github-copilot", "google-gemini-cli", "google-antigravity"];
+const TOKEN_KEY = "leeloo.token";
+
+function getToken() { return localStorage.getItem(TOKEN_KEY) || ""; }
 
 async function api(path, init) {
-  const r = await fetch(`${BASE}${path}`, init);
+  const headers = { ...(init?.headers || {}), Authorization: `Bearer ${getToken()}` };
+  const r = await fetch(`${BASE}${path}`, { ...init, headers });
+  if (r.status === 401) { localStorage.removeItem(TOKEN_KEY); location.reload(); throw new Error("Session expired"); }
   if (!r.ok) { const e = await r.json().catch(() => ({})); throw new Error(e?.error?.message || `HTTP ${r.status}`); }
   return r.json();
 }
@@ -142,10 +147,19 @@ function DashboardPanel({ data }) {
         return html`<tr key=${p.provider}><td style=${{ color: "#fafafa", fontWeight: 500 }}>${p.label || p.provider}</td><td><${QuotaBar} score=${p.score} /> <span style=${{ color: qColor(p.score) }}>${p.score == null ? "?" : `${p.score}%`}</span></td><td>${statusBadge}</td><td>${ps.requests || 0}</td><td>${ps.tokens_in || 0} / ${ps.tokens_out || 0}</td><td>${ago(ps.last_used)}</td></tr>`;
       })}</tbody>
     </table></div>
+    ${(data?.stats?.users || []).length > 0 ? html`
+      <h2 className="mt">Per-user usage</h2>
+      <div className="table-wrap"><table>
+        <thead><tr><th>User</th><th>Requests</th><th>Tokens in</th><th>Tokens out</th><th>Errors</th><th>Last used</th></tr></thead>
+        <tbody>${(data.stats.users || []).map((u) => html`
+          <tr key=${u.username}><td style=${{ fontWeight: 500, color: "#fafafa" }}>${u.username}</td><td>${u.requests}</td><td>${u.tokens_in}</td><td>${u.tokens_out}</td><td>${u.errors}</td><td>${ago(u.last_used)}</td></tr>
+        `)}</tbody>
+      </table></div>
+    ` : null}
     <h2 className="mt">Recent chats</h2>
     <div className="table-wrap"><table>
-      <thead><tr><th>Time</th><th>Provider</th><th>Model</th><th>Tokens</th><th>Duration</th><th>Error</th><th>Request</th><th>Response</th></tr></thead>
-      <tbody>${recent.length === 0 ? html`<tr><td colSpan="8" className="empty">No requests yet.</td></tr>` : recent.slice(0, 50).map((r, i) => html`<tr key=${i}><td>${ago(r.timestamp)}</td><td>${r.provider}</td><td style=${{ fontFamily: "monospace", fontSize: "11px" }}>${r.model}</td><td>${r.tokens_in} / ${r.tokens_out}</td><td>${r.duration_ms}ms</td><td>${r.error ? html`<span style=${{ color: "#ef4444" }}>${r.error}</span>` : "--"}</td><td>${r.request_text ? html`<details><summary>${r.request_text.slice(0, 40)}...</summary><pre>${r.request_text}</pre></details>` : "--"}</td><td>${r.response_text ? html`<details><summary>${r.response_text.slice(0, 40)}...</summary><pre>${r.response_text}</pre></details>` : "--"}</td></tr>`)}</tbody>
+      <thead><tr><th>Time</th><th>User</th><th>Provider</th><th>Model</th><th>Tokens</th><th>Duration</th><th>Error</th><th>Request</th><th>Response</th></tr></thead>
+      <tbody>${recent.length === 0 ? html`<tr><td colSpan="9" className="empty">No requests yet.</td></tr>` : recent.slice(0, 50).map((r, i) => html`<tr key=${i}><td>${ago(r.timestamp)}</td><td>${r.user || "--"}</td><td>${r.provider}</td><td style=${{ fontFamily: "monospace", fontSize: "11px" }}>${r.model}</td><td>${r.tokens_in} / ${r.tokens_out}</td><td>${r.duration_ms}ms</td><td>${r.error ? html`<span style=${{ color: "#ef4444" }}>${r.error}</span>` : "--"}</td><td>${r.request_text ? html`<details><summary>${r.request_text.slice(0, 40)}...</summary><pre>${r.request_text}</pre></details>` : "--"}</td><td>${r.response_text ? html`<details><summary>${r.response_text.slice(0, 40)}...</summary><pre>${r.response_text}</pre></details>` : "--"}</td></tr>`)}</tbody>
     </table></div>
   </div>`;
 }
@@ -712,7 +726,101 @@ function AuditPanel({ entries, onRefresh }) {
 }
 
 // ════════════════════════════════════════════════════════════════════════════════
-// APP
+// ════════════════════════════════════════════════════════════════════════════════
+// USERS
+// ════════════════════════════════════════════════════════════════════════════════
+
+function UsersPanel() {
+  const [users, setUsers] = useState([]);
+  const [showForm, setShowForm] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [revealedKeys, setRevealedKeys] = useState({});
+  const { names } = useNames();
+
+  // Form state
+  const [draftName, setDraftName] = useState("");
+  const [draftPresets, setDraftPresets] = useState([]);
+  const [draftPools, setDraftPools] = useState([]);
+
+  async function load() { try { setUsers((await api("/v1/users")).users || []); } catch {} }
+  useEffect(() => { load(); }, []);
+
+  async function create() {
+    setBusy(true);
+    try {
+      const res = await api("/v1/users", jpost({
+        username: draftName || `user-${Date.now()}`,
+        allowedPresets: draftPresets,
+        allowedPools: draftPools,
+      }));
+      setRevealedKeys((k) => ({ ...k, [res.user.username]: res.user.key }));
+      setShowForm(false); setDraftName(""); setDraftPresets([]); setDraftPools([]);
+      await load();
+    } finally { setBusy(false); }
+  }
+
+  async function toggleUser(u, enabled) { setBusy(true); try { await api(`/v1/users/${encodeURIComponent(u.username)}`, jput({ enabled })); await load(); } finally { setBusy(false); } }
+  async function del(u) { if (!confirm(`Delete user "${u.username}"?`)) return; setBusy(true); try { await api(`/v1/users/${encodeURIComponent(u.username)}`, { method: "DELETE" }); await load(); } finally { setBusy(false); } }
+  async function revealKey(username) {
+    try {
+      const d = await api(`/v1/users/${encodeURIComponent(username)}/key`);
+      setRevealedKeys((k) => ({ ...k, [username]: d.key }));
+    } catch {}
+  }
+
+  function copyKey(key) { navigator.clipboard.writeText(key); }
+
+  const presetNames = (names?.providers || []).concat(names?.pools || []).concat(names?.chains || []);
+
+  return html`<div>
+    <div className="card-row" style=${{ marginBottom: "12px" }}>
+      <h2 style=${{ margin: 0 }}>Users</h2>
+      <div className="actions"><button className="btn" onClick=${load}>Refresh</button><button className="btn primary" onClick=${() => setShowForm((v) => !v)}>${showForm ? "Close" : "+ Add user"}</button></div>
+    </div>
+    <div style=${{ marginBottom: "6px", fontSize: "11px", color: "#52525b" }}>Stored in: ~/.pi/agent/multi-pass-users.json. Each user gets an API key for /ui and /v1 access.</div>
+
+    ${showForm ? html`
+      <div className="card" style=${{ marginBottom: "12px" }}>
+        <div className="form-grid">
+          <div><label>Username</label><input value=${draftName} onInput=${(e) => setDraftName(e.target.value)} placeholder="e.g. alice" /></div>
+          <div><label>Allowed presets (empty = all)</label><input value=${draftPresets.join(", ")} onInput=${(e) => setDraftPresets(e.target.value.split(",").map((s) => s.trim()).filter(Boolean))} placeholder="coding-premium, fastest" /></div>
+          <div><label>Allowed pools (empty = all)</label><input value=${draftPools.join(", ")} onInput=${(e) => setDraftPools(e.target.value.split(",").map((s) => s.trim()).filter(Boolean))} placeholder="codex-pool" /></div>
+        </div>
+        <div className="actions" style=${{ marginTop: "10px" }}><button className="btn primary" onClick=${create} disabled=${busy}>Create</button><button className="btn" onClick=${() => setShowForm(false)}>Cancel</button></div>
+      </div>
+    ` : null}
+
+    ${users.length === 0 ? html`<div className="empty">No users. Admin token has full access. Create users to share access with restricted permissions.</div>` : null}
+
+    ${users.map((u) => {
+      const key = revealedKeys[u.username];
+      return html`
+        <div className="card" key=${u.username}>
+          <div className="card-row">
+            <div>
+              <span className="name">${u.username}</span>
+              <span className=${`badge ${u.enabled !== false ? "on" : "off"}`}>${u.enabled !== false ? "active" : "disabled"}</span>
+              ${u.allowedPresets?.length ? html`<span className="badge neutral">presets: ${u.allowedPresets.join(", ")}</span>` : null}
+              ${u.allowedPools?.length ? html`<span className="badge neutral">pools: ${u.allowedPools.join(", ")}</span>` : null}
+              ${!u.allowedPresets?.length && !u.allowedPools?.length ? html`<span className="badge neutral">all access</span>` : null}
+            </div>
+            <div className="actions">
+              ${key
+                ? html`<span style=${{ fontFamily: "monospace", fontSize: "11px", color: "#f59e0b", cursor: "pointer", padding: "4px 8px", border: "1px solid #3f3f46", borderRadius: "6px" }} onClick=${() => copyKey(key)} title="Click to copy">${key.slice(0, 12)}... (click to copy)</span>`
+                : html`<button className="btn" onClick=${() => revealKey(u.username)}>Show key</button>`
+              }
+              <button className="btn" disabled=${busy} onClick=${() => toggleUser(u, !(u.enabled !== false))}>${u.enabled !== false ? "Disable" : "Enable"}</button>
+              <button className="btn danger" disabled=${busy} onClick=${() => del(u)}>Delete</button>
+            </div>
+          </div>
+        </div>
+      `;
+    })}
+  </div>`;
+}
+
+// ════════════════════════════════════════════════════════════════════════════════
+// APP + LOGIN
 // ════════════════════════════════════════════════════════════════════════════════
 
 function App() {
@@ -741,16 +849,25 @@ function App() {
     } catch (e) { if (!silent) setError(e.message); }
   }
 
-  const tabs = ["dashboard", "config", "rules", "audit"];
+  function logout() { localStorage.removeItem(TOKEN_KEY); location.reload(); }
+
+  const tabs = ["dashboard", "config", "users", "rules", "audit"];
 
   return html`
     <div className="app">
-      <div className="header"><div className="logo">Leeloo Admin</div><a className="nav-link" href="/ui">Chat UI</a><a className="nav-link" href="/health">Health</a></div>
+      <div className="header">
+        <div className="logo">Leeloo Admin</div>
+        <a className="nav-link" href="/ui">Chat UI</a>
+        <a className="nav-link" href="/health">Health</a>
+        <div style=${{ flex: 1 }} />
+        <button className="btn" onClick=${logout} style=${{ fontSize: "11px" }}>Logout</button>
+      </div>
       <div className="tabs">${tabs.map((t) => html`<button key=${t} className=${`tab ${tab === t ? "active" : ""}`} onClick=${() => setTab(t)}>${t}</button>`)}</div>
       <div className="panel"><div className="panel-inner">
         ${error ? html`<div className="card" style=${{ color: "#ef4444", borderColor: "#7f1d1d" }}>Error: ${error}</div>` : null}
         ${tab === "dashboard" ? html`<${DashboardPanel} data=${dash} />` : null}
         ${tab === "config" ? html`<${ConfigPanel} onRefresh=${() => load("dashboard", true)} />` : null}
+        ${tab === "users" ? html`<${UsersPanel} />` : null}
         ${tab === "rules" ? html`<${RulesPanel} rules=${rules} onRefresh=${() => load("rules")} />` : null}
         ${tab === "audit" ? html`<${AuditPanel} entries=${audit} onRefresh=${() => load("audit")} />` : null}
       </div></div>
@@ -758,4 +875,54 @@ function App() {
   `;
 }
 
-createRoot(document.getElementById("app")).render(html`<${App} />`);
+function LoginScreen({ onLogin }) {
+  const [token, setToken] = useState("");
+  const [error, setError] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  async function submit() {
+    if (!token.trim()) return;
+    setBusy(true); setError("");
+    try {
+      const r = await fetch(`${BASE}/v1/auth/verify`, { method: "POST", headers: { Authorization: `Bearer ${token.trim()}` } });
+      const d = await r.json();
+      if (d.valid && d.role === "admin") { localStorage.setItem(TOKEN_KEY, token.trim()); onLogin(); }
+      else if (d.valid) setError("Admin token required for admin panel");
+      else setError("Invalid token");
+    } catch (e) { setError(e.message); }
+    setBusy(false);
+  }
+
+  return html`
+    <div style=${{ display: "flex", alignItems: "center", justifyContent: "center", height: "100vh", background: "#09090b" }}>
+      <div style=${{ width: "340px", padding: "32px", background: "#18181b", border: "1px solid #27272a", borderRadius: "16px" }}>
+        <h2 style=${{ color: "#f59e0b", fontSize: "18px", fontWeight: 700, marginBottom: "4px" }}>Leeloo Admin</h2>
+        <p style=${{ color: "#52525b", fontSize: "13px", marginBottom: "20px" }}>Enter the admin token to continue.</p>
+        <input type="password" value=${token} onInput=${(e) => setToken(e.target.value)} onKeyDown=${(e) => { if (e.key === "Enter") submit(); }} placeholder="Admin token..." style=${{ width: "100%", marginBottom: "10px" }} autoFocus />
+        ${error ? html`<div style=${{ color: "#ef4444", fontSize: "12px", marginBottom: "8px" }}>${error}</div>` : null}
+        <button className="btn primary" onClick=${submit} disabled=${busy} style=${{ width: "100%" }}>${busy ? "Verifying..." : "Login"}</button>
+      </div>
+    </div>
+  `;
+}
+
+function AuthGate() {
+  const [authed, setAuthed] = useState(false);
+  const [checking, setChecking] = useState(true);
+
+  useEffect(() => {
+    const t = getToken();
+    if (!t) { setChecking(false); return; }
+    fetch(`${BASE}/v1/auth/verify`, { method: "POST", headers: { Authorization: `Bearer ${t}` } })
+      .then((r) => r.json())
+      .then((d) => { if (d.valid && d.role === "admin") setAuthed(true); })
+      .catch(() => {})
+      .finally(() => setChecking(false));
+  }, []);
+
+  if (checking) return html`<div style=${{ display: "flex", alignItems: "center", justifyContent: "center", height: "100vh", background: "#09090b", color: "#52525b" }}>Loading...</div>`;
+  if (!authed) return html`<${LoginScreen} onLogin=${() => setAuthed(true)} />`;
+  return html`<${App} />`;
+}
+
+createRoot(document.getElementById("app")).render(html`<${AuthGate} />`);

--- a/web/admin/app.js
+++ b/web/admin/app.js
@@ -1,0 +1,449 @@
+import React, { useEffect, useMemo, useState } from "https://esm.sh/react@18.3.1";
+import { createRoot } from "https://esm.sh/react-dom@18.3.1/client";
+import htm from "https://esm.sh/htm@3.1.1";
+
+const html = htm.bind(React.createElement);
+const BASE = location.origin;
+
+async function fetchJson(path, init) {
+  const res = await fetch(`${BASE}${path}`, init);
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err?.error?.message || `HTTP ${res.status}`);
+  }
+  return res.json();
+}
+
+function ago(ts) {
+  if (!ts) return "--";
+  const d = Date.now() - new Date(ts).getTime();
+  if (d < 60_000) return `${Math.round(d / 1000)}s ago`;
+  if (d < 3_600_000) return `${Math.round(d / 60_000)}m ago`;
+  return `${Math.round(d / 3_600_000)}h ago`;
+}
+
+function Tabs({ active, setActive }) {
+  const tabs = ["dashboard", "rules", "audit", "config"];
+  return html`
+    <div className="tabs">
+      ${tabs.map((t) => html`
+        <button
+          key=${t}
+          className=${`tab ${active === t ? "active" : ""}`}
+          onClick=${() => setActive(t)}
+        >${t}</button>
+      `)}
+    </div>
+  `;
+}
+
+function DashboardPanel({ data }) {
+  const stats = data?.stats || {};
+  const session = stats.session || {};
+  const providers = stats.providers || [];
+  const recent = stats.recent || [];
+  const quotaProviders = data?.quota?.providers || [];
+  const exhausted = new Set(data?.health?.exhausted || []);
+
+  return html`
+    <div>
+      <h2>Session overview</h2>
+      <div className="stat-grid">
+        <div className="stat"><div className="stat-num">${session.total_requests || 0}</div><div className="stat-label">Requests</div></div>
+        <div className="stat"><div className="stat-num">${session.total_tokens_in || 0}</div><div className="stat-label">Tokens in</div></div>
+        <div className="stat"><div className="stat-num">${session.total_tokens_out || 0}</div><div className="stat-label">Tokens out</div></div>
+        <div className="stat"><div className="stat-num">${session.total_errors || 0}</div><div className="stat-label">Errors</div></div>
+      </div>
+
+      <h2>Provider health</h2>
+      <div className="table-wrap">
+        <table>
+          <thead>
+            <tr><th>Provider</th><th>Quota</th><th>Status</th><th>Requests</th><th>Tokens</th><th>Last used</th></tr>
+          </thead>
+          <tbody>
+            ${quotaProviders.map((p) => {
+              const ps = providers.find((x) => x.provider === p.provider) || {};
+              return html`
+                <tr key=${p.provider}>
+                  <td>${p.label || p.provider}</td>
+                  <td>${p.score == null ? "?" : `${p.score}%`}</td>
+                  <td>${exhausted.has(p.provider) ? "exhausted" : (p.status || "ok")}</td>
+                  <td>${ps.requests || 0}</td>
+                  <td>${ps.tokens_in || 0} / ${ps.tokens_out || 0}</td>
+                  <td>${ago(ps.last_used)}</td>
+                </tr>
+              `;
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <h2 style=${{ marginTop: "14px" }}>Recent requests</h2>
+      <div className="table-wrap">
+        <table>
+          <thead>
+            <tr><th>Time</th><th>Provider</th><th>Model</th><th>Tokens</th><th>Duration</th><th>Error</th></tr>
+          </thead>
+          <tbody>
+            ${recent.slice(0, 30).map((r, idx) => html`
+              <tr key=${idx}>
+                <td>${ago(r.timestamp)}</td>
+                <td>${r.provider}</td>
+                <td>${r.model}</td>
+                <td>${r.tokens_in} / ${r.tokens_out}</td>
+                <td>${r.duration_ms}ms</td>
+                <td>${r.error || "--"}</td>
+              </tr>
+            `)}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  `;
+}
+
+function RuleForm({ onCreate, onCancel }) {
+  const [name, setName] = useState(`rule-${Date.now()}`);
+  const [type, setType] = useState("block");
+  const [scope, setScope] = useState("request");
+  const [patterns, setPatterns] = useState("");
+  const [replacement, setReplacement] = useState("[REDACTED]");
+  const [message, setMessage] = useState("");
+  const [allow, setAllow] = useState("");
+  const [deny, setDeny] = useState("");
+  const [maxRequests, setMaxRequests] = useState("60");
+  const [windowSeconds, setWindowSeconds] = useState("60");
+
+  async function submit() {
+    const payload = {
+      name,
+      type,
+      scope,
+      enabled: true,
+      patterns: patterns.split("\n").map((x) => x.trim()).filter(Boolean),
+      replacement: replacement || undefined,
+      message: message || undefined,
+    };
+    if (type === "model") {
+      payload.allow = allow.split(",").map((x) => x.trim()).filter(Boolean);
+      payload.deny = deny.split(",").map((x) => x.trim()).filter(Boolean);
+    }
+    if (type === "limit") {
+      payload.maxRequests = parseInt(maxRequests || "60", 10);
+      payload.windowSeconds = parseInt(windowSeconds || "60", 10);
+    }
+    await onCreate(payload);
+  }
+
+  return html`
+    <div className="card">
+      <div className="form-grid">
+        <div>
+          <label>Name</label>
+          <input value=${name} onInput=${(e) => setName(e.target.value)} />
+        </div>
+        <div>
+          <label>Type</label>
+          <select value=${type} onChange=${(e) => setType(e.target.value)}>
+            <option value="block">block</option>
+            <option value="redact">redact</option>
+            <option value="warn">warn</option>
+            <option value="model">model</option>
+            <option value="limit">limit</option>
+          </select>
+        </div>
+
+        <div>
+          <label>Scope</label>
+          <select value=${scope} onChange=${(e) => setScope(e.target.value)}>
+            <option value="request">request</option>
+            <option value="response">response</option>
+            <option value="both">both</option>
+          </select>
+        </div>
+
+        ${(type === "block" || type === "redact" || type === "warn") && html`
+          <div className="full">
+            <label>Patterns (regex, one per line)</label>
+            <textarea rows="4" value=${patterns} onInput=${(e) => setPatterns(e.target.value)} placeholder="AKIA[0-9A-Z]{16}"></textarea>
+          </div>
+        `}
+
+        ${type === "redact" && html`
+          <div>
+            <label>Replacement</label>
+            <input value=${replacement} onInput=${(e) => setReplacement(e.target.value)} />
+          </div>
+        `}
+
+        ${(type === "block" || type === "limit" || type === "model") && html`
+          <div>
+            <label>Message (optional)</label>
+            <input value=${message} onInput=${(e) => setMessage(e.target.value)} placeholder="Blocked by policy" />
+          </div>
+        `}
+
+        ${type === "model" && [
+          html`<div key="allow">
+            <label>Allow list (comma-separated globs)</label>
+            <input value=${allow} onInput=${(e) => setAllow(e.target.value)} placeholder="claude-*, gpt-5*" />
+          </div>`,
+          html`<div key="deny">
+            <label>Deny list</label>
+            <input value=${deny} onInput=${(e) => setDeny(e.target.value)} placeholder="gpt-4o*" />
+          </div>`,
+        ]}
+
+        ${type === "limit" && [
+          html`<div key="maxRequests">
+            <label>Max requests</label>
+            <input value=${maxRequests} onInput=${(e) => setMaxRequests(e.target.value)} type="number" />
+          </div>`,
+          html`<div key="windowSeconds">
+            <label>Window seconds</label>
+            <input value=${windowSeconds} onInput=${(e) => setWindowSeconds(e.target.value)} type="number" />
+          </div>`,
+        ]}
+      </div>
+
+      <div className="actions" style=${{ marginTop: "10px" }}>
+        <button className="btn primary" onClick=${submit}>Create</button>
+        <button className="btn" onClick=${onCancel}>Cancel</button>
+      </div>
+    </div>
+  `;
+}
+
+function RulesPanel({ rules, onRefresh }) {
+  const [showForm, setShowForm] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  async function toggleRule(rule, enabled) {
+    setBusy(true);
+    try {
+      await fetchJson(`/v1/rules/${encodeURIComponent(rule.name)}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled }),
+      });
+      await onRefresh();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function deleteRule(rule) {
+    if (!confirm(`Delete rule ${rule.name}?`)) return;
+    setBusy(true);
+    try {
+      await fetchJson(`/v1/rules/${encodeURIComponent(rule.name)}`, { method: "DELETE" });
+      await onRefresh();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function createRule(payload) {
+    setBusy(true);
+    try {
+      await fetchJson(`/v1/rules`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      setShowForm(false);
+      await onRefresh();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return html`
+    <div>
+      <div style=${{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "10px" }}>
+        <h2 style=${{ margin: 0 }}>Rules</h2>
+        <div className="actions">
+          <button className="btn" onClick=${onRefresh}>Refresh</button>
+          <button className="btn primary" onClick=${() => setShowForm((v) => !v)}>${showForm ? "Close" : "+ Add rule"}</button>
+        </div>
+      </div>
+
+      ${showForm ? html`<${RuleForm} onCreate=${createRule} onCancel=${() => setShowForm(false)} />` : null}
+
+      ${rules.length === 0 ? html`<div className="empty">No rules configured.</div>` : null}
+
+      ${rules.map((r) => html`
+        <div className="card" key=${r.name + String(r.enabled)}>
+          <div style=${{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+            <div>
+              <span className="name">${r.name}</span>
+              <span className=${`badge ${r.type}`}>${r.type}</span>
+              <span className=${`badge ${r.enabled ? "on" : "off"}`}>${r.enabled ? "enabled" : "disabled"}</span>
+            </div>
+            <div className="actions">
+              <button className="btn" disabled=${busy} onClick=${() => toggleRule(r, !r.enabled)}>${r.enabled ? "Disable" : "Enable"}</button>
+              <button className="btn danger" disabled=${busy} onClick=${() => deleteRule(r)}>Delete</button>
+            </div>
+          </div>
+          <div className="meta">
+            scope: ${r.scope || "request"}
+            ${r.patterns?.length ? html` | patterns: ${r.patterns.join(", ")}` : null}
+            ${r.allow?.length ? html` | allow: ${r.allow.join(", ")}` : null}
+            ${r.deny?.length ? html` | deny: ${r.deny.join(", ")}` : null}
+            ${r.maxRequests ? html` | ${r.maxRequests} req/${r.windowSeconds}s` : null}
+            ${r.replacement ? html` | replacement: ${r.replacement}` : null}
+          </div>
+        </div>
+      `)}
+    </div>
+  `;
+}
+
+function AuditPanel({ entries, onRefresh }) {
+  return html`
+    <div>
+      <div style=${{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "10px" }}>
+        <h2 style=${{ margin: 0 }}>Audit log</h2>
+        <button className="btn" onClick=${onRefresh}>Refresh</button>
+      </div>
+
+      ${entries.length === 0
+        ? html`<div className="empty">No audit events yet.</div>`
+        : html`
+          <div className="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Time</th><th>Rule</th><th>Type</th><th>Action</th><th>Source</th><th>Detail</th><th>Matched</th><th>Before</th><th>After</th>
+                </tr>
+              </thead>
+              <tbody>
+                ${entries.map((e, idx) => html`
+                  <tr key=${idx}>
+                    <td>${ago(e.timestamp)}</td>
+                    <td>${e.rule}</td>
+                    <td>${e.type}</td>
+                    <td>${e.action}</td>
+                    <td>${e.source || "--"}</td>
+                    <td>${e.detail}</td>
+                    <td>${e.matched_text || "--"}</td>
+                    <td>
+                      ${e.full_message
+                        ? html`<details><summary>view (${e.full_message.length})</summary><pre>${e.full_message}</pre></details>`
+                        : "--"}
+                    </td>
+                    <td>
+                      ${e.redacted_message
+                        ? html`<details><summary>view (${e.redacted_message.length})</summary><pre>${e.redacted_message}</pre></details>`
+                        : "--"}
+                    </td>
+                  </tr>
+                `)}
+              </tbody>
+            </table>
+          </div>
+        `}
+    </div>
+  `;
+}
+
+function ConfigPanel({ health }) {
+  const pools = health?.pools || [];
+  const presets = health?.presets || [];
+  const providers = health?.providers || [];
+  const exhausted = new Set(health?.exhausted || []);
+
+  return html`
+    <div>
+      <h2>Pools</h2>
+      ${pools.length === 0 ? html`<div className="empty">No pools</div>` : null}
+      ${pools.map((p) => html`
+        <div className="card" key=${p.name}>
+          <span className="name">${p.name}</span>
+          <span className="badge">${p.strategy}</span>
+          <div className="meta">Members: ${(p.members || []).join(", ")}</div>
+        </div>
+      `)}
+
+      <h2 style=${{ marginTop: "14px" }}>Presets</h2>
+      ${presets.length === 0 ? html`<div className="empty">No presets</div>` : null}
+      ${presets.map((p) => html`
+        <div className="card" key=${p.name}>
+          <span className="name">${p.name}</span>
+          <div className="meta">${(p.entries || []).join(" -> ")}</div>
+        </div>
+      `)}
+
+      <h2 style=${{ marginTop: "14px" }}>Providers</h2>
+      ${providers.map((p) => html`
+        <div className="card" key=${p}>
+          <span className="name">${p}</span>
+          <span className=${`badge ${exhausted.has(p) ? "off" : "on"}`}>${exhausted.has(p) ? "exhausted" : "ok"}</span>
+        </div>
+      `)}
+    </div>
+  `;
+}
+
+function App() {
+  const [active, setActive] = useState("dashboard");
+  const [error, setError] = useState("");
+
+  const [dashboard, setDashboard] = useState({ stats: null, quota: null, health: null });
+  const [rules, setRules] = useState([]);
+  const [auditEntries, setAuditEntries] = useState([]);
+  const [health, setHealth] = useState(null);
+
+  useEffect(() => {
+    refreshTab(active);
+  }, [active]);
+
+  async function refreshTab(tab = active) {
+    setError("");
+    try {
+      if (tab === "dashboard") {
+        const [stats, quota, healthData] = await Promise.all([
+          fetchJson("/v1/stats"),
+          fetchJson("/v1/quota"),
+          fetchJson("/health"),
+        ]);
+        setDashboard({ stats, quota, health: healthData });
+      } else if (tab === "rules") {
+        const data = await fetchJson("/v1/rules");
+        setRules(data.rules || []);
+      } else if (tab === "audit") {
+        const data = await fetchJson("/v1/audit?limit=200");
+        setAuditEntries(data.entries || []);
+      } else if (tab === "config") {
+        const h = await fetchJson("/health");
+        setHealth(h);
+      }
+    } catch (e) {
+      setError(e.message);
+    }
+  }
+
+  let panel = null;
+  if (active === "dashboard") panel = html`<${DashboardPanel} data=${dashboard} />`;
+  if (active === "rules") panel = html`<${RulesPanel} rules=${rules} onRefresh=${() => refreshTab("rules")} />`;
+  if (active === "audit") panel = html`<${AuditPanel} entries=${auditEntries} onRefresh=${() => refreshTab("audit")} />`;
+  if (active === "config") panel = html`<${ConfigPanel} health=${health} />`;
+
+  return html`
+    <div className="app">
+      <div className="header">
+        <div className="title">Leeloo Admin</div>
+        <a className="link" href="/ui">Chat UI</a>
+        <a className="link" href="/health">Health API</a>
+      </div>
+      <${Tabs} active=${active} setActive=${setActive} />
+      <div className="panel">
+        ${error ? html`<div className="card" style=${{ color: "#ff7e7e" }}>Error: ${error}</div>` : null}
+        ${panel}
+      </div>
+    </div>
+  `;
+}
+
+createRoot(document.getElementById("app")).render(html`<${App} />`);

--- a/web/admin/app.js
+++ b/web/admin/app.js
@@ -462,6 +462,65 @@ function ApiKeyEditor({ apiKeys, onSave }) {
   </div>`;
 }
 
+// ── Accounts (v2 unified primitive) ──
+
+function AccountEditor({ accounts, onSave, readOnly }) {
+  const [editing, setEditing] = useState(null);
+  const [draft, setDraft] = useState({});
+
+  function startNew() { setEditing("__new__"); setDraft({ id: "", provider: "openai-codex", kind: "subscription", key: "", baseUrl: "", label: "", enabled: true }); }
+  function startEdit(a) { setEditing(a.id); setDraft({ ...a }); }
+  function cancel() { setEditing(null); }
+
+  async function save() {
+    if (editing === "__new__") { await api("/v1/config/accounts", jpost(draft)); }
+    else { await api(`/v1/config/accounts/${encodeURIComponent(editing)}`, jput(draft)); }
+    setEditing(null); onSave();
+  }
+  async function del(id) { if (confirm(`Delete account "${id}"?`)) { await api(`/v1/config/accounts/${encodeURIComponent(id)}`, { method: "DELETE" }); onSave(); } }
+
+  function renderForm(isNew) {
+    return html`
+      <div className="card">
+        <div className="form-grid">
+          <div><label>ID</label><input value=${draft.id} onInput=${(e) => setDraft({ ...draft, id: e.target.value })} placeholder="e.g. openai-team" disabled=${!isNew} /></div>
+          <div><label>Label</label><input value=${draft.label || ""} onInput=${(e) => setDraft({ ...draft, label: e.target.value })} placeholder="e.g. Team account" /></div>
+          <div><label>Provider</label><select value=${draft.provider} onChange=${(e) => setDraft({ ...draft, provider: e.target.value })}>${BASE_PROVIDERS.concat(["openai", "openrouter", "azure", "custom"]).map((p) => html`<option key=${p} value=${p}>${p}</option>`)}</select></div>
+          <div><label>Kind</label><select value=${draft.kind} onChange=${(e) => setDraft({ ...draft, kind: e.target.value })}><option value="subscription">subscription (OAuth)</option><option value="apiKey">apiKey (raw key)</option></select></div>
+          ${draft.kind === "apiKey" ? html`
+            <div className="full"><label>API Key</label><input type="password" value=${draft.key || ""} onInput=${(e) => setDraft({ ...draft, key: e.target.value })} placeholder="sk-..." /></div>
+            <div className="full"><label>Base URL (optional)</label><input value=${draft.baseUrl || ""} onInput=${(e) => setDraft({ ...draft, baseUrl: e.target.value })} placeholder="auto-inferred from key prefix" /></div>
+          ` : null}
+          <div><label>Enabled</label><select value=${String(draft.enabled !== false)} onChange=${(e) => setDraft({ ...draft, enabled: e.target.value === "true" })}><option value="true">Yes</option><option value="false">No</option></select></div>
+        </div>
+        <div className="actions" style=${{ marginTop: "10px" }}><button className="btn primary" onClick=${save}>${isNew ? "Create" : "Save"}</button><button className="btn" onClick=${cancel}>Cancel</button></div>
+      </div>
+    `;
+  }
+
+  return html`<div>
+    <div className="card-row" style=${{ marginBottom: "10px" }}><h2 style=${{ margin: 0 }}>Accounts (v2)</h2>${!readOnly ? html`<button className="btn primary" onClick=${startNew}>+ Add account</button>` : null}</div>
+    <div style=${{ marginBottom: "10px", fontSize: "11px", color: "#52525b" }}>v2 unified primitive: any access point (subscription or raw API key). Used by modes for cross-provider routing. OAuth accounts above and API keys below are auto-included if not listed here.</div>
+    ${editing === "__new__" ? renderForm(true) : null}
+    ${(accounts || []).length === 0 && editing !== "__new__" ? html`<div className="empty">No v2 accounts. Add one to use it as a candidate in modes.</div>` : null}
+    ${(accounts || []).map((a) => editing === a.id ? renderForm(false) : html`
+      <div className="card" key=${a.id}>
+        <div className="card-row">
+          <div>
+            <span className="name">${a.label || a.id}</span>
+            <span className="badge neutral" style=${{ fontFamily: "monospace" }}>${a.id}</span>
+            <span className="badge neutral">${a.kind}</span>
+            <span className="badge neutral">${a.provider}</span>
+            <span className=${`badge ${a.enabled !== false ? "on" : "off"}`}>${a.enabled !== false ? "active" : "disabled"}</span>
+          </div>
+          ${!readOnly ? html`<div className="actions"><button className="btn" onClick=${() => startEdit(a)}>Edit</button><button className="btn danger" onClick=${() => del(a.id)}>Del</button></div>` : null}
+        </div>
+        ${a.baseUrl ? html`<div className="meta">${a.baseUrl}</div>` : null}
+      </div>
+    `)}
+  </div>`;
+}
+
 // ── Pools ──
 
 function PoolEditor({ pools, names, onSave }) {
@@ -971,6 +1030,8 @@ function ConfigPanel({ onRefresh }) {
     <div style=${{ marginTop: "24px" }} />
     <${ApiKeyEditor} apiKeys=${config.apiKeys || []} onSave=${refresh} />
     <div style=${{ marginTop: "24px" }} />
+    <${AccountEditor} accounts=${config.accounts || []} onSave=${refresh} readOnly=${readOnly} />
+    <div style=${{ marginTop: "24px" }} />
     <div style=${{ marginBottom: "6px", fontSize: "11px", color: "#52525b" }}>Editing: ${config._source || "~/.pi/agent/multi-pass.json"}</div>
     <${PoolEditor} pools=${config.pools || []} names=${names} onSave=${refresh} />
     <div style=${{ marginTop: "20px" }} />
@@ -1321,6 +1382,196 @@ function UsersPanel() {
 // APP + LOGIN
 // ════════════════════════════════════════════════════════════════════════════════
 
+// ════════════════════════════════════════════════════════════════════════════════
+// FILES (raw editor with Monaco)
+// ════════════════════════════════════════════════════════════════════════════════
+
+let _monacoLoaderPromise = null;
+function loadMonaco() {
+  if (_monacoLoaderPromise) return _monacoLoaderPromise;
+  _monacoLoaderPromise = new Promise((resolve, reject) => {
+    if (window.monaco) return resolve(window.monaco);
+    const script = document.createElement("script");
+    script.src = "https://cdn.jsdelivr.net/npm/monaco-editor@0.46.0/min/vs/loader.js";
+    script.onload = () => {
+      window.require.config({ paths: { vs: "https://cdn.jsdelivr.net/npm/monaco-editor@0.46.0/min/vs" } });
+      window.require(["vs/editor/editor.main"], () => resolve(window.monaco));
+    };
+    script.onerror = () => reject(new Error("Failed to load Monaco from CDN"));
+    document.head.appendChild(script);
+  });
+  return _monacoLoaderPromise;
+}
+
+function MonacoEditor({ value, language, onChange, height }) {
+  const containerRef = useRef(null);
+  const editorRef = useRef(null);
+  const valueRef = useRef(value);
+
+  useEffect(() => {
+    let disposed = false;
+    loadMonaco().then((monaco) => {
+      if (disposed || !containerRef.current) return;
+      // Apply dark theme matching admin
+      monaco.editor.defineTheme("leeloo-dark", {
+        base: "vs-dark",
+        inherit: true,
+        rules: [],
+        colors: {
+          "editor.background": "#0d0d0f",
+          "editor.foreground": "#e4e4e7",
+          "editorLineNumber.foreground": "#3f3f46",
+          "editorLineNumber.activeForeground": "#a1a1aa",
+          "editor.selectionBackground": "#27272a",
+          "editor.lineHighlightBackground": "#14141a",
+        },
+      });
+      editorRef.current = monaco.editor.create(containerRef.current, {
+        value: valueRef.current,
+        language,
+        theme: "leeloo-dark",
+        automaticLayout: true,
+        fontSize: 13,
+        lineNumbers: "on",
+        minimap: { enabled: false },
+        scrollBeyondLastLine: false,
+        wordWrap: "on",
+        tabSize: 2,
+        fontFamily: "JetBrains Mono, Menlo, monospace",
+      });
+      editorRef.current.onDidChangeModelContent(() => {
+        const v = editorRef.current.getValue();
+        valueRef.current = v;
+        onChange?.(v);
+      });
+    }).catch((err) => {
+      if (containerRef.current) containerRef.current.innerHTML = `<div class="empty">Monaco failed to load: ${err.message}</div>`;
+    });
+    return () => {
+      disposed = true;
+      if (editorRef.current) { editorRef.current.dispose(); editorRef.current = null; }
+    };
+  }, [language]);
+
+  // Update editor content when external value changes (e.g. switching files)
+  useEffect(() => {
+    if (editorRef.current && value !== valueRef.current) {
+      valueRef.current = value;
+      editorRef.current.setValue(value || "");
+    }
+  }, [value]);
+
+  return html`<div ref=${containerRef} style=${{ height: height || "560px", border: "1px solid #27272a", borderRadius: "10px", overflow: "hidden" }} />`;
+}
+
+function FilesPanel() {
+  const [files, setFiles] = useState([]);
+  const [activeFile, setActiveFile] = useState(null);
+  const [content, setContent] = useState("");
+  const [original, setOriginal] = useState("");
+  const [language, setLanguage] = useState("json");
+  const [busy, setBusy] = useState(false);
+  const [status, setStatus] = useState(null);
+  const [error, setError] = useState("");
+
+  async function loadFileList() {
+    try { const d = await api("/v1/files"); setFiles(d.files || []); } catch (e) { setError(e.message); }
+  }
+  useEffect(() => { loadFileList(); }, []);
+
+  async function selectFile(name) {
+    setError(""); setStatus(null);
+    try {
+      const d = await api(`/v1/files/${encodeURIComponent(name)}`);
+      setActiveFile(d);
+      setContent(d.content);
+      setOriginal(d.content);
+      setLanguage(d.language || "json");
+    } catch (e) { setError(e.message); }
+  }
+
+  async function save() {
+    if (!activeFile) return;
+    setBusy(true); setError(""); setStatus(null);
+    try {
+      const d = await api(`/v1/files/${encodeURIComponent(activeFile.name)}`, jput({ content }));
+      setOriginal(content);
+      setStatus(`Saved ${d.bytes} bytes`);
+      await loadFileList();
+      setTimeout(() => setStatus(null), 3000);
+    } catch (e) { setError(e.message); }
+    setBusy(false);
+  }
+
+  function revert() {
+    setContent(original);
+  }
+
+  async function deleteFile() {
+    if (!activeFile) return;
+    if (!confirm(`Delete ${activeFile.name}?`)) return;
+    setBusy(true);
+    try {
+      await api(`/v1/files/${encodeURIComponent(activeFile.name)}`, { method: "DELETE" });
+      setActiveFile(null);
+      setContent("");
+      setOriginal("");
+      await loadFileList();
+    } catch (e) { setError(e.message); }
+    setBusy(false);
+  }
+
+  const dirty = content !== original;
+
+  return html`
+    <div>
+      <div className="card-row" style=${{ marginBottom: "12px" }}>
+        <h2 style=${{ margin: 0 }}>Files</h2>
+        <div className="actions">
+          <button className="btn" onClick=${loadFileList}>Refresh list</button>
+        </div>
+      </div>
+      <div style=${{ marginBottom: "12px", fontSize: "11px", color: "#52525b" }}>Raw config file editor with Monaco. Edit any config file directly. Changes hot-reload.</div>
+
+      ${error ? html`<div className="card" style=${{ color: "#ef4444", borderColor: "#7f1d1d" }}>Error: ${error}</div>` : null}
+
+      <div style=${{ display: "flex", gap: "12px", marginBottom: "12px", flexWrap: "wrap" }}>
+        ${files.map((f) => html`
+          <button
+            key=${f.name}
+            className=${`btn ${activeFile?.name === f.name ? "primary" : ""}`}
+            onClick=${() => selectFile(f.name)}
+            style=${{ display: "flex", alignItems: "center", gap: "6px" }}
+          >
+            ${f.name}
+            ${!f.exists ? html`<span style=${{ color: "#52525b", fontSize: "10px" }}>(missing)</span>` : null}
+          </button>
+        `)}
+      </div>
+
+      ${activeFile ? html`
+        <div className="card" style=${{ marginBottom: "10px" }}>
+          <div className="card-row" style=${{ marginBottom: "10px" }}>
+            <div>
+              <span className="name">${activeFile.name}</span>
+              <span className="badge neutral">${activeFile.language}</span>
+              ${dirty ? html`<span className="badge warn">unsaved</span>` : html`<span className="badge on">saved</span>`}
+              ${status ? html`<span style=${{ color: "#22c55e", marginLeft: "10px", fontSize: "12px" }}>${status}</span>` : null}
+            </div>
+            <div className="actions">
+              <button className="btn" onClick=${revert} disabled=${!dirty || busy}>Revert</button>
+              <button className="btn primary" onClick=${save} disabled=${!dirty || busy}>${busy ? "Saving..." : "Save"}</button>
+              <button className="btn danger" onClick=${deleteFile} disabled=${busy}>Delete file</button>
+            </div>
+          </div>
+          <div style=${{ fontSize: "11px", color: "#52525b", marginBottom: "8px" }}>${activeFile.path}</div>
+          <${MonacoEditor} value=${content} language=${language} onChange=${setContent} height="600px" />
+        </div>
+      ` : html`<div className="empty">Select a file above to edit it.</div>`}
+    </div>
+  `;
+}
+
 function App() {
   const [tab, setTab] = useState("dashboard");
   const [error, setError] = useState("");
@@ -1349,7 +1600,7 @@ function App() {
 
   function logout() { localStorage.removeItem(TOKEN_KEY); location.reload(); }
 
-  const tabs = ["dashboard", "config", "routing", "users", "rules", "audit"];
+  const tabs = ["dashboard", "config", "routing", "users", "rules", "audit", "files"];
 
   return html`
     <div className="app">
@@ -1369,6 +1620,7 @@ function App() {
         ${tab === "users" ? html`<${UsersPanel} />` : null}
         ${tab === "rules" ? html`<${RulesPanel} rules=${rules} onRefresh=${() => load("rules")} />` : null}
         ${tab === "audit" ? html`<${AuditPanel} entries=${audit} onRefresh=${() => load("audit")} />` : null}
+        ${tab === "files" ? html`<${FilesPanel} />` : null}
       </div></div>
     </div>
   `;

--- a/web/admin/app.js
+++ b/web/admin/app.js
@@ -5,49 +5,38 @@ import htm from "https://esm.sh/htm@3.1.1";
 const html = htm.bind(React.createElement);
 const BASE = location.origin;
 
-async function fetchJson(path, init) {
-  const res = await fetch(`${BASE}${path}`, init);
-  if (!res.ok) {
-    const err = await res.json().catch(() => ({}));
-    throw new Error(err?.error?.message || `HTTP ${res.status}`);
-  }
-  return res.json();
+async function api(path, init) {
+  const r = await fetch(`${BASE}${path}`, init);
+  if (!r.ok) { const e = await r.json().catch(() => ({})); throw new Error(e?.error?.message || `HTTP ${r.status}`); }
+  return r.json();
 }
 
 function ago(ts) {
   if (!ts) return "--";
-  const d = Date.now() - new Date(ts).getTime();
-  if (d < 60_000) return `${Math.round(d / 1000)}s ago`;
-  if (d < 3_600_000) return `${Math.round(d / 60_000)}m ago`;
-  return `${Math.round(d / 3_600_000)}h ago`;
+  const ms = Date.now() - new Date(ts).getTime();
+  if (ms < 60e3) return `${Math.round(ms / 1e3)}s ago`;
+  if (ms < 36e5) return `${Math.round(ms / 6e4)}m ago`;
+  return `${Math.round(ms / 36e5)}h ago`;
 }
 
-function Tabs({ active, setActive }) {
-  const tabs = ["dashboard", "rules", "audit", "config"];
-  return html`
-    <div className="tabs">
-      ${tabs.map((t) => html`
-        <button
-          key=${t}
-          className=${`tab ${active === t ? "active" : ""}`}
-          onClick=${() => setActive(t)}
-        >${t}</button>
-      `)}
-    </div>
-  `;
+function qColor(s) { return s == null ? "#3f3f46" : s > 50 ? "#22c55e" : s > 20 ? "#eab308" : "#ef4444"; }
+
+function QuotaBar({ score }) {
+  return html`<span className="q-bar"><span className="q-fill" style=${{ width: `${score ?? 0}%`, background: qColor(score) }} /></span>`;
 }
+
+// ── Dashboard ──
 
 function DashboardPanel({ data }) {
-  const stats = data?.stats || {};
-  const session = stats.session || {};
-  const providers = stats.providers || [];
-  const recent = stats.recent || [];
+  const session = data?.stats?.session || {};
+  const providers = data?.stats?.providers || [];
+  const recent = data?.stats?.recent || [];
   const quotaProviders = data?.quota?.providers || [];
   const exhausted = new Set(data?.health?.exhausted || []);
 
   return html`
     <div>
-      <h2>Session overview</h2>
+      <h2>Session</h2>
       <div className="stat-grid">
         <div className="stat"><div className="stat-num">${session.total_requests || 0}</div><div className="stat-label">Requests</div></div>
         <div className="stat"><div className="stat-num">${session.total_tokens_in || 0}</div><div className="stat-label">Tokens in</div></div>
@@ -55,69 +44,54 @@ function DashboardPanel({ data }) {
         <div className="stat"><div className="stat-num">${session.total_errors || 0}</div><div className="stat-label">Errors</div></div>
       </div>
 
-      <h2>Provider health</h2>
-      <div className="table-wrap">
-        <table>
-          <thead>
-            <tr><th>Provider</th><th>Quota</th><th>Status</th><th>Requests</th><th>Tokens</th><th>Last used</th></tr>
-          </thead>
-          <tbody>
-            ${quotaProviders.map((p) => {
-              const ps = providers.find((x) => x.provider === p.provider) || {};
-              return html`
-                <tr key=${p.provider}>
-                  <td>${p.label || p.provider}</td>
-                  <td>${p.score == null ? "?" : `${p.score}%`}</td>
-                  <td>${exhausted.has(p.provider) ? "exhausted" : (p.status || "ok")}</td>
-                  <td>${ps.requests || 0}</td>
-                  <td>${ps.tokens_in || 0} / ${ps.tokens_out || 0}</td>
-                  <td>${ago(ps.last_used)}</td>
-                </tr>
-              `;
-            })}
-          </tbody>
-        </table>
-      </div>
-
-      <h2 style=${{ marginTop: "14px" }}>Recent chats</h2>
-      <div className="table-wrap">
-        <table>
-          <thead>
-            <tr><th>Time</th><th>Provider</th><th>Model</th><th>Tokens</th><th>Duration</th><th>Error</th><th>Request</th><th>Response</th></tr>
-          </thead>
-          <tbody>
-            ${recent.length === 0 ? html`
-              <tr><td colSpan="8" style=${{ color: "#666", fontStyle: "italic" }}>No chat requests yet.</td></tr>
-            ` : null}
-            ${recent.slice(0, 30).map((r, idx) => html`
-              <tr key=${idx}>
-                <td>${ago(r.timestamp)}</td>
-                <td>${r.provider}</td>
-                <td>${r.model}</td>
-                <td>${r.tokens_in} / ${r.tokens_out}</td>
-                <td>${r.duration_ms}ms</td>
-                <td>${r.error || "--"}</td>
-                <td>
-                  ${r.request_text
-                    ? html`<details><summary>view (${r.request_text.length})</summary><pre>${r.request_text}</pre></details>`
-                    : "--"}
-                </td>
-                <td>
-                  ${r.response_text
-                    ? html`<details><summary>view (${r.response_text.length})</summary><pre>${r.response_text}</pre></details>`
-                    : "--"}
-                </td>
+      <h2 className="mt">Providers</h2>
+      <div className="table-wrap"><table>
+        <thead><tr><th>Provider</th><th>Quota</th><th>Status</th><th>Requests</th><th>Tokens</th><th>Last used</th></tr></thead>
+        <tbody>
+          ${quotaProviders.map((p) => {
+            const ps = providers.find((x) => x.provider === p.provider) || {};
+            const exh = exhausted.has(p.provider);
+            return html`
+              <tr key=${p.provider}>
+                <td style=${{ color: "#fafafa", fontWeight: 500 }}>${p.label || p.provider}</td>
+                <td><${QuotaBar} score=${p.score} /> <span style=${{ color: qColor(p.score) }}>${p.score == null ? "?" : `${p.score}%`}</span></td>
+                <td>${exh ? html`<span className="badge off">exhausted</span>` : html`<span className="badge on">${p.status || "ok"}</span>`}</td>
+                <td>${ps.requests || 0}</td>
+                <td>${ps.tokens_in || 0} / ${ps.tokens_out || 0}</td>
+                <td>${ago(ps.last_used)}</td>
               </tr>
-            `)}
-          </tbody>
-        </table>
-      </div>
+            `;
+          })}
+        </tbody>
+      </table></div>
+
+      <h2 className="mt">Recent chats</h2>
+      <div className="table-wrap"><table>
+        <thead><tr><th>Time</th><th>Provider</th><th>Model</th><th>Tokens</th><th>Duration</th><th>Error</th><th>Request</th><th>Response</th></tr></thead>
+        <tbody>
+          ${recent.length === 0 ? html`<tr><td colSpan="8" className="empty">No requests yet.</td></tr>` : null}
+          ${recent.slice(0, 50).map((r, i) => html`
+            <tr key=${i}>
+              <td>${ago(r.timestamp)}</td>
+              <td>${r.provider}</td>
+              <td style=${{ fontFamily: "monospace", fontSize: "11px" }}>${r.model}</td>
+              <td>${r.tokens_in} / ${r.tokens_out}</td>
+              <td>${r.duration_ms}ms</td>
+              <td>${r.error ? html`<span style=${{ color: "#ef4444" }}>${r.error}</span>` : "--"}</td>
+              <td>${r.request_text ? html`<details><summary>${r.request_text.slice(0, 40)}...</summary><pre>${r.request_text}</pre></details>` : "--"}</td>
+              <td>${r.response_text ? html`<details><summary>${r.response_text.slice(0, 40)}...</summary><pre>${r.response_text}</pre></details>` : "--"}</td>
+            </tr>
+          `)}
+        </tbody>
+      </table></div>
     </div>
   `;
 }
 
+// ── Rules ──
+
 function RuleForm({ onCreate, onCancel }) {
-  const [name, setName] = useState(`rule-${Date.now()}`);
+  const [name, setName] = useState("");
   const [type, setType] = useState("block");
   const [scope, setScope] = useState("request");
   const [patterns, setPatterns] = useState("");
@@ -125,105 +99,35 @@ function RuleForm({ onCreate, onCancel }) {
   const [message, setMessage] = useState("");
   const [allow, setAllow] = useState("");
   const [deny, setDeny] = useState("");
-  const [maxRequests, setMaxRequests] = useState("60");
-  const [windowSeconds, setWindowSeconds] = useState("60");
+  const [maxReq, setMaxReq] = useState("60");
+  const [winSec, setWinSec] = useState("60");
 
-  async function submit() {
-    const payload = {
-      name,
-      type,
-      scope,
-      enabled: true,
-      patterns: patterns.split("\n").map((x) => x.trim()).filter(Boolean),
-      replacement: replacement || undefined,
-      message: message || undefined,
-    };
-    if (type === "model") {
-      payload.allow = allow.split(",").map((x) => x.trim()).filter(Boolean);
-      payload.deny = deny.split(",").map((x) => x.trim()).filter(Boolean);
-    }
-    if (type === "limit") {
-      payload.maxRequests = parseInt(maxRequests || "60", 10);
-      payload.windowSeconds = parseInt(windowSeconds || "60", 10);
-    }
-    await onCreate(payload);
+  function submit() {
+    const rule = { name: name || `rule-${Date.now()}`, type, scope, enabled: true, patterns: patterns.split("\n").map((x) => x.trim()).filter(Boolean), replacement: replacement || undefined, message: message || undefined };
+    if (type === "model") { rule.allow = allow.split(",").map((x) => x.trim()).filter(Boolean); rule.deny = deny.split(",").map((x) => x.trim()).filter(Boolean); }
+    if (type === "limit") { rule.maxRequests = parseInt(maxReq) || 60; rule.windowSeconds = parseInt(winSec) || 60; }
+    onCreate(rule);
   }
 
   return html`
-    <div className="card">
+    <div className="card" style=${{ marginBottom: "16px" }}>
       <div className="form-grid">
-        <div>
-          <label>Name</label>
-          <input value=${name} onInput=${(e) => setName(e.target.value)} />
-        </div>
-        <div>
-          <label>Type</label>
-          <select value=${type} onChange=${(e) => setType(e.target.value)}>
-            <option value="block">block</option>
-            <option value="redact">redact</option>
-            <option value="warn">warn</option>
-            <option value="model">model</option>
-            <option value="limit">limit</option>
-          </select>
-        </div>
-
-        <div>
-          <label>Scope</label>
-          <select value=${scope} onChange=${(e) => setScope(e.target.value)}>
-            <option value="request">request</option>
-            <option value="response">response</option>
-            <option value="both">both</option>
-          </select>
-        </div>
-
-        ${(type === "block" || type === "redact" || type === "warn") && html`
-          <div className="full">
-            <label>Patterns (regex, one per line)</label>
-            <textarea rows="4" value=${patterns} onInput=${(e) => setPatterns(e.target.value)} placeholder="AKIA[0-9A-Z]{16}"></textarea>
-          </div>
-        `}
-
-        ${type === "redact" && html`
-          <div>
-            <label>Replacement</label>
-            <input value=${replacement} onInput=${(e) => setReplacement(e.target.value)} />
-          </div>
-        `}
-
-        ${(type === "block" || type === "limit" || type === "model") && html`
-          <div>
-            <label>Message (optional)</label>
-            <input value=${message} onInput=${(e) => setMessage(e.target.value)} placeholder="Blocked by policy" />
-          </div>
-        `}
-
+        <div><label>Name</label><input value=${name} onInput=${(e) => setName(e.target.value)} placeholder="e.g. block-secrets" /></div>
+        <div><label>Type</label><select value=${type} onChange=${(e) => setType(e.target.value)}><option value="block">block</option><option value="redact">redact</option><option value="warn">warn</option><option value="model">model</option><option value="limit">limit</option></select></div>
+        <div><label>Scope</label><select value=${scope} onChange=${(e) => setScope(e.target.value)}><option value="request">request</option><option value="response">response</option><option value="both">both</option></select></div>
+        ${(type === "block" || type === "redact" || type === "warn") && html`<div className="full"><label>Patterns (regex, one per line)</label><textarea value=${patterns} onInput=${(e) => setPatterns(e.target.value)} placeholder="AKIA[0-9A-Z]{16}" /></div>`}
+        ${type === "redact" && html`<div><label>Replacement</label><input value=${replacement} onInput=${(e) => setReplacement(e.target.value)} /></div>`}
+        ${(type === "block" || type === "model") && html`<div><label>Block message</label><input value=${message} onInput=${(e) => setMessage(e.target.value)} placeholder="Blocked by policy" /></div>`}
         ${type === "model" && [
-          html`<div key="allow">
-            <label>Allow list (comma-separated globs)</label>
-            <input value=${allow} onInput=${(e) => setAllow(e.target.value)} placeholder="claude-*, gpt-5*" />
-          </div>`,
-          html`<div key="deny">
-            <label>Deny list</label>
-            <input value=${deny} onInput=${(e) => setDeny(e.target.value)} placeholder="gpt-4o*" />
-          </div>`,
+          html`<div key="a"><label>Allow (globs)</label><input value=${allow} onInput=${(e) => setAllow(e.target.value)} placeholder="claude-*, gpt-5*" /></div>`,
+          html`<div key="d"><label>Deny (globs)</label><input value=${deny} onInput=${(e) => setDeny(e.target.value)} placeholder="gpt-4o*" /></div>`,
         ]}
-
         ${type === "limit" && [
-          html`<div key="maxRequests">
-            <label>Max requests</label>
-            <input value=${maxRequests} onInput=${(e) => setMaxRequests(e.target.value)} type="number" />
-          </div>`,
-          html`<div key="windowSeconds">
-            <label>Window seconds</label>
-            <input value=${windowSeconds} onInput=${(e) => setWindowSeconds(e.target.value)} type="number" />
-          </div>`,
+          html`<div key="mr"><label>Max requests</label><input value=${maxReq} onInput=${(e) => setMaxReq(e.target.value)} type="number" /></div>`,
+          html`<div key="ws"><label>Window (seconds)</label><input value=${winSec} onInput=${(e) => setWinSec(e.target.value)} type="number" /></div>`,
         ]}
       </div>
-
-      <div className="actions" style=${{ marginTop: "10px" }}>
-        <button className="btn primary" onClick=${submit}>Create</button>
-        <button className="btn" onClick=${onCancel}>Cancel</button>
-      </div>
+      <div className="actions" style=${{ marginTop: "12px" }}><button className="btn primary" onClick=${submit}>Create</button><button className="btn" onClick=${onCancel}>Cancel</button></div>
     </div>
   `;
 }
@@ -232,80 +136,39 @@ function RulesPanel({ rules, onRefresh }) {
   const [showForm, setShowForm] = useState(false);
   const [busy, setBusy] = useState(false);
 
-  async function toggleRule(rule, enabled) {
-    setBusy(true);
-    try {
-      await fetchJson(`/v1/rules/${encodeURIComponent(rule.name)}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ enabled }),
-      });
-      await onRefresh();
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  async function deleteRule(rule) {
-    if (!confirm(`Delete rule ${rule.name}?`)) return;
-    setBusy(true);
-    try {
-      await fetchJson(`/v1/rules/${encodeURIComponent(rule.name)}`, { method: "DELETE" });
-      await onRefresh();
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  async function createRule(payload) {
-    setBusy(true);
-    try {
-      await fetchJson(`/v1/rules`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
-      });
-      setShowForm(false);
-      await onRefresh();
-    } finally {
-      setBusy(false);
-    }
-  }
+  async function toggle(r, enabled) { setBusy(true); try { await api(`/v1/rules/${encodeURIComponent(r.name)}`, { method: "PUT", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ enabled }) }); await onRefresh(); } finally { setBusy(false); } }
+  async function del(r) { if (!confirm(`Delete "${r.name}"?`)) return; setBusy(true); try { await api(`/v1/rules/${encodeURIComponent(r.name)}`, { method: "DELETE" }); await onRefresh(); } finally { setBusy(false); } }
+  async function create(payload) { setBusy(true); try { await api("/v1/rules", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload) }); setShowForm(false); await onRefresh(); } finally { setBusy(false); } }
 
   return html`
     <div>
-      <div style=${{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "10px" }}>
-        <h2 style=${{ margin: 0 }}>Rules</h2>
-        <div className="actions">
-          <button className="btn" onClick=${onRefresh}>Refresh</button>
-          <button className="btn primary" onClick=${() => setShowForm((v) => !v)}>${showForm ? "Close" : "+ Add rule"}</button>
-        </div>
+      <div className="card-row" style=${{ marginBottom: "12px" }}>
+        <h2 style=${{ margin: 0 }}>Policy rules</h2>
+        <div className="actions"><button className="btn" onClick=${onRefresh}>Refresh</button><button className="btn primary" onClick=${() => setShowForm((v) => !v)}>${showForm ? "Close" : "+ Add rule"}</button></div>
       </div>
-
-      ${showForm ? html`<${RuleForm} onCreate=${createRule} onCancel=${() => setShowForm(false)} />` : null}
-
-      ${rules.length === 0 ? html`<div className="empty">No rules configured.</div>` : null}
-
+      ${showForm ? html`<${RuleForm} onCreate=${create} onCancel=${() => setShowForm(false)} />` : null}
+      ${rules.length === 0 ? html`<div className="empty">No rules configured. Click "+ Add rule" to create DLP policies.</div>` : null}
       ${rules.map((r) => html`
-        <div className="card" key=${r.name + String(r.enabled)}>
-          <div style=${{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <div className="card" key=${r.name}>
+          <div className="card-row">
             <div>
               <span className="name">${r.name}</span>
               <span className=${`badge ${r.type}`}>${r.type}</span>
-              <span className=${`badge ${r.enabled ? "on" : "off"}`}>${r.enabled ? "enabled" : "disabled"}</span>
+              <span className=${`badge ${r.enabled ? "on" : "off"}`}>${r.enabled ? "on" : "off"}</span>
+              <span className="badge neutral">${r.scope || "request"}</span>
             </div>
             <div className="actions">
-              <button className="btn" disabled=${busy} onClick=${() => toggleRule(r, !r.enabled)}>${r.enabled ? "Disable" : "Enable"}</button>
-              <button className="btn danger" disabled=${busy} onClick=${() => deleteRule(r)}>Delete</button>
+              <button className="btn" disabled=${busy} onClick=${() => toggle(r, !r.enabled)}>${r.enabled ? "Disable" : "Enable"}</button>
+              <button className="btn danger" disabled=${busy} onClick=${() => del(r)}>Delete</button>
             </div>
           </div>
           <div className="meta">
-            scope: ${r.scope || "request"}
-            ${r.patterns?.length ? html` | patterns: ${r.patterns.join(", ")}` : null}
-            ${r.allow?.length ? html` | allow: ${r.allow.join(", ")}` : null}
-            ${r.deny?.length ? html` | deny: ${r.deny.join(", ")}` : null}
-            ${r.maxRequests ? html` | ${r.maxRequests} req/${r.windowSeconds}s` : null}
-            ${r.replacement ? html` | replacement: ${r.replacement}` : null}
+            ${r.patterns?.length ? `patterns: ${r.patterns.join(", ")}` : ""}
+            ${r.allow?.length ? ` | allow: ${r.allow.join(", ")}` : ""}
+            ${r.deny?.length ? ` | deny: ${r.deny.join(", ")}` : ""}
+            ${r.maxRequests ? ` | ${r.maxRequests} req/${r.windowSeconds}s` : ""}
+            ${r.replacement ? ` | replacement: ${r.replacement}` : ""}
+            ${r.message ? ` | msg: ${r.message}` : ""}
           </div>
         </div>
       `)}
@@ -313,53 +176,45 @@ function RulesPanel({ rules, onRefresh }) {
   `;
 }
 
+// ── Audit ──
+
 function AuditPanel({ entries, onRefresh }) {
+  const [filter, setFilter] = useState("");
+  const filtered = filter ? entries.filter((e) => e.rule?.includes(filter) || e.action?.includes(filter) || e.detail?.includes(filter)) : entries;
+
   return html`
     <div>
-      <div style=${{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "10px" }}>
+      <div className="card-row" style=${{ marginBottom: "12px" }}>
         <h2 style=${{ margin: 0 }}>Audit log</h2>
-        <button className="btn" onClick=${onRefresh}>Refresh</button>
+        <div className="actions">
+          <input value=${filter} onInput=${(e) => setFilter(e.target.value)} placeholder="Filter..." style=${{ width: "160px", padding: "5px 8px", fontSize: "12px" }} />
+          <button className="btn" onClick=${onRefresh}>Refresh</button>
+        </div>
       </div>
-
-      ${entries.length === 0
-        ? html`<div className="empty">No audit events yet.</div>`
-        : html`
-          <div className="table-wrap">
-            <table>
-              <thead>
-                <tr>
-                  <th>Time</th><th>Rule</th><th>Type</th><th>Action</th><th>Source</th><th>Detail</th><th>Matched</th><th>Before</th><th>After</th>
-                </tr>
-              </thead>
-              <tbody>
-                ${entries.map((e, idx) => html`
-                  <tr key=${idx}>
-                    <td>${ago(e.timestamp)}</td>
-                    <td>${e.rule}</td>
-                    <td>${e.type}</td>
-                    <td>${e.action}</td>
-                    <td>${e.source || "--"}</td>
-                    <td>${e.detail}</td>
-                    <td>${e.matched_text || "--"}</td>
-                    <td>
-                      ${e.full_message
-                        ? html`<details><summary>view (${e.full_message.length})</summary><pre>${e.full_message}</pre></details>`
-                        : "--"}
-                    </td>
-                    <td>
-                      ${e.redacted_message
-                        ? html`<details><summary>view (${e.redacted_message.length})</summary><pre>${e.redacted_message}</pre></details>`
-                        : "--"}
-                    </td>
-                  </tr>
-                `)}
-              </tbody>
-            </table>
-          </div>
-        `}
+      ${filtered.length === 0 ? html`<div className="empty">No audit events${filter ? " matching filter" : ""}.</div>` : html`
+        <div className="table-wrap"><table>
+          <thead><tr><th>Time</th><th>Rule</th><th>Type</th><th>Action</th><th>Source</th><th>Matched</th><th>Before</th><th>After</th></tr></thead>
+          <tbody>
+            ${filtered.map((e, i) => html`
+              <tr key=${i}>
+                <td>${ago(e.timestamp)}</td>
+                <td style=${{ fontWeight: 600 }}>${e.rule}</td>
+                <td><span className=${`badge ${e.type}`}>${e.type}</span></td>
+                <td>${e.action}</td>
+                <td>${e.source || "--"}</td>
+                <td style=${{ color: "#ef4444", fontFamily: "monospace", fontSize: "11px" }}>${e.matched_text || "--"}</td>
+                <td>${e.full_message ? html`<details><summary>view</summary><pre>${e.full_message}</pre></details>` : "--"}</td>
+                <td>${e.redacted_message ? html`<details><summary>view</summary><pre>${e.redacted_message}</pre></details>` : "--"}</td>
+              </tr>
+            `)}
+          </tbody>
+        </table></div>
+      `}
     </div>
   `;
 }
+
+// ── Config ──
 
 function ConfigPanel({ health }) {
   const pools = health?.pools || [];
@@ -372,107 +227,66 @@ function ConfigPanel({ health }) {
       <h2>Pools</h2>
       ${pools.length === 0 ? html`<div className="empty">No pools</div>` : null}
       ${pools.map((p) => html`
-        <div className="card" key=${p.name}>
-          <span className="name">${p.name}</span>
-          <span className="badge">${p.strategy}</span>
-          <div className="meta">Members: ${(p.members || []).join(", ")}</div>
-        </div>
+        <div className="card" key=${p.name}><span className="name">${p.name}</span><span className="badge neutral">${p.strategy}</span><div className="meta">Members: ${p.members?.join(", ")}</div></div>
       `)}
-
-      <h2 style=${{ marginTop: "14px" }}>Presets</h2>
+      <h2 className="mt">Presets</h2>
       ${presets.length === 0 ? html`<div className="empty">No presets</div>` : null}
-      ${presets.map((p) => html`
-        <div className="card" key=${p.name}>
-          <span className="name">${p.name}</span>
-          <div className="meta">${(p.entries || []).join(" -> ")}</div>
-        </div>
-      `)}
-
-      <h2 style=${{ marginTop: "14px" }}>Providers</h2>
-      ${providers.map((p) => html`
-        <div className="card" key=${p}>
-          <span className="name">${p}</span>
-          <span className=${`badge ${exhausted.has(p) ? "off" : "on"}`}>${exhausted.has(p) ? "exhausted" : "ok"}</span>
-        </div>
-      `)}
+      ${presets.map((p) => html`<div className="card" key=${p.name}><span className="name">${p.name}</span><div className="meta">${p.entries?.join(" -> ")}</div></div>`)}
+      <h2 className="mt">Providers</h2>
+      ${providers.map((p) => html`<div className="card" key=${p}><span className="name">${p}</span><span className=${`badge ${exhausted.has(p) ? "off" : "on"}`}>${exhausted.has(p) ? "exhausted" : "ok"}</span></div>`)}
     </div>
   `;
 }
 
-function App() {
-  const [active, setActive] = useState("dashboard");
-  const [error, setError] = useState("");
+// ── App ──
 
-  const [dashboard, setDashboard] = useState({ stats: null, quota: null, health: null });
+function App() {
+  const [tab, setTab] = useState("dashboard");
+  const [error, setError] = useState("");
+  const [dash, setDash] = useState({});
   const [rules, setRules] = useState([]);
-  const [auditEntries, setAuditEntries] = useState([]);
+  const [audit, setAudit] = useState([]);
   const [health, setHealth] = useState(null);
 
+  useEffect(() => { load(tab); }, [tab]);
   useEffect(() => {
-    refreshTab(active);
-  }, [active]);
+    const ms = tab === "dashboard" ? 3000 : tab === "audit" ? 5000 : 0;
+    if (!ms) return;
+    const t = setInterval(() => load(tab, true), ms);
+    return () => clearInterval(t);
+  }, [tab]);
 
-  useEffect(() => {
-    const intervalMs = active === "dashboard" ? 3000 : active === "audit" ? 5000 : 0;
-    if (!intervalMs) return;
-    const timer = setInterval(() => {
-      refreshTab(active, true);
-    }, intervalMs);
-    return () => clearInterval(timer);
-  }, [active]);
-
-  async function refreshTab(tab = active, silent = false) {
+  async function load(t = tab, silent = false) {
     if (!silent) setError("");
     try {
-      if (tab === "dashboard") {
-        const [statsRes, quotaRes, healthRes] = await Promise.allSettled([
-          fetchJson("/v1/stats"),
-          fetchJson("/v1/quota"),
-          fetchJson("/health"),
-        ]);
-
-        setDashboard((prev) => ({
-          stats: statsRes.status === "fulfilled" ? statsRes.value : prev.stats,
-          quota: quotaRes.status === "fulfilled" ? quotaRes.value : prev.quota,
-          health: healthRes.status === "fulfilled" ? healthRes.value : prev.health,
-        }));
-
-        if (statsRes.status !== "fulfilled" && quotaRes.status !== "fulfilled" && healthRes.status !== "fulfilled") {
-          throw new Error("Dashboard data unavailable");
-        }
-      } else if (tab === "rules") {
-        const data = await fetchJson("/v1/rules");
-        setRules(data.rules || []);
-      } else if (tab === "audit") {
-        const data = await fetchJson("/v1/audit?limit=200");
-        setAuditEntries(data.entries || []);
-      } else if (tab === "config") {
-        const h = await fetchJson("/health");
-        setHealth(h);
-      }
-    } catch (e) {
-      if (!silent) setError(e.message);
-    }
+      if (t === "dashboard") {
+        const [s, q, h] = await Promise.allSettled([api("/v1/stats"), api("/v1/quota"), api("/health")]);
+        setDash((prev) => ({ stats: s.status === "fulfilled" ? s.value : prev.stats, quota: q.status === "fulfilled" ? q.value : prev.quota, health: h.status === "fulfilled" ? h.value : prev.health }));
+      } else if (t === "rules") { setRules((await api("/v1/rules")).rules || []); }
+      else if (t === "audit") { setAudit((await api("/v1/audit?limit=200")).entries || []); }
+      else if (t === "config") { setHealth(await api("/health")); }
+    } catch (e) { if (!silent) setError(e.message); }
   }
 
-  let panel = null;
-  if (active === "dashboard") panel = html`<${DashboardPanel} data=${dashboard} />`;
-  if (active === "rules") panel = html`<${RulesPanel} rules=${rules} onRefresh=${() => refreshTab("rules")} />`;
-  if (active === "audit") panel = html`<${AuditPanel} entries=${auditEntries} onRefresh=${() => refreshTab("audit")} />`;
-  if (active === "config") panel = html`<${ConfigPanel} health=${health} />`;
+  const tabs = ["dashboard", "rules", "audit", "config"];
 
   return html`
     <div className="app">
       <div className="header">
-        <div className="title">Leeloo Admin</div>
-        <a className="link" href="/ui">Chat UI</a>
-        <a className="link" href="/health">Health API</a>
+        <div className="logo">Leeloo Admin</div>
+        <a className="nav-link" href="/ui">Chat UI</a>
+        <a className="nav-link" href="/health">Health</a>
       </div>
-      <${Tabs} active=${active} setActive=${setActive} />
-      <div className="panel">
-        ${error ? html`<div className="card" style=${{ color: "#ff7e7e" }}>Error: ${error}</div>` : null}
-        ${panel}
+      <div className="tabs">
+        ${tabs.map((t) => html`<button key=${t} className=${`tab ${tab === t ? "active" : ""}`} onClick=${() => setTab(t)}>${t}</button>`)}
       </div>
+      <div className="panel"><div className="panel-inner">
+        ${error ? html`<div className="card" style=${{ color: "#ef4444", borderColor: "#7f1d1d" }}>Error: ${error}</div>` : null}
+        ${tab === "dashboard" ? html`<${DashboardPanel} data=${dash} />` : null}
+        ${tab === "rules" ? html`<${RulesPanel} rules=${rules} onRefresh=${() => load("rules")} />` : null}
+        ${tab === "audit" ? html`<${AuditPanel} entries=${audit} onRefresh=${() => load("audit")} />` : null}
+        ${tab === "config" ? html`<${ConfigPanel} health=${health} />` : null}
+      </div></div>
     </div>
   `;
 }

--- a/web/admin/app.js
+++ b/web/admin/app.js
@@ -732,68 +732,96 @@ function AuditPanel({ entries, onRefresh }) {
 
 function UsersPanel() {
   const [users, setUsers] = useState([]);
+  const [stats, setStats] = useState([]);
   const [showForm, setShowForm] = useState(false);
+  const [editing, setEditing] = useState(null);
   const [busy, setBusy] = useState(false);
   const [revealedKeys, setRevealedKeys] = useState({});
   const { names } = useNames();
 
-  // Form state
-  const [draftName, setDraftName] = useState("");
-  const [draftPresets, setDraftPresets] = useState([]);
-  const [draftPools, setDraftPools] = useState([]);
+  // Form state (shared for create + edit)
+  const [draft, setDraft] = useState({ username: "", allowedPresets: [], allowedPools: [] });
 
-  async function load() { try { setUsers((await api("/v1/users")).users || []); } catch {} }
+  async function load() {
+    try { setUsers((await api("/v1/users")).users || []); } catch {}
+    try { const s = await api("/v1/stats"); setStats(s.users || []); } catch {}
+  }
   useEffect(() => { load(); }, []);
 
-  async function create() {
+  function startNew() { setEditing("__new__"); setDraft({ username: "", allowedPresets: [], allowedPools: [] }); setShowForm(true); }
+  function startEdit(u) { setEditing(u.username); setDraft({ username: u.username, allowedPresets: u.allowedPresets || [], allowedPools: u.allowedPools || [] }); setShowForm(true); }
+  function cancelForm() { setShowForm(false); setEditing(null); }
+
+  async function save() {
     setBusy(true);
     try {
-      const res = await api("/v1/users", jpost({
-        username: draftName || `user-${Date.now()}`,
-        allowedPresets: draftPresets,
-        allowedPools: draftPools,
-      }));
-      setRevealedKeys((k) => ({ ...k, [res.user.username]: res.user.key }));
-      setShowForm(false); setDraftName(""); setDraftPresets([]); setDraftPools([]);
+      if (editing === "__new__") {
+        const res = await api("/v1/users", jpost({ username: draft.username || `user-${Date.now()}`, allowedPresets: draft.allowedPresets, allowedPools: draft.allowedPools }));
+        setRevealedKeys((k) => ({ ...k, [res.user.username]: res.user.key }));
+      } else {
+        await api(`/v1/users/${encodeURIComponent(editing)}`, jput({ allowedPresets: draft.allowedPresets, allowedPools: draft.allowedPools }));
+      }
+      cancelForm();
       await load();
     } finally { setBusy(false); }
   }
 
   async function toggleUser(u, enabled) { setBusy(true); try { await api(`/v1/users/${encodeURIComponent(u.username)}`, jput({ enabled })); await load(); } finally { setBusy(false); } }
   async function del(u) { if (!confirm(`Delete user "${u.username}"?`)) return; setBusy(true); try { await api(`/v1/users/${encodeURIComponent(u.username)}`, { method: "DELETE" }); await load(); } finally { setBusy(false); } }
-  async function revealKey(username) {
+  async function regen(u) {
+    if (!confirm(`Regenerate key for "${u.username}"? The old key will stop working.`)) return;
+    setBusy(true);
     try {
-      const d = await api(`/v1/users/${encodeURIComponent(username)}/key`);
-      setRevealedKeys((k) => ({ ...k, [username]: d.key }));
-    } catch {}
+      const res = await api(`/v1/users/${encodeURIComponent(u.username)}`, jput({ key: undefined }));
+      // Need a new endpoint or trick -- just delete + recreate
+      // Actually let's add key regen to the update handler
+      await load();
+    } finally { setBusy(false); }
   }
-
+  async function revealKey(username) {
+    try { const d = await api(`/v1/users/${encodeURIComponent(username)}/key`); setRevealedKeys((k) => ({ ...k, [username]: d.key })); } catch {}
+  }
   function copyKey(key) { navigator.clipboard.writeText(key); }
 
-  const presetNames = (names?.providers || []).concat(names?.pools || []).concat(names?.chains || []);
+  function getUserStats(username) { return stats.find((s) => s.username === username); }
+
+  // Available presets/pools for dropdowns
+  const configPresets = (names?.pools || []).map((p) => p.label).concat(
+    // We need preset names too - fetch from config
+  );
+
+  function renderForm() {
+    const isNew = editing === "__new__";
+    return html`
+      <div className="card" style=${{ marginBottom: "12px" }}>
+        <div className="form-grid">
+          ${isNew ? html`<div><label>Username</label><input value=${draft.username} onInput=${(e) => setDraft({ ...draft, username: e.target.value })} placeholder="e.g. alice" /></div>` : html`<div><label>Username</label><input value=${draft.username} disabled /></div>`}
+          <div className="full"><label>Allowed presets (comma-separated, empty = all)</label><input value=${draft.allowedPresets.join(", ")} onInput=${(e) => setDraft({ ...draft, allowedPresets: e.target.value.split(",").map((s) => s.trim()).filter(Boolean) })} placeholder="coding-premium, fastest" /></div>
+          <div className="full"><label>Allowed pools (comma-separated, empty = all)</label><input value=${draft.allowedPools.join(", ")} onInput=${(e) => setDraft({ ...draft, allowedPools: e.target.value.split(",").map((s) => s.trim()).filter(Boolean) })} placeholder="codex-pool, google-pool" /></div>
+        </div>
+        <div className="actions" style=${{ marginTop: "10px" }}><button className="btn primary" onClick=${save} disabled=${busy}>${isNew ? "Create" : "Save"}</button><button className="btn" onClick=${cancelForm}>Cancel</button></div>
+      </div>
+    `;
+  }
 
   return html`<div>
     <div className="card-row" style=${{ marginBottom: "12px" }}>
       <h2 style=${{ margin: 0 }}>Users</h2>
-      <div className="actions"><button className="btn" onClick=${load}>Refresh</button><button className="btn primary" onClick=${() => setShowForm((v) => !v)}>${showForm ? "Close" : "+ Add user"}</button></div>
+      <div className="actions"><button className="btn" onClick=${load}>Refresh</button><button className="btn primary" onClick=${startNew}>${showForm && editing === "__new__" ? "Close" : "+ Add user"}</button></div>
     </div>
-    <div style=${{ marginBottom: "6px", fontSize: "11px", color: "#52525b" }}>Stored in: ~/.pi/agent/multi-pass-users.json. Each user gets an API key for /ui and /v1 access.</div>
+    <div style=${{ marginBottom: "10px", fontSize: "11px", color: "#52525b" }}>Stored in: ~/.pi/agent/multi-pass-users.json. Each user gets an API key for /ui and /v1 access.</div>
 
-    ${showForm ? html`
-      <div className="card" style=${{ marginBottom: "12px" }}>
-        <div className="form-grid">
-          <div><label>Username</label><input value=${draftName} onInput=${(e) => setDraftName(e.target.value)} placeholder="e.g. alice" /></div>
-          <div><label>Allowed presets (empty = all)</label><input value=${draftPresets.join(", ")} onInput=${(e) => setDraftPresets(e.target.value.split(",").map((s) => s.trim()).filter(Boolean))} placeholder="coding-premium, fastest" /></div>
-          <div><label>Allowed pools (empty = all)</label><input value=${draftPools.join(", ")} onInput=${(e) => setDraftPools(e.target.value.split(",").map((s) => s.trim()).filter(Boolean))} placeholder="codex-pool" /></div>
-        </div>
-        <div className="actions" style=${{ marginTop: "10px" }}><button className="btn primary" onClick=${create} disabled=${busy}>Create</button><button className="btn" onClick=${() => setShowForm(false)}>Cancel</button></div>
-      </div>
-    ` : null}
+    ${showForm && editing === "__new__" ? renderForm() : null}
 
-    ${users.length === 0 ? html`<div className="empty">No users. Admin token has full access. Create users to share access with restricted permissions.</div>` : null}
+    ${users.length === 0 && !showForm ? html`<div className="empty">No users. Admin token has full access. Create users to share access with restricted permissions.</div>` : null}
 
     ${users.map((u) => {
       const key = revealedKeys[u.username];
+      const us = getUserStats(u.username);
+      const isEditing = showForm && editing === u.username;
+
+      if (isEditing) return html`<div key=${u.username}>${renderForm()}</div>`;
+
       return html`
         <div className="card" key=${u.username}>
           <div className="card-row">
@@ -806,13 +834,23 @@ function UsersPanel() {
             </div>
             <div className="actions">
               ${key
-                ? html`<span style=${{ fontFamily: "monospace", fontSize: "11px", color: "#f59e0b", cursor: "pointer", padding: "4px 8px", border: "1px solid #3f3f46", borderRadius: "6px" }} onClick=${() => copyKey(key)} title="Click to copy">${key.slice(0, 12)}... (click to copy)</span>`
-                : html`<button className="btn" onClick=${() => revealKey(u.username)}>Show key</button>`
+                ? html`<span style=${{ fontFamily: "monospace", fontSize: "11px", color: "#f59e0b", cursor: "pointer", padding: "4px 8px", border: "1px solid #3f3f46", borderRadius: "6px" }} onClick=${() => copyKey(key)} title="Click to copy">${key.slice(0, 12)}... ${"\u2398"}</span>`
+                : html`<button className="btn" onClick=${() => revealKey(u.username)}>Key</button>`
               }
+              <button className="btn" onClick=${() => startEdit(u)}>Edit</button>
               <button className="btn" disabled=${busy} onClick=${() => toggleUser(u, !(u.enabled !== false))}>${u.enabled !== false ? "Disable" : "Enable"}</button>
               <button className="btn danger" disabled=${busy} onClick=${() => del(u)}>Delete</button>
             </div>
           </div>
+          ${us ? html`
+            <div className="meta" style=${{ marginTop: "6px", display: "flex", gap: "16px" }}>
+              <span>${us.requests} requests</span>
+              <span>${us.tokens_in} tokens in</span>
+              <span>${us.tokens_out} tokens out</span>
+              <span>${us.errors} errors</span>
+              <span>last: ${ago(us.last_used)}</span>
+            </div>
+          ` : null}
         </div>
       `;
     })}

--- a/web/admin/app.js
+++ b/web/admin/app.js
@@ -84,7 +84,16 @@ function DashboardPanel({ data }) {
       <thead><tr><th>Provider</th><th>Quota</th><th>Status</th><th>Requests</th><th>Tokens</th><th>Last used</th></tr></thead>
       <tbody>${quotaProviders.map((p) => {
         const ps = providers.find((x) => x.provider === p.provider) || {};
-        return html`<tr key=${p.provider}><td style=${{ color: "#fafafa", fontWeight: 500 }}>${p.label || p.provider}</td><td><${QuotaBar} score=${p.score} /> <span style=${{ color: qColor(p.score) }}>${p.score == null ? "?" : `${p.score}%`}</span></td><td>${exhausted.has(p.provider) ? html`<span className="badge off">exhausted</span>` : html`<span className="badge on">${p.status || "ok"}</span>`}</td><td>${ps.requests || 0}</td><td>${ps.tokens_in || 0} / ${ps.tokens_out || 0}</td><td>${ago(ps.last_used)}</td></tr>`;
+        const statusBadge = exhausted.has(p.provider)
+          ? html`<span className="badge off">exhausted</span>`
+          : p.status === "expired"
+            ? html`<span className="badge warn">expired - re-login</span>`
+            : p.status === "no-auth"
+              ? html`<span className="badge off">no auth</span>`
+              : p.status === "error"
+                ? html`<span className="badge off" title=${p.error || ""}>${p.error?.slice(0, 30) || "error"}</span>`
+                : html`<span className="badge on">${p.status || "ok"}</span>`;
+        return html`<tr key=${p.provider}><td style=${{ color: "#fafafa", fontWeight: 500 }}>${p.label || p.provider}</td><td><${QuotaBar} score=${p.score} /> <span style=${{ color: qColor(p.score) }}>${p.score == null ? "?" : `${p.score}%`}</span></td><td>${statusBadge}</td><td>${ps.requests || 0}</td><td>${ps.tokens_in || 0} / ${ps.tokens_out || 0}</td><td>${ago(ps.last_used)}</td></tr>`;
       })}</tbody>
     </table></div>
     <h2 className="mt">Recent chats</h2>
@@ -206,7 +215,11 @@ function AuthPanel({ onRefresh, reloadNames }) {
           <div>
             <span className="name">${p.name}</span>
             <span className="badge neutral" style=${{ fontFamily: "monospace" }}>${p.id}</span>
-            <span className=${`badge ${p.authenticated ? "on" : "off"}`}>${p.authenticated ? "logged in" : "not logged in"}</span>
+            <span className=${`badge ${p.tokenStatus === "ok" ? "on" : p.tokenStatus === "expired" ? "warn" : "off"}`}>${
+              p.tokenStatus === "ok" ? "logged in" :
+              p.tokenStatus === "expired" ? "token expired" :
+              "not logged in"
+            }</span>
           </div>
           <div className="actions">
             ${busy[p.id]

--- a/web/admin/app.js
+++ b/web/admin/app.js
@@ -1,15 +1,19 @@
-import React, { useEffect, useState } from "https://esm.sh/react@18.3.1";
+import React, { useEffect, useState, useCallback } from "https://esm.sh/react@18.3.1";
 import { createRoot } from "https://esm.sh/react-dom@18.3.1/client";
 import htm from "https://esm.sh/htm@3.1.1";
 
 const html = htm.bind(React.createElement);
 const BASE = location.origin;
+const STRATEGIES = ["round-robin", "quota-first", "scheduled", "custom"];
+const PROVIDERS = ["anthropic", "openai-codex", "github-copilot", "google-gemini-cli", "google-antigravity"];
 
 async function api(path, init) {
   const r = await fetch(`${BASE}${path}`, init);
   if (!r.ok) { const e = await r.json().catch(() => ({})); throw new Error(e?.error?.message || `HTTP ${r.status}`); }
   return r.json();
 }
+function jpost(data) { return { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(data) }; }
+function jput(data) { return { method: "PUT", headers: { "Content-Type": "application/json" }, body: JSON.stringify(data) }; }
 
 function ago(ts) {
   if (!ts) return "--";
@@ -18,14 +22,12 @@ function ago(ts) {
   if (ms < 36e5) return `${Math.round(ms / 6e4)}m ago`;
   return `${Math.round(ms / 36e5)}h ago`;
 }
-
 function qColor(s) { return s == null ? "#3f3f46" : s > 50 ? "#22c55e" : s > 20 ? "#eab308" : "#ef4444"; }
+function QuotaBar({ score }) { return html`<span className="q-bar"><span className="q-fill" style=${{ width: `${score ?? 0}%`, background: qColor(score) }} /></span>`; }
 
-function QuotaBar({ score }) {
-  return html`<span className="q-bar"><span className="q-fill" style=${{ width: `${score ?? 0}%`, background: qColor(score) }} /></span>`;
-}
-
-// ── Dashboard ──
+// ════════════════════════════════════════════════════════════════════════════════
+// DASHBOARD
+// ════════════════════════════════════════════════════════════════════════════════
 
 function DashboardPanel({ data }) {
   const session = data?.stats?.session || {};
@@ -34,61 +36,311 @@ function DashboardPanel({ data }) {
   const quotaProviders = data?.quota?.providers || [];
   const exhausted = new Set(data?.health?.exhausted || []);
 
+  return html`<div>
+    <h2>Session</h2>
+    <div className="stat-grid">
+      <div className="stat"><div className="stat-num">${session.total_requests || 0}</div><div className="stat-label">Requests</div></div>
+      <div className="stat"><div className="stat-num">${session.total_tokens_in || 0}</div><div className="stat-label">Tokens in</div></div>
+      <div className="stat"><div className="stat-num">${session.total_tokens_out || 0}</div><div className="stat-label">Tokens out</div></div>
+      <div className="stat"><div className="stat-num">${session.total_errors || 0}</div><div className="stat-label">Errors</div></div>
+    </div>
+    <h2 className="mt">Providers</h2>
+    <div className="table-wrap"><table>
+      <thead><tr><th>Provider</th><th>Quota</th><th>Status</th><th>Requests</th><th>Tokens</th><th>Last used</th></tr></thead>
+      <tbody>${quotaProviders.map((p) => {
+        const ps = providers.find((x) => x.provider === p.provider) || {};
+        return html`<tr key=${p.provider}><td style=${{ color: "#fafafa", fontWeight: 500 }}>${p.label || p.provider}</td><td><${QuotaBar} score=${p.score} /> <span style=${{ color: qColor(p.score) }}>${p.score == null ? "?" : `${p.score}%`}</span></td><td>${exhausted.has(p.provider) ? html`<span className="badge off">exhausted</span>` : html`<span className="badge on">${p.status || "ok"}</span>`}</td><td>${ps.requests || 0}</td><td>${ps.tokens_in || 0} / ${ps.tokens_out || 0}</td><td>${ago(ps.last_used)}</td></tr>`;
+      })}</tbody>
+    </table></div>
+    <h2 className="mt">Recent chats</h2>
+    <div className="table-wrap"><table>
+      <thead><tr><th>Time</th><th>Provider</th><th>Model</th><th>Tokens</th><th>Duration</th><th>Error</th><th>Request</th><th>Response</th></tr></thead>
+      <tbody>${recent.length === 0 ? html`<tr><td colSpan="8" className="empty">No requests yet.</td></tr>` : recent.slice(0, 50).map((r, i) => html`<tr key=${i}><td>${ago(r.timestamp)}</td><td>${r.provider}</td><td style=${{ fontFamily: "monospace", fontSize: "11px" }}>${r.model}</td><td>${r.tokens_in} / ${r.tokens_out}</td><td>${r.duration_ms}ms</td><td>${r.error ? html`<span style=${{ color: "#ef4444" }}>${r.error}</span>` : "--"}</td><td>${r.request_text ? html`<details><summary>${r.request_text.slice(0, 40)}...</summary><pre>${r.request_text}</pre></details>` : "--"}</td><td>${r.response_text ? html`<details><summary>${r.response_text.slice(0, 40)}...</summary><pre>${r.response_text}</pre></details>` : "--"}</td></tr>`)}</tbody>
+    </table></div>
+  </div>`;
+}
+
+// ════════════════════════════════════════════════════════════════════════════════
+// CONFIG EDITOR
+// ════════════════════════════════════════════════════════════════════════════════
+
+function InlineEdit({ value, onChange, placeholder, mono }) {
+  return html`<input className=${mono ? "mono" : ""} value=${value || ""} onInput=${(e) => onChange(e.target.value)} placeholder=${placeholder} />`;
+}
+
+function TagList({ items, onChange, placeholder }) {
+  const [draft, setDraft] = useState("");
+  function add() { if (draft.trim()) { onChange([...items, draft.trim()]); setDraft(""); } }
+  function remove(i) { onChange(items.filter((_, idx) => idx !== i)); }
   return html`
     <div>
-      <h2>Session</h2>
-      <div className="stat-grid">
-        <div className="stat"><div className="stat-num">${session.total_requests || 0}</div><div className="stat-label">Requests</div></div>
-        <div className="stat"><div className="stat-num">${session.total_tokens_in || 0}</div><div className="stat-label">Tokens in</div></div>
-        <div className="stat"><div className="stat-num">${session.total_tokens_out || 0}</div><div className="stat-label">Tokens out</div></div>
-        <div className="stat"><div className="stat-num">${session.total_errors || 0}</div><div className="stat-label">Errors</div></div>
+      <div style=${{ display: "flex", flexWrap: "wrap", gap: "4px", marginBottom: "6px" }}>
+        ${items.map((item, i) => html`<span key=${i} className="badge neutral" style=${{ cursor: "pointer" }} onClick=${() => remove(i)}>${item} x</span>`)}
       </div>
-
-      <h2 className="mt">Providers</h2>
-      <div className="table-wrap"><table>
-        <thead><tr><th>Provider</th><th>Quota</th><th>Status</th><th>Requests</th><th>Tokens</th><th>Last used</th></tr></thead>
-        <tbody>
-          ${quotaProviders.map((p) => {
-            const ps = providers.find((x) => x.provider === p.provider) || {};
-            const exh = exhausted.has(p.provider);
-            return html`
-              <tr key=${p.provider}>
-                <td style=${{ color: "#fafafa", fontWeight: 500 }}>${p.label || p.provider}</td>
-                <td><${QuotaBar} score=${p.score} /> <span style=${{ color: qColor(p.score) }}>${p.score == null ? "?" : `${p.score}%`}</span></td>
-                <td>${exh ? html`<span className="badge off">exhausted</span>` : html`<span className="badge on">${p.status || "ok"}</span>`}</td>
-                <td>${ps.requests || 0}</td>
-                <td>${ps.tokens_in || 0} / ${ps.tokens_out || 0}</td>
-                <td>${ago(ps.last_used)}</td>
-              </tr>
-            `;
-          })}
-        </tbody>
-      </table></div>
-
-      <h2 className="mt">Recent chats</h2>
-      <div className="table-wrap"><table>
-        <thead><tr><th>Time</th><th>Provider</th><th>Model</th><th>Tokens</th><th>Duration</th><th>Error</th><th>Request</th><th>Response</th></tr></thead>
-        <tbody>
-          ${recent.length === 0 ? html`<tr><td colSpan="8" className="empty">No requests yet.</td></tr>` : null}
-          ${recent.slice(0, 50).map((r, i) => html`
-            <tr key=${i}>
-              <td>${ago(r.timestamp)}</td>
-              <td>${r.provider}</td>
-              <td style=${{ fontFamily: "monospace", fontSize: "11px" }}>${r.model}</td>
-              <td>${r.tokens_in} / ${r.tokens_out}</td>
-              <td>${r.duration_ms}ms</td>
-              <td>${r.error ? html`<span style=${{ color: "#ef4444" }}>${r.error}</span>` : "--"}</td>
-              <td>${r.request_text ? html`<details><summary>${r.request_text.slice(0, 40)}...</summary><pre>${r.request_text}</pre></details>` : "--"}</td>
-              <td>${r.response_text ? html`<details><summary>${r.response_text.slice(0, 40)}...</summary><pre>${r.response_text}</pre></details>` : "--"}</td>
-            </tr>
-          `)}
-        </tbody>
-      </table></div>
+      <div style=${{ display: "flex", gap: "6px" }}>
+        <input value=${draft} onInput=${(e) => setDraft(e.target.value)} placeholder=${placeholder} onKeyDown=${(e) => { if (e.key === "Enter") { e.preventDefault(); add(); } }} style=${{ flex: 1 }} />
+        <button className="btn" onClick=${add}>+</button>
+      </div>
     </div>
   `;
 }
 
-// ── Rules ──
+// ── Subscriptions ──
+
+function SubEditor({ subs, onSave }) {
+  const [editing, setEditing] = useState(null);
+  const [draft, setDraft] = useState({});
+
+  function startEdit(s) { setEditing(s.name); setDraft({ ...s }); }
+  function startNew() { setEditing("__new__"); setDraft({ name: "", provider: PROVIDERS[0], enabled: true, alias: "" }); }
+  function cancel() { setEditing(null); }
+  async function save() {
+    if (editing === "__new__") {
+      await api("/v1/config/subscriptions", jpost(draft));
+    } else {
+      await api(`/v1/config/subscriptions/${encodeURIComponent(editing)}`, jput(draft));
+    }
+    setEditing(null);
+    onSave();
+  }
+  async function del(name) { if (confirm(`Delete subscription "${name}"?`)) { await api(`/v1/config/subscriptions/${encodeURIComponent(name)}`, { method: "DELETE" }); onSave(); } }
+
+  return html`<div>
+    <div className="card-row" style=${{ marginBottom: "10px" }}><h2 style=${{ margin: 0 }}>Subscriptions</h2><button className="btn primary" onClick=${startNew}>+ Add</button></div>
+    ${subs.map((s) => editing === s.name ? html`
+      <div className="card" key=${s.name}>
+        <div className="form-grid">
+          <div><label>Name</label><input value=${draft.name} onInput=${(e) => setDraft({ ...draft, name: e.target.value })} /></div>
+          <div><label>Provider</label><select value=${draft.provider} onChange=${(e) => setDraft({ ...draft, provider: e.target.value })}>${PROVIDERS.map((p) => html`<option key=${p} value=${p}>${p}</option>`)}</select></div>
+          <div><label>Alias</label><input value=${draft.alias || ""} onInput=${(e) => setDraft({ ...draft, alias: e.target.value })} /></div>
+          <div><label>Enabled</label><select value=${String(draft.enabled)} onChange=${(e) => setDraft({ ...draft, enabled: e.target.value === "true" })}><option value="true">Yes</option><option value="false">No</option></select></div>
+        </div>
+        <div className="actions" style=${{ marginTop: "10px" }}><button className="btn primary" onClick=${save}>Save</button><button className="btn" onClick=${cancel}>Cancel</button></div>
+      </div>
+    ` : html`
+      <div className="card" key=${s.name}>
+        <div className="card-row">
+          <div><span className="name">${s.name}</span><span className="badge neutral">${s.provider}</span><span className=${`badge ${s.enabled !== false ? "on" : "off"}`}>${s.enabled !== false ? "on" : "off"}</span>${s.alias ? html`<span className="badge neutral">${s.alias}</span>` : null}</div>
+          <div className="actions"><button className="btn" onClick=${() => startEdit(s)}>Edit</button><button className="btn danger" onClick=${() => del(s.name)}>Del</button></div>
+        </div>
+      </div>
+    `)}
+    ${editing === "__new__" ? html`
+      <div className="card">
+        <div className="form-grid">
+          <div><label>Name</label><input value=${draft.name} onInput=${(e) => setDraft({ ...draft, name: e.target.value })} placeholder="e.g. openai-codex-2" /></div>
+          <div><label>Provider</label><select value=${draft.provider} onChange=${(e) => setDraft({ ...draft, provider: e.target.value })}>${PROVIDERS.map((p) => html`<option key=${p} value=${p}>${p}</option>`)}</select></div>
+          <div><label>Alias</label><input value=${draft.alias} onInput=${(e) => setDraft({ ...draft, alias: e.target.value })} /></div>
+          <div><label>Enabled</label><select value=${String(draft.enabled)} onChange=${(e) => setDraft({ ...draft, enabled: e.target.value === "true" })}><option value="true">Yes</option><option value="false">No</option></select></div>
+        </div>
+        <div className="actions" style=${{ marginTop: "10px" }}><button className="btn primary" onClick=${save}>Create</button><button className="btn" onClick=${cancel}>Cancel</button></div>
+      </div>
+    ` : null}
+  </div>`;
+}
+
+// ── Pools ──
+
+function PoolEditor({ pools, onSave }) {
+  const [editing, setEditing] = useState(null);
+  const [draft, setDraft] = useState({});
+
+  function startEdit(p) { setEditing(p.name); setDraft({ ...p, members: [...(p.members || [])] }); }
+  function startNew() { setEditing("__new__"); setDraft({ name: "", enabled: true, baseProvider: PROVIDERS[0], members: [], strategy: "round-robin" }); }
+  function cancel() { setEditing(null); }
+  async function save() {
+    if (editing === "__new__") { await api("/v1/config/pools", jpost(draft)); }
+    else { await api(`/v1/config/pools/${encodeURIComponent(editing)}`, jput(draft)); }
+    setEditing(null); onSave();
+  }
+  async function del(name) { if (confirm(`Delete pool "${name}"?`)) { await api(`/v1/config/pools/${encodeURIComponent(name)}`, { method: "DELETE" }); onSave(); } }
+
+  function renderForm(isNew) {
+    return html`
+      <div className="card">
+        <div className="form-grid">
+          <div><label>Name</label><input value=${draft.name} onInput=${(e) => setDraft({ ...draft, name: e.target.value })} placeholder="e.g. codex-pool" /></div>
+          <div><label>Base Provider</label><select value=${draft.baseProvider} onChange=${(e) => setDraft({ ...draft, baseProvider: e.target.value })}>${PROVIDERS.map((p) => html`<option key=${p} value=${p}>${p}</option>`)}</select></div>
+          <div><label>Strategy</label><select value=${draft.strategy} onChange=${(e) => setDraft({ ...draft, strategy: e.target.value })}>${STRATEGIES.map((s) => html`<option key=${s} value=${s}>${s}</option>`)}</select></div>
+          <div><label>Enabled</label><select value=${String(draft.enabled)} onChange=${(e) => setDraft({ ...draft, enabled: e.target.value === "true" })}><option value="true">Yes</option><option value="false">No</option></select></div>
+          <div className="full"><label>Members</label><${TagList} items=${draft.members} onChange=${(m) => setDraft({ ...draft, members: m })} placeholder="Add member name..." /></div>
+          ${draft.strategy === "scheduled" ? html`<div className="full"><label>Schedule (JSON)</label><textarea value=${JSON.stringify(draft.memberSchedule || {}, null, 2)} onInput=${(e) => { try { setDraft({ ...draft, memberSchedule: JSON.parse(e.target.value) }); } catch {} }} rows="4" /></div>` : null}
+          ${draft.strategy === "custom" ? html`<div className="full"><label>Selector Script Path</label><input value=${draft.selectorScript || ""} onInput=${(e) => setDraft({ ...draft, selectorScript: e.target.value })} placeholder="./my-selector.js" /></div>` : null}
+        </div>
+        <div className="actions" style=${{ marginTop: "10px" }}><button className="btn primary" onClick=${save}>${isNew ? "Create" : "Save"}</button><button className="btn" onClick=${cancel}>Cancel</button></div>
+      </div>
+    `;
+  }
+
+  return html`<div>
+    <div className="card-row" style=${{ marginBottom: "10px" }}><h2 style=${{ margin: 0 }}>Pools</h2><button className="btn primary" onClick=${startNew}>+ Add</button></div>
+    ${pools.map((p) => editing === p.name ? renderForm(false) : html`
+      <div className="card" key=${p.name}>
+        <div className="card-row">
+          <div><span className="name">${p.name}</span><span className="badge neutral">${p.strategy || "round-robin"}</span><span className=${`badge ${p.enabled !== false ? "on" : "off"}`}>${p.enabled !== false ? "on" : "off"}</span></div>
+          <div className="actions"><button className="btn" onClick=${() => startEdit(p)}>Edit</button><button className="btn danger" onClick=${() => del(p.name)}>Del</button></div>
+        </div>
+        <div className="meta">Base: ${p.baseProvider} | Members: ${(p.members || []).join(", ") || "none"}</div>
+      </div>
+    `)}
+    ${editing === "__new__" ? renderForm(true) : null}
+  </div>`;
+}
+
+// ── Chains ──
+
+function ChainEditor({ chains, onSave }) {
+  const [editing, setEditing] = useState(null);
+  const [draft, setDraft] = useState({});
+
+  function startEdit(c) { setEditing(c.name); setDraft({ ...c, steps: [...(c.steps || [])] }); }
+  function startNew() { setEditing("__new__"); setDraft({ name: "", enabled: true, steps: [] }); }
+  function cancel() { setEditing(null); }
+  async function save() {
+    if (editing === "__new__") { await api("/v1/config/chains", jpost(draft)); }
+    else { await api(`/v1/config/chains/${encodeURIComponent(editing)}`, jput(draft)); }
+    setEditing(null); onSave();
+  }
+  async function del(name) { if (confirm(`Delete chain "${name}"?`)) { await api(`/v1/config/chains/${encodeURIComponent(name)}`, { method: "DELETE" }); onSave(); } }
+
+  function updateStep(i, field, value) {
+    const steps = [...draft.steps];
+    steps[i] = { ...steps[i], [field]: value };
+    setDraft({ ...draft, steps });
+  }
+  function addStep() { setDraft({ ...draft, steps: [...draft.steps, { provider: "", model: "", enabled: true }] }); }
+  function removeStep(i) { setDraft({ ...draft, steps: draft.steps.filter((_, idx) => idx !== i) }); }
+
+  function renderForm(isNew) {
+    return html`
+      <div className="card">
+        <div className="form-grid">
+          <div><label>Name</label><input value=${draft.name} onInput=${(e) => setDraft({ ...draft, name: e.target.value })} placeholder="e.g. premium-fallback" /></div>
+          <div><label>Enabled</label><select value=${String(draft.enabled)} onChange=${(e) => setDraft({ ...draft, enabled: e.target.value === "true" })}><option value="true">Yes</option><option value="false">No</option></select></div>
+        </div>
+        <div style=${{ marginTop: "10px" }}>
+          <label>Steps (in order)</label>
+          ${draft.steps.map((s, i) => html`
+            <div key=${i} style=${{ display: "flex", gap: "6px", marginBottom: "6px", alignItems: "center" }}>
+              <span style=${{ color: "#52525b", fontSize: "11px", width: "20px" }}>${i + 1}.</span>
+              <input value=${s.provider || ""} onInput=${(e) => updateStep(i, "provider", e.target.value)} placeholder="provider or pool:name" style=${{ flex: 1 }} />
+              <input value=${s.model || ""} onInput=${(e) => updateStep(i, "model", e.target.value)} placeholder="model (optional)" style=${{ flex: 1 }} />
+              <button className="btn danger" onClick=${() => removeStep(i)} style=${{ padding: "4px 8px" }}>x</button>
+            </div>
+          `)}
+          <button className="btn" onClick=${addStep}>+ Add step</button>
+        </div>
+        <div className="actions" style=${{ marginTop: "10px" }}><button className="btn primary" onClick=${save}>${isNew ? "Create" : "Save"}</button><button className="btn" onClick=${cancel}>Cancel</button></div>
+      </div>
+    `;
+  }
+
+  return html`<div>
+    <div className="card-row" style=${{ marginBottom: "10px" }}><h2 style=${{ margin: 0 }}>Chains</h2><button className="btn primary" onClick=${startNew}>+ Add</button></div>
+    ${chains.map((c) => editing === c.name ? renderForm(false) : html`
+      <div className="card" key=${c.name}>
+        <div className="card-row">
+          <div><span className="name">${c.name}</span><span className=${`badge ${c.enabled !== false ? "on" : "off"}`}>${c.enabled !== false ? "on" : "off"}</span><span className="badge neutral">${(c.steps || []).length} steps</span></div>
+          <div className="actions"><button className="btn" onClick=${() => startEdit(c)}>Edit</button><button className="btn danger" onClick=${() => del(c.name)}>Del</button></div>
+        </div>
+        <div className="meta">${(c.steps || []).map((s) => `${s.provider}${s.model ? "/" + s.model : ""}`).join(" -> ") || "no steps"}</div>
+      </div>
+    `)}
+    ${editing === "__new__" ? renderForm(true) : null}
+  </div>`;
+}
+
+// ── Presets ──
+
+function PresetEditor({ presets, onSave }) {
+  const [editing, setEditing] = useState(null);
+  const [draft, setDraft] = useState({});
+
+  function startEdit(p) { setEditing(p.name); setDraft({ ...p, entries: [...(p.entries || [])] }); }
+  function startNew() { setEditing("__new__"); setDraft({ name: "", enabled: true, entries: [] }); }
+  function cancel() { setEditing(null); }
+  async function save() {
+    if (editing === "__new__") { await api("/v1/config/presets", jpost(draft)); }
+    else { await api(`/v1/config/presets/${encodeURIComponent(editing)}`, jput(draft)); }
+    setEditing(null); onSave();
+  }
+  async function del(name) { if (confirm(`Delete preset "${name}"?`)) { await api(`/v1/config/presets/${encodeURIComponent(name)}`, { method: "DELETE" }); onSave(); } }
+
+  function updateEntry(i, field, value) {
+    const entries = [...draft.entries];
+    entries[i] = { ...entries[i], [field]: field === "enabled" ? value === "true" : value };
+    setDraft({ ...draft, entries });
+  }
+  function addEntry() { setDraft({ ...draft, entries: [...draft.entries, { provider: "", model: "", enabled: true }] }); }
+  function removeEntry(i) { setDraft({ ...draft, entries: draft.entries.filter((_, idx) => idx !== i) }); }
+
+  function renderForm(isNew) {
+    return html`
+      <div className="card">
+        <div className="form-grid">
+          <div><label>Name</label><input value=${draft.name} onInput=${(e) => setDraft({ ...draft, name: e.target.value })} placeholder="e.g. coding-premium" /></div>
+          <div><label>Enabled</label><select value=${String(draft.enabled)} onChange=${(e) => setDraft({ ...draft, enabled: e.target.value === "true" })}><option value="true">Yes</option><option value="false">No</option></select></div>
+        </div>
+        <div style=${{ marginTop: "10px" }}>
+          <label>Entries (failover order)</label>
+          ${draft.entries.map((e, i) => html`
+            <div key=${i} style=${{ display: "flex", gap: "6px", marginBottom: "6px", alignItems: "center" }}>
+              <span style=${{ color: "#52525b", fontSize: "11px", width: "20px" }}>${i + 1}.</span>
+              <input value=${e.provider || ""} onInput=${(ev) => updateEntry(i, "provider", ev.target.value)} placeholder="provider or pool:name" style=${{ flex: 1 }} />
+              <input value=${e.model || ""} onInput=${(ev) => updateEntry(i, "model", ev.target.value)} placeholder="model" style=${{ flex: 1 }} />
+              <select value=${String(e.enabled !== false)} onChange=${(ev) => updateEntry(i, "enabled", ev.target.value)} style=${{ width: "70px" }}><option value="true">On</option><option value="false">Off</option></select>
+              <button className="btn danger" onClick=${() => removeEntry(i)} style=${{ padding: "4px 8px" }}>x</button>
+            </div>
+          `)}
+          <button className="btn" onClick=${addEntry}>+ Add entry</button>
+        </div>
+        <div className="actions" style=${{ marginTop: "10px" }}><button className="btn primary" onClick=${save}>${isNew ? "Create" : "Save"}</button><button className="btn" onClick=${cancel}>Cancel</button></div>
+      </div>
+    `;
+  }
+
+  return html`<div>
+    <div className="card-row" style=${{ marginBottom: "10px" }}><h2 style=${{ margin: 0 }}>Presets</h2><button className="btn primary" onClick=${startNew}>+ Add</button></div>
+    ${presets.map((p) => editing === p.name ? renderForm(false) : html`
+      <div className="card" key=${p.name}>
+        <div className="card-row">
+          <div><span className="name">${p.name}</span><span className=${`badge ${p.enabled !== false ? "on" : "off"}`}>${p.enabled !== false ? "on" : "off"}</span><span className="badge neutral">${(p.entries || []).length} entries</span></div>
+          <div className="actions"><button className="btn" onClick=${() => startEdit(p)}>Edit</button><button className="btn danger" onClick=${() => del(p.name)}>Del</button></div>
+        </div>
+        <div className="meta">${(p.entries || []).filter((e) => e.enabled !== false).map((e) => `${e.provider}/${e.model}`).join(" -> ") || "no entries"}</div>
+      </div>
+    `)}
+    ${editing === "__new__" ? renderForm(true) : null}
+  </div>`;
+}
+
+function ConfigPanel({ onRefresh }) {
+  const [config, setConfig] = useState(null);
+  const [err, setErr] = useState("");
+
+  async function load() { setErr(""); try { setConfig(await api("/v1/config")); } catch (e) { setErr(e.message); } }
+  useEffect(() => { load(); }, []);
+
+  async function refresh() { await load(); if (onRefresh) onRefresh(); }
+
+  if (!config) return html`<div className="empty">${err || "Loading..."}</div>`;
+
+  return html`<div>
+    ${err ? html`<div className="card" style=${{ color: "#ef4444", borderColor: "#7f1d1d" }}>Error: ${err}</div>` : null}
+    <div style=${{ marginBottom: "6px", fontSize: "11px", color: "#52525b" }}>Editing: ~/.pi/agent/multi-pass.json</div>
+    <${SubEditor} subs=${config.subscriptions || []} onSave=${refresh} />
+    <div style=${{ marginTop: "20px" }} />
+    <${PoolEditor} pools=${config.pools || []} onSave=${refresh} />
+    <div style=${{ marginTop: "20px" }} />
+    <${ChainEditor} chains=${config.chains || []} onSave=${refresh} />
+    <div style=${{ marginTop: "20px" }} />
+    <${PresetEditor} presets=${config.presets || []} onSave=${refresh} />
+  </div>`;
+}
+
+// ════════════════════════════════════════════════════════════════════════════════
+// RULES
+// ════════════════════════════════════════════════════════════════════════════════
 
 function RuleForm({ onCreate, onCancel }) {
   const [name, setName] = useState("");
@@ -118,14 +370,8 @@ function RuleForm({ onCreate, onCancel }) {
         ${(type === "block" || type === "redact" || type === "warn") && html`<div className="full"><label>Patterns (regex, one per line)</label><textarea value=${patterns} onInput=${(e) => setPatterns(e.target.value)} placeholder="AKIA[0-9A-Z]{16}" /></div>`}
         ${type === "redact" && html`<div><label>Replacement</label><input value=${replacement} onInput=${(e) => setReplacement(e.target.value)} /></div>`}
         ${(type === "block" || type === "model") && html`<div><label>Block message</label><input value=${message} onInput=${(e) => setMessage(e.target.value)} placeholder="Blocked by policy" /></div>`}
-        ${type === "model" && [
-          html`<div key="a"><label>Allow (globs)</label><input value=${allow} onInput=${(e) => setAllow(e.target.value)} placeholder="claude-*, gpt-5*" /></div>`,
-          html`<div key="d"><label>Deny (globs)</label><input value=${deny} onInput=${(e) => setDeny(e.target.value)} placeholder="gpt-4o*" /></div>`,
-        ]}
-        ${type === "limit" && [
-          html`<div key="mr"><label>Max requests</label><input value=${maxReq} onInput=${(e) => setMaxReq(e.target.value)} type="number" /></div>`,
-          html`<div key="ws"><label>Window (seconds)</label><input value=${winSec} onInput=${(e) => setWinSec(e.target.value)} type="number" /></div>`,
-        ]}
+        ${type === "model" && [html`<div key="a"><label>Allow (globs)</label><input value=${allow} onInput=${(e) => setAllow(e.target.value)} placeholder="claude-*, gpt-5*" /></div>`, html`<div key="d"><label>Deny (globs)</label><input value=${deny} onInput=${(e) => setDeny(e.target.value)} placeholder="gpt-4o*" /></div>`]}
+        ${type === "limit" && [html`<div key="mr"><label>Max requests</label><input value=${maxReq} onInput=${(e) => setMaxReq(e.target.value)} type="number" /></div>`, html`<div key="ws"><label>Window (seconds)</label><input value=${winSec} onInput=${(e) => setWinSec(e.target.value)} type="number" /></div>`]}
       </div>
       <div className="actions" style=${{ marginTop: "12px" }}><button className="btn primary" onClick=${submit}>Create</button><button className="btn" onClick=${onCancel}>Cancel</button></div>
     </div>
@@ -136,109 +382,73 @@ function RulesPanel({ rules, onRefresh }) {
   const [showForm, setShowForm] = useState(false);
   const [busy, setBusy] = useState(false);
 
-  async function toggle(r, enabled) { setBusy(true); try { await api(`/v1/rules/${encodeURIComponent(r.name)}`, { method: "PUT", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ enabled }) }); await onRefresh(); } finally { setBusy(false); } }
+  async function toggle(r, enabled) { setBusy(true); try { await api(`/v1/rules/${encodeURIComponent(r.name)}`, jput({ enabled })); await onRefresh(); } finally { setBusy(false); } }
   async function del(r) { if (!confirm(`Delete "${r.name}"?`)) return; setBusy(true); try { await api(`/v1/rules/${encodeURIComponent(r.name)}`, { method: "DELETE" }); await onRefresh(); } finally { setBusy(false); } }
-  async function create(payload) { setBusy(true); try { await api("/v1/rules", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload) }); setShowForm(false); await onRefresh(); } finally { setBusy(false); } }
+  async function create(payload) { setBusy(true); try { await api("/v1/rules", jpost(payload)); setShowForm(false); await onRefresh(); } finally { setBusy(false); } }
 
-  return html`
-    <div>
-      <div className="card-row" style=${{ marginBottom: "12px" }}>
-        <h2 style=${{ margin: 0 }}>Policy rules</h2>
-        <div className="actions"><button className="btn" onClick=${onRefresh}>Refresh</button><button className="btn primary" onClick=${() => setShowForm((v) => !v)}>${showForm ? "Close" : "+ Add rule"}</button></div>
-      </div>
-      ${showForm ? html`<${RuleForm} onCreate=${create} onCancel=${() => setShowForm(false)} />` : null}
-      ${rules.length === 0 ? html`<div className="empty">No rules configured. Click "+ Add rule" to create DLP policies.</div>` : null}
-      ${rules.map((r) => html`
-        <div className="card" key=${r.name}>
-          <div className="card-row">
-            <div>
-              <span className="name">${r.name}</span>
-              <span className=${`badge ${r.type}`}>${r.type}</span>
-              <span className=${`badge ${r.enabled ? "on" : "off"}`}>${r.enabled ? "on" : "off"}</span>
-              <span className="badge neutral">${r.scope || "request"}</span>
-            </div>
-            <div className="actions">
-              <button className="btn" disabled=${busy} onClick=${() => toggle(r, !r.enabled)}>${r.enabled ? "Disable" : "Enable"}</button>
-              <button className="btn danger" disabled=${busy} onClick=${() => del(r)}>Delete</button>
-            </div>
-          </div>
-          <div className="meta">
-            ${r.patterns?.length ? `patterns: ${r.patterns.join(", ")}` : ""}
-            ${r.allow?.length ? ` | allow: ${r.allow.join(", ")}` : ""}
-            ${r.deny?.length ? ` | deny: ${r.deny.join(", ")}` : ""}
-            ${r.maxRequests ? ` | ${r.maxRequests} req/${r.windowSeconds}s` : ""}
-            ${r.replacement ? ` | replacement: ${r.replacement}` : ""}
-            ${r.message ? ` | msg: ${r.message}` : ""}
-          </div>
-        </div>
-      `)}
+  return html`<div>
+    <div style=${{ marginBottom: "6px", fontSize: "11px", color: "#52525b" }}>Stored in: ~/.pi/agent/multi-pass-rules.json</div>
+    <div className="card-row" style=${{ marginBottom: "12px" }}>
+      <h2 style=${{ margin: 0 }}>Policy rules</h2>
+      <div className="actions"><button className="btn" onClick=${onRefresh}>Refresh</button><button className="btn primary" onClick=${() => setShowForm((v) => !v)}>${showForm ? "Close" : "+ Add rule"}</button></div>
     </div>
-  `;
+    ${showForm ? html`<${RuleForm} onCreate=${create} onCancel=${() => setShowForm(false)} />` : null}
+    ${rules.length === 0 ? html`<div className="empty">No rules configured.</div>` : null}
+    ${rules.map((r) => html`
+      <div className="card" key=${r.name}>
+        <div className="card-row">
+          <div><span className="name">${r.name}</span><span className=${`badge ${r.type}`}>${r.type}</span><span className=${`badge ${r.enabled ? "on" : "off"}`}>${r.enabled ? "on" : "off"}</span><span className="badge neutral">${r.scope || "request"}</span></div>
+          <div className="actions"><button className="btn" disabled=${busy} onClick=${() => toggle(r, !r.enabled)}>${r.enabled ? "Disable" : "Enable"}</button><button className="btn danger" disabled=${busy} onClick=${() => del(r)}>Delete</button></div>
+        </div>
+        <div className="meta">
+          ${r.patterns?.length ? `patterns: ${r.patterns.join(", ")}` : ""}
+          ${r.allow?.length ? ` | allow: ${r.allow.join(", ")}` : ""}
+          ${r.deny?.length ? ` | deny: ${r.deny.join(", ")}` : ""}
+          ${r.maxRequests ? ` | ${r.maxRequests} req/${r.windowSeconds}s` : ""}
+          ${r.replacement ? ` | replace: ${r.replacement}` : ""}
+          ${r.message ? ` | msg: ${r.message}` : ""}
+        </div>
+      </div>
+    `)}
+  </div>`;
 }
 
-// ── Audit ──
+// ════════════════════════════════════════════════════════════════════════════════
+// AUDIT
+// ════════════════════════════════════════════════════════════════════════════════
 
 function AuditPanel({ entries, onRefresh }) {
   const [filter, setFilter] = useState("");
   const filtered = filter ? entries.filter((e) => e.rule?.includes(filter) || e.action?.includes(filter) || e.detail?.includes(filter)) : entries;
 
-  return html`
-    <div>
-      <div className="card-row" style=${{ marginBottom: "12px" }}>
-        <h2 style=${{ margin: 0 }}>Audit log</h2>
-        <div className="actions">
-          <input value=${filter} onInput=${(e) => setFilter(e.target.value)} placeholder="Filter..." style=${{ width: "160px", padding: "5px 8px", fontSize: "12px" }} />
-          <button className="btn" onClick=${onRefresh}>Refresh</button>
-        </div>
+  return html`<div>
+    <div className="card-row" style=${{ marginBottom: "12px" }}>
+      <h2 style=${{ margin: 0 }}>Audit log</h2>
+      <div className="actions">
+        <input value=${filter} onInput=${(e) => setFilter(e.target.value)} placeholder="Filter..." style=${{ width: "160px", padding: "5px 8px", fontSize: "12px" }} />
+        <button className="btn" onClick=${onRefresh}>Refresh</button>
       </div>
-      ${filtered.length === 0 ? html`<div className="empty">No audit events${filter ? " matching filter" : ""}.</div>` : html`
-        <div className="table-wrap"><table>
-          <thead><tr><th>Time</th><th>Rule</th><th>Type</th><th>Action</th><th>Source</th><th>Matched</th><th>Before</th><th>After</th></tr></thead>
-          <tbody>
-            ${filtered.map((e, i) => html`
-              <tr key=${i}>
-                <td>${ago(e.timestamp)}</td>
-                <td style=${{ fontWeight: 600 }}>${e.rule}</td>
-                <td><span className=${`badge ${e.type}`}>${e.type}</span></td>
-                <td>${e.action}</td>
-                <td>${e.source || "--"}</td>
-                <td style=${{ color: "#ef4444", fontFamily: "monospace", fontSize: "11px" }}>${e.matched_text || "--"}</td>
-                <td>${e.full_message ? html`<details><summary>view</summary><pre>${e.full_message}</pre></details>` : "--"}</td>
-                <td>${e.redacted_message ? html`<details><summary>view</summary><pre>${e.redacted_message}</pre></details>` : "--"}</td>
-              </tr>
-            `)}
-          </tbody>
-        </table></div>
-      `}
     </div>
-  `;
+    <div style=${{ marginBottom: "6px", fontSize: "11px", color: "#52525b" }}>Persisted to: ~/.pi/agent/leeloo-audit.jsonl</div>
+    ${filtered.length === 0 ? html`<div className="empty">No audit events${filter ? " matching filter" : ""}.</div>` : html`
+      <div className="table-wrap"><table>
+        <thead><tr><th>Time</th><th>Rule</th><th>Type</th><th>Action</th><th>Source</th><th>Matched</th><th>Before</th><th>After</th></tr></thead>
+        <tbody>${filtered.map((e, i) => html`
+          <tr key=${i}>
+            <td>${ago(e.timestamp)}</td><td style=${{ fontWeight: 600 }}>${e.rule}</td><td><span className=${`badge ${e.type}`}>${e.type}</span></td><td>${e.action}</td><td>${e.source || "--"}</td>
+            <td style=${{ color: "#ef4444", fontFamily: "monospace", fontSize: "11px" }}>${e.matched_text || "--"}</td>
+            <td>${e.full_message ? html`<details><summary>view</summary><pre>${e.full_message}</pre></details>` : "--"}</td>
+            <td>${e.redacted_message ? html`<details><summary>view</summary><pre>${e.redacted_message}</pre></details>` : "--"}</td>
+          </tr>
+        `)}</tbody>
+      </table></div>
+    `}
+  </div>`;
 }
 
-// ── Config ──
-
-function ConfigPanel({ health }) {
-  const pools = health?.pools || [];
-  const presets = health?.presets || [];
-  const providers = health?.providers || [];
-  const exhausted = new Set(health?.exhausted || []);
-
-  return html`
-    <div>
-      <h2>Pools</h2>
-      ${pools.length === 0 ? html`<div className="empty">No pools</div>` : null}
-      ${pools.map((p) => html`
-        <div className="card" key=${p.name}><span className="name">${p.name}</span><span className="badge neutral">${p.strategy}</span><div className="meta">Members: ${p.members?.join(", ")}</div></div>
-      `)}
-      <h2 className="mt">Presets</h2>
-      ${presets.length === 0 ? html`<div className="empty">No presets</div>` : null}
-      ${presets.map((p) => html`<div className="card" key=${p.name}><span className="name">${p.name}</span><div className="meta">${p.entries?.join(" -> ")}</div></div>`)}
-      <h2 className="mt">Providers</h2>
-      ${providers.map((p) => html`<div className="card" key=${p}><span className="name">${p}</span><span className=${`badge ${exhausted.has(p) ? "off" : "on"}`}>${exhausted.has(p) ? "exhausted" : "ok"}</span></div>`)}
-    </div>
-  `;
-}
-
-// ── App ──
+// ════════════════════════════════════════════════════════════════════════════════
+// APP
+// ════════════════════════════════════════════════════════════════════════════════
 
 function App() {
   const [tab, setTab] = useState("dashboard");
@@ -246,7 +456,6 @@ function App() {
   const [dash, setDash] = useState({});
   const [rules, setRules] = useState([]);
   const [audit, setAudit] = useState([]);
-  const [health, setHealth] = useState(null);
 
   useEffect(() => { load(tab); }, [tab]);
   useEffect(() => {
@@ -264,28 +473,21 @@ function App() {
         setDash((prev) => ({ stats: s.status === "fulfilled" ? s.value : prev.stats, quota: q.status === "fulfilled" ? q.value : prev.quota, health: h.status === "fulfilled" ? h.value : prev.health }));
       } else if (t === "rules") { setRules((await api("/v1/rules")).rules || []); }
       else if (t === "audit") { setAudit((await api("/v1/audit?limit=200")).entries || []); }
-      else if (t === "config") { setHealth(await api("/health")); }
     } catch (e) { if (!silent) setError(e.message); }
   }
 
-  const tabs = ["dashboard", "rules", "audit", "config"];
+  const tabs = ["dashboard", "config", "rules", "audit"];
 
   return html`
     <div className="app">
-      <div className="header">
-        <div className="logo">Leeloo Admin</div>
-        <a className="nav-link" href="/ui">Chat UI</a>
-        <a className="nav-link" href="/health">Health</a>
-      </div>
-      <div className="tabs">
-        ${tabs.map((t) => html`<button key=${t} className=${`tab ${tab === t ? "active" : ""}`} onClick=${() => setTab(t)}>${t}</button>`)}
-      </div>
+      <div className="header"><div className="logo">Leeloo Admin</div><a className="nav-link" href="/ui">Chat UI</a><a className="nav-link" href="/health">Health</a></div>
+      <div className="tabs">${tabs.map((t) => html`<button key=${t} className=${`tab ${tab === t ? "active" : ""}`} onClick=${() => setTab(t)}>${t}</button>`)}</div>
       <div className="panel"><div className="panel-inner">
         ${error ? html`<div className="card" style=${{ color: "#ef4444", borderColor: "#7f1d1d" }}>Error: ${error}</div>` : null}
         ${tab === "dashboard" ? html`<${DashboardPanel} data=${dash} />` : null}
+        ${tab === "config" ? html`<${ConfigPanel} onRefresh=${() => load("dashboard", true)} />` : null}
         ${tab === "rules" ? html`<${RulesPanel} rules=${rules} onRefresh=${() => load("rules")} />` : null}
         ${tab === "audit" ? html`<${AuditPanel} entries=${audit} onRefresh=${() => load("audit")} />` : null}
-        ${tab === "config" ? html`<${ConfigPanel} health=${health} />` : null}
       </div></div>
     </div>
   `;

--- a/web/admin/app.js
+++ b/web/admin/app.js
@@ -383,6 +383,82 @@ function ScheduleEditor({ members, schedule, onChange }) {
   `;
 }
 
+// ── API Keys ──
+
+const API_KEY_TYPES = ["openai", "anthropic", "azure", "custom"];
+
+function ApiKeyEditor({ apiKeys, onSave }) {
+  const [editing, setEditing] = useState(null);
+  const [draft, setDraft] = useState({});
+  const [modelDraft, setModelDraft] = useState("");
+
+  function startNew() { setEditing("__new__"); setDraft({ name: "", type: "openai", key: "", baseUrl: "https://api.openai.com/v1", models: [], enabled: true, label: "" }); }
+  function startEdit(k) { setEditing(k.name); setDraft({ ...k, models: [...(k.models || [])] }); }
+  function cancel() { setEditing(null); }
+
+  async function save() {
+    if (editing === "__new__") { await api("/v1/config/apikeys", jpost(draft)); }
+    else { await api(`/v1/config/apikeys/${encodeURIComponent(editing)}`, jput(draft)); }
+    setEditing(null); onSave();
+  }
+  async function del(name) { if (confirm(`Delete API key "${name}"?`)) { await api(`/v1/config/apikeys/${encodeURIComponent(name)}`, { method: "DELETE" }); onSave(); } }
+
+  function addModel() { if (modelDraft.trim() && !draft.models.includes(modelDraft.trim())) { setDraft({ ...draft, models: [...draft.models, modelDraft.trim()] }); setModelDraft(""); } }
+  function removeModel(i) { setDraft({ ...draft, models: draft.models.filter((_, idx) => idx !== i) }); }
+
+  function renderForm(isNew) {
+    return html`
+      <div className="card" style=${{ marginBottom: "10px" }}>
+        <div className="form-grid">
+          <div><label>Name (unique ID)</label><input value=${draft.name} onInput=${(e) => setDraft({ ...draft, name: e.target.value })} placeholder="e.g. oai-team-1" disabled=${!isNew} style=${!isNew ? { opacity: 0.6 } : {}} /></div>
+          <div><label>Label</label><input value=${draft.label || ""} onInput=${(e) => setDraft({ ...draft, label: e.target.value })} placeholder="e.g. Team key" /></div>
+          <div><label>Type</label><select value=${draft.type} onChange=${(e) => setDraft({ ...draft, type: e.target.value })}>${API_KEY_TYPES.map((t) => html`<option key=${t} value=${t}>${t}</option>`)}</select></div>
+          <div><label>Enabled</label><select value=${String(draft.enabled)} onChange=${(e) => setDraft({ ...draft, enabled: e.target.value === "true" })}><option value="true">Yes</option><option value="false">No</option></select></div>
+          <div className="full"><label>API Key</label><input type="password" value=${draft.key || ""} onInput=${(e) => setDraft({ ...draft, key: e.target.value })} placeholder="sk-..." /></div>
+          <div className="full"><label>Base URL</label><input value=${draft.baseUrl || ""} onInput=${(e) => setDraft({ ...draft, baseUrl: e.target.value })} placeholder="https://api.openai.com/v1" /></div>
+          <div className="full">
+            <label>Models (empty = any model accepted)</label>
+            <div style=${{ display: "flex", flexWrap: "wrap", gap: "4px", marginBottom: "6px" }}>
+              ${draft.models.map((m, i) => html`<span key=${m} className="badge on" style=${{ cursor: "pointer", fontSize: "12px", padding: "3px 8px" }} onClick=${() => removeModel(i)}>${m} x</span>`)}
+              ${draft.models.length === 0 ? html`<span style=${{ color: "#52525b", fontSize: "12px" }}>Any model (no restriction)</span>` : null}
+            </div>
+            <div style=${{ display: "flex", gap: "6px" }}>
+              <input value=${modelDraft} onInput=${(e) => setModelDraft(e.target.value)} onKeyDown=${(e) => { if (e.key === "Enter") { e.preventDefault(); addModel(); } }} placeholder="e.g. gpt-4o" style=${{ flex: 1 }} />
+              <button className="btn" onClick=${addModel}>+</button>
+            </div>
+          </div>
+        </div>
+        <div className="actions" style=${{ marginTop: "10px" }}><button className="btn primary" onClick=${save}>${isNew ? "Create" : "Save"}</button><button className="btn" onClick=${cancel}>Cancel</button></div>
+      </div>
+    `;
+  }
+
+  return html`<div>
+    <div className="card-row" style=${{ marginBottom: "10px" }}><h2 style=${{ margin: 0 }}>API keys</h2><button className="btn primary" onClick=${startNew}>+ Add key</button></div>
+    <div style=${{ marginBottom: "10px", fontSize: "11px", color: "#52525b" }}>Add raw API keys for OpenAI, Anthropic, Azure, or any OpenAI-compatible endpoint. Pool and route them just like OAuth accounts.</div>
+    ${editing === "__new__" ? renderForm(true) : null}
+    ${apiKeys.map((k) => editing === k.name ? renderForm(false) : html`
+      <div className="card" key=${k.name}>
+        <div className="card-row">
+          <div>
+            <span className="name">${k.label || k.name}</span>
+            <span className="badge neutral" style=${{ fontFamily: "monospace" }}>${k.name}</span>
+            <span className="badge neutral">${k.type}</span>
+            <span className=${`badge ${k.enabled !== false ? "on" : "off"}`}>${k.enabled !== false ? "active" : "disabled"}</span>
+            ${k.models?.length ? html`<span className="badge neutral">${k.models.join(", ")}</span>` : html`<span className="badge neutral">any model</span>`}
+          </div>
+          <div className="actions">
+            <button className="btn" onClick=${() => startEdit(k)}>Edit</button>
+            <button className="btn danger" onClick=${() => del(k.name)}>Del</button>
+          </div>
+        </div>
+        <div className="meta">${k.baseUrl || "https://api.openai.com/v1"} | key: ${k.key ? k.key.slice(0, 8) + "..." : "not set"}</div>
+      </div>
+    `)}
+    ${apiKeys.length === 0 && editing !== "__new__" ? html`<div className="empty">No API keys configured. Use "+ Add key" to add OpenAI, Anthropic, or custom API keys.</div>` : null}
+  </div>`;
+}
+
 // ── Pools ──
 
 function PoolEditor({ pools, names, onSave }) {
@@ -579,6 +655,8 @@ function ConfigPanel({ onRefresh }) {
   return html`<div>
     ${err ? html`<div className="card" style=${{ color: "#ef4444", borderColor: "#7f1d1d" }}>Error: ${err}</div>` : null}
     <${AuthPanel} onRefresh=${refresh} reloadNames=${reloadNames} />
+    <div style=${{ marginTop: "24px" }} />
+    <${ApiKeyEditor} apiKeys=${config.apiKeys || []} onSave=${refresh} />
     <div style=${{ marginTop: "24px" }} />
     <div style=${{ marginBottom: "6px", fontSize: "11px", color: "#52525b" }}>Editing: ~/.pi/agent/multi-pass.json</div>
     <${PoolEditor} pools=${config.pools || []} names=${names} onSave=${refresh} />

--- a/web/admin/app.js
+++ b/web/admin/app.js
@@ -223,6 +223,93 @@ function AuthPanel({ onRefresh, reloadNames }) {
   </div>`;
 }
 
+// ── Schedule editor ──
+
+const ALL_DAYS = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"];
+const ROLES = [{ value: "", label: "default (always available)" }, { value: "preferred", label: "preferred (active in windows only)" }, { value: "overflow", label: "overflow (last resort)" }];
+
+function ScheduleEditor({ members, schedule, onChange }) {
+  // schedule = { memberName: { role, windows: [{ hours, days, dateRange }] } }
+  const sched = schedule || {};
+
+  function setMemberField(member, field, value) {
+    const ms = { ...sched, [member]: { ...(sched[member] || {}), [field]: value } };
+    if (field === "role" && !value) delete ms[member].role;
+    onChange(ms);
+  }
+
+  function getWindows(member) { return sched[member]?.windows || []; }
+
+  function setWindows(member, windows) {
+    const ms = { ...sched, [member]: { ...(sched[member] || {}), windows } };
+    onChange(ms);
+  }
+
+  function addWindow(member) {
+    setWindows(member, [...getWindows(member), { hours: [9, 17], days: [...ALL_DAYS] }]);
+  }
+
+  function updateWindow(member, idx, field, value) {
+    const wins = [...getWindows(member)];
+    wins[idx] = { ...wins[idx], [field]: value };
+    setWindows(member, wins);
+  }
+
+  function removeWindow(member, idx) {
+    setWindows(member, getWindows(member).filter((_, i) => i !== idx));
+  }
+
+  function toggleDay(member, idx, day) {
+    const wins = [...getWindows(member)];
+    const w = { ...wins[idx] };
+    const days = w.days || [...ALL_DAYS];
+    w.days = days.includes(day) ? days.filter((d) => d !== day) : [...days, day];
+    wins[idx] = w;
+    setWindows(member, wins);
+  }
+
+  if (members.length === 0) return html`<div className="empty" style=${{ padding: "10px" }}>Add members first, then configure their schedules.</div>`;
+
+  return html`
+    <div>
+      ${members.map((member) => {
+        const ms = sched[member] || {};
+        const windows = ms.windows || [];
+        return html`
+          <div key=${member} className="card" style=${{ marginBottom: "8px", padding: "10px 14px" }}>
+            <div style=${{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "6px" }}>
+              <span className="name" style=${{ fontSize: "13px" }}>${member}</span>
+              <select value=${ms.role || ""} onChange=${(e) => setMemberField(member, "role", e.target.value || undefined)} style=${{ width: "240px", fontSize: "12px" }}>
+                ${ROLES.map((r) => html`<option key=${r.value} value=${r.value}>${r.label}</option>`)}
+              </select>
+            </div>
+            ${windows.map((w, wi) => html`
+              <div key=${wi} style=${{ background: "#0d0d0f", border: "1px solid #27272a", borderRadius: "8px", padding: "8px 10px", marginBottom: "6px" }}>
+                <div style=${{ display: "flex", gap: "8px", alignItems: "center", marginBottom: "6px", flexWrap: "wrap" }}>
+                  <label style=${{ margin: 0, width: "auto" }}>Hours:</label>
+                  <input type="number" min="0" max="23" value=${w.hours?.[0] ?? 0} onInput=${(e) => updateWindow(member, wi, "hours", [parseInt(e.target.value) || 0, w.hours?.[1] ?? 24])} style=${{ width: "60px" }} />
+                  <span style=${{ color: "#52525b" }}>to</span>
+                  <input type="number" min="0" max="24" value=${w.hours?.[1] ?? 24} onInput=${(e) => updateWindow(member, wi, "hours", [w.hours?.[0] ?? 0, parseInt(e.target.value) || 24])} style=${{ width: "60px" }} />
+                  <span style=${{ color: "#3f3f46", fontSize: "11px" }}>(24h, wraps midnight)</span>
+                  <div className="spacer" />
+                  <button className="btn danger" onClick=${() => removeWindow(member, wi)} style=${{ padding: "2px 8px", fontSize: "11px" }}>Remove</button>
+                </div>
+                <div style=${{ display: "flex", gap: "4px", flexWrap: "wrap" }}>
+                  ${ALL_DAYS.map((day) => {
+                    const active = (w.days || ALL_DAYS).includes(day);
+                    return html`<button key=${day} className=${`btn ${active ? "primary" : ""}`} onClick=${() => toggleDay(member, wi, day)} style=${{ padding: "2px 8px", fontSize: "11px", minWidth: "36px" }}>${day}</button>`;
+                  })}
+                </div>
+              </div>
+            `)}
+            <button className="btn" onClick=${() => addWindow(member)} style=${{ fontSize: "11px" }}>+ Add time window</button>
+          </div>
+        `;
+      })}
+    </div>
+  `;
+}
+
 // ── Pools ──
 
 function PoolEditor({ pools, names, onSave }) {
@@ -266,7 +353,7 @@ function PoolEditor({ pools, names, onSave }) {
               </select>
             </div>
           </div>
-          ${draft.strategy === "scheduled" ? html`<div className="full"><label>Schedule (JSON)</label><textarea value=${JSON.stringify(draft.memberSchedule || {}, null, 2)} onInput=${(e) => { try { setDraft({ ...draft, memberSchedule: JSON.parse(e.target.value) }); } catch {} }} rows="4" /></div>` : null}
+          ${draft.strategy === "scheduled" ? html`<div className="full"><label>Member schedules</label><${ScheduleEditor} members=${draft.members} schedule=${draft.memberSchedule || {}} onChange=${(s) => setDraft({ ...draft, memberSchedule: s })} /></div>` : null}
           ${draft.strategy === "custom" ? html`<div className="full"><label>Selector Script Path</label><input value=${draft.selectorScript || ""} onInput=${(e) => setDraft({ ...draft, selectorScript: e.target.value })} placeholder="./my-selector.js" /></div>` : null}
         </div>
         <div className="actions" style=${{ marginTop: "10px" }}><button className="btn primary" onClick=${save}>${isNew ? "Create" : "Save"}</button><button className="btn" onClick=${cancel}>Cancel</button></div>

--- a/web/admin/app.js
+++ b/web/admin/app.js
@@ -60,6 +60,51 @@ function ProviderSelect({ value, onChange, names, allowPools, allowChains, place
   `;
 }
 
+/** Drag-and-drop sortable list. items=array, onReorder=callback, renderItem(item,index)=JSX */
+function SortableList({ items, onReorder, renderItem }) {
+  const [dragIdx, setDragIdx] = useState(null);
+  const [overIdx, setOverIdx] = useState(null);
+
+  function onDragStart(e, i) { setDragIdx(i); e.dataTransfer.effectAllowed = "move"; }
+  function onDragOver(e, i) { e.preventDefault(); e.dataTransfer.dropEffect = "move"; setOverIdx(i); }
+  function onDragLeave() { setOverIdx(null); }
+  function onDrop(e, i) {
+    e.preventDefault();
+    if (dragIdx == null || dragIdx === i) { setDragIdx(null); setOverIdx(null); return; }
+    const arr = [...items];
+    const [moved] = arr.splice(dragIdx, 1);
+    arr.splice(i, 0, moved);
+    onReorder(arr);
+    setDragIdx(null);
+    setOverIdx(null);
+  }
+  function onDragEnd() { setDragIdx(null); setOverIdx(null); }
+
+  return html`<div>
+    ${items.map((item, i) => html`
+      <div key=${i}
+        draggable="true"
+        onDragStart=${(e) => onDragStart(e, i)}
+        onDragOver=${(e) => onDragOver(e, i)}
+        onDragLeave=${onDragLeave}
+        onDrop=${(e) => onDrop(e, i)}
+        onDragEnd=${onDragEnd}
+        style=${{
+          display: "flex", gap: "6px", marginBottom: "4px", alignItems: "center",
+          padding: "4px 6px", borderRadius: "6px", cursor: "grab",
+          background: overIdx === i ? "#1e1e22" : dragIdx === i ? "#111113" : "transparent",
+          border: overIdx === i ? "1px dashed #f59e0b" : "1px solid transparent",
+          opacity: dragIdx === i ? 0.5 : 1,
+          transition: "background .1s, border .1s",
+        }}
+      >
+        <span style=${{ color: "#3f3f46", fontSize: "14px", cursor: "grab", userSelect: "none" }}>&#x2630;</span>
+        ${renderItem(item, i)}
+      </div>
+    `)}
+  </div>`;
+}
+
 // ════════════════════════════════════════════════════════════════════════════════
 // DASHBOARD
 // ════════════════════════════════════════════════════════════════════════════════
@@ -354,12 +399,14 @@ function PoolEditor({ pools, names, onSave }) {
           <div><label>Strategy</label><select value=${draft.strategy} onChange=${(e) => setDraft({ ...draft, strategy: e.target.value })}>${STRATEGIES.map((s) => html`<option key=${s} value=${s}>${s}</option>`)}</select></div>
           <div><label>Enabled</label><select value=${String(draft.enabled)} onChange=${(e) => setDraft({ ...draft, enabled: e.target.value === "true" })}><option value="true">Yes</option><option value="false">No</option></select></div>
           <div className="full">
-            <label>Members</label>
-            <div style=${{ display: "flex", flexWrap: "wrap", gap: "4px", marginBottom: "6px" }}>
-              ${draft.members.map((m, i) => html`<span key=${i} className="badge on" style=${{ cursor: "pointer" }} onClick=${() => removeMember(i)}>${m} x</span>`)}
-              ${draft.members.length === 0 ? html`<span style=${{ color: "#52525b", fontSize: "12px" }}>No members yet</span>` : null}
-            </div>
-            <div style=${{ display: "flex", gap: "6px" }}>
+            <label>Members (drag to reorder priority)</label>
+            ${draft.members.length > 0 ? html`
+              <${SortableList} items=${draft.members} onReorder=${(arr) => setDraft({ ...draft, members: arr })} renderItem=${(m, i) => html`
+                <span style=${{ flex: 1, fontSize: "13px", color: "#e4e4e7" }}>${m}</span>
+                <button className="btn danger" onClick=${() => removeMember(i)} style=${{ padding: "2px 8px", fontSize: "11px" }}>x</button>
+              `} />
+            ` : html`<div style=${{ color: "#52525b", fontSize: "12px", padding: "6px 0" }}>No members yet</div>`}
+            <div style=${{ display: "flex", gap: "6px", marginTop: "4px" }}>
               <select onChange=${(e) => { addMember(e.target.value); e.target.value = ""; }} style=${{ flex: 1 }}>
                 <option value="">+ Add member...</option>
                 ${eligible.filter((n) => !draft.members.includes(n)).map((n) => html`<option key=${n} value=${n}>${n}</option>`)}
@@ -406,7 +453,7 @@ function ChainEditor({ chains, names, onSave }) {
   async function del(name) { if (confirm(`Delete chain "${name}"?`)) { await api(`/v1/config/chains/${encodeURIComponent(name)}`, { method: "DELETE" }); onSave(); } }
 
   function updateStep(i, field, value) { const steps = [...draft.steps]; steps[i] = { ...steps[i], [field]: value }; setDraft({ ...draft, steps }); }
-  function addStep() { setDraft({ ...draft, steps: [...draft.steps, { provider: "", model: "", enabled: true }] }); }
+  function addStep() { setDraft({ ...draft, steps: [...draft.steps, { provider: "", enabled: true }] }); }
   function removeStep(i) { setDraft({ ...draft, steps: draft.steps.filter((_, idx) => idx !== i) }); }
 
   function renderForm(isNew) {
@@ -417,16 +464,12 @@ function ChainEditor({ chains, names, onSave }) {
           <div><label>Enabled</label><select value=${String(draft.enabled)} onChange=${(e) => setDraft({ ...draft, enabled: e.target.value === "true" })}><option value="true">Yes</option><option value="false">No</option></select></div>
         </div>
         <div style=${{ marginTop: "10px" }}>
-          <label>Steps (failover order)</label>
-          ${draft.steps.map((s, i) => html`
-            <div key=${i} style=${{ display: "flex", gap: "6px", marginBottom: "6px", alignItems: "center" }}>
-              <span style=${{ color: "#52525b", fontSize: "11px", width: "20px" }}>${i + 1}.</span>
-              <${ProviderSelect} value=${s.provider} onChange=${(v) => updateStep(i, "provider", v)} names=${names} allowPools=${true} placeholder="provider or pool" />
-              <input value=${s.model || ""} onInput=${(e) => updateStep(i, "model", e.target.value)} placeholder="model (optional)" style=${{ flex: 1 }} />
-              <button className="btn danger" onClick=${() => removeStep(i)} style=${{ padding: "4px 8px" }}>x</button>
-            </div>
-          `)}
-          <button className="btn" onClick=${addStep}>+ Add step</button>
+          <label>Steps (drag to reorder)</label>
+          <${SortableList} items=${draft.steps} onReorder=${(arr) => setDraft({ ...draft, steps: arr })} renderItem=${(s, i) => html`
+            <${ProviderSelect} value=${s.provider} onChange=${(v) => updateStep(i, "provider", v)} names=${names} allowPools=${true} placeholder="provider or pool" />
+            <button className="btn danger" onClick=${() => removeStep(i)} style=${{ padding: "4px 8px" }}>x</button>
+          `} />
+          <button className="btn" onClick=${addStep} style=${{ marginTop: "4px" }}>+ Add step</button>
         </div>
         <div className="actions" style=${{ marginTop: "10px" }}><button className="btn primary" onClick=${save}>${isNew ? "Create" : "Save"}</button><button className="btn" onClick=${cancel}>Cancel</button></div>
       </div>
@@ -441,7 +484,7 @@ function ChainEditor({ chains, names, onSave }) {
           <div><span className="name">${c.name}</span><span className=${`badge ${c.enabled !== false ? "on" : "off"}`}>${c.enabled !== false ? "on" : "off"}</span><span className="badge neutral">${(c.steps || []).length} steps</span></div>
           <div className="actions"><button className="btn" onClick=${() => startEdit(c)}>Edit</button><button className="btn danger" onClick=${() => del(c.name)}>Del</button></div>
         </div>
-        <div className="meta">${(c.steps || []).map((s) => `${s.provider}${s.model ? "/" + s.model : ""}`).join(" -> ") || "no steps"}</div>
+        <div className="meta">${(c.steps || []).map((s) => s.provider).join(" -> ") || "no steps"}</div>
       </div>
     `)}
     ${editing === "__new__" ? renderForm(true) : null}
@@ -465,7 +508,7 @@ function PresetEditor({ presets, names, onSave }) {
   async function del(name) { if (confirm(`Delete preset "${name}"?`)) { await api(`/v1/config/presets/${encodeURIComponent(name)}`, { method: "DELETE" }); onSave(); } }
 
   function updateEntry(i, field, value) { const entries = [...draft.entries]; entries[i] = { ...entries[i], [field]: field === "enabled" ? value === "true" : value }; setDraft({ ...draft, entries }); }
-  function addEntry() { setDraft({ ...draft, entries: [...draft.entries, { provider: "", model: "", enabled: true }] }); }
+  function addEntry() { setDraft({ ...draft, entries: [...draft.entries, { provider: "", enabled: true }] }); }
   function removeEntry(i) { setDraft({ ...draft, entries: draft.entries.filter((_, idx) => idx !== i) }); }
 
   function renderForm(isNew) {
@@ -476,17 +519,13 @@ function PresetEditor({ presets, names, onSave }) {
           <div><label>Enabled</label><select value=${String(draft.enabled)} onChange=${(e) => setDraft({ ...draft, enabled: e.target.value === "true" })}><option value="true">Yes</option><option value="false">No</option></select></div>
         </div>
         <div style=${{ marginTop: "10px" }}>
-          <label>Entries (failover order)</label>
-          ${draft.entries.map((e, i) => html`
-            <div key=${i} style=${{ display: "flex", gap: "6px", marginBottom: "6px", alignItems: "center" }}>
-              <span style=${{ color: "#52525b", fontSize: "11px", width: "20px" }}>${i + 1}.</span>
-              <${ProviderSelect} value=${e.provider} onChange=${(v) => updateEntry(i, "provider", v)} names=${names} allowPools=${true} allowChains=${true} placeholder="provider, pool, or chain" />
-              <input value=${e.model || ""} onInput=${(ev) => updateEntry(i, "model", ev.target.value)} placeholder="model" style=${{ flex: 1 }} />
-              <select value=${String(e.enabled !== false)} onChange=${(ev) => updateEntry(i, "enabled", ev.target.value)} style=${{ width: "70px" }}><option value="true">On</option><option value="false">Off</option></select>
-              <button className="btn danger" onClick=${() => removeEntry(i)} style=${{ padding: "4px 8px" }}>x</button>
-            </div>
-          `)}
-          <button className="btn" onClick=${addEntry}>+ Add entry</button>
+          <label>Entries (drag to reorder)</label>
+          <${SortableList} items=${draft.entries} onReorder=${(arr) => setDraft({ ...draft, entries: arr })} renderItem=${(e, i) => html`
+            <${ProviderSelect} value=${e.provider} onChange=${(v) => updateEntry(i, "provider", v)} names=${names} allowPools=${true} allowChains=${true} placeholder="provider, pool, or chain" />
+            <select value=${String(e.enabled !== false)} onChange=${(ev) => updateEntry(i, "enabled", ev.target.value)} style=${{ width: "60px", fontSize: "12px" }}><option value="true">On</option><option value="false">Off</option></select>
+            <button className="btn danger" onClick=${() => removeEntry(i)} style=${{ padding: "4px 8px" }}>x</button>
+          `} />
+          <button className="btn" onClick=${addEntry} style=${{ marginTop: "4px" }}>+ Add entry</button>
         </div>
         <div className="actions" style=${{ marginTop: "10px" }}><button className="btn primary" onClick=${save}>${isNew ? "Create" : "Save"}</button><button className="btn" onClick=${cancel}>Cancel</button></div>
       </div>
@@ -501,7 +540,7 @@ function PresetEditor({ presets, names, onSave }) {
           <div><span className="name">${p.name}</span><span className=${`badge ${p.enabled !== false ? "on" : "off"}`}>${p.enabled !== false ? "on" : "off"}</span><span className="badge neutral">${(p.entries || []).length} entries</span></div>
           <div className="actions"><button className="btn" onClick=${() => startEdit(p)}>Edit</button><button className="btn danger" onClick=${() => del(p.name)}>Del</button></div>
         </div>
-        <div className="meta">${(p.entries || []).filter((e) => e.enabled !== false).map((e) => `${e.provider}/${e.model}`).join(" -> ") || "no entries"}</div>
+        <div className="meta">${(p.entries || []).filter((e) => e.enabled !== false).map((e) => e.provider).join(" -> ") || "no entries"}</div>
       </div>
     `)}
     ${editing === "__new__" ? renderForm(true) : null}

--- a/web/admin/app.js
+++ b/web/admin/app.js
@@ -790,14 +790,50 @@ function UsersPanel() {
     // We need preset names too - fetch from config
   );
 
+  function ChipPicker({ label, items, available, onChange, emptyText }) {
+    function add(val) { if (val && !items.includes(val)) onChange([...items, val]); }
+    function remove(i) { onChange(items.filter((_, idx) => idx !== i)); }
+    const remaining = available.filter((a) => !items.includes(a));
+    return html`
+      <div className="full">
+        <label>${label}</label>
+        <div style=${{ display: "flex", flexWrap: "wrap", gap: "4px", marginBottom: "6px", minHeight: "24px" }}>
+          ${items.length === 0 ? html`<span style=${{ color: "#52525b", fontSize: "12px" }}>${emptyText || "None (all access)"}</span>` : null}
+          ${items.map((item, i) => html`<span key=${item} className="badge on" style=${{ cursor: "pointer", fontSize: "12px", padding: "3px 8px" }} onClick=${() => remove(i)}>${item} ${"x"}</span>`)}
+        </div>
+        ${remaining.length > 0 ? html`
+          <select onChange=${(e) => { add(e.target.value); e.target.value = ""; }} style=${{ width: "100%" }}>
+            <option value="">+ Add...</option>
+            ${remaining.map((a) => html`<option key=${a} value=${a}>${a}</option>`)}
+          </select>
+        ` : null}
+      </div>
+    `;
+  }
+
+  const availablePresetNames = (names?.presets || []).map((p) => p.label);
+  const availablePoolNames = (names?.pools || []).map((p) => p.label);
+
   function renderForm() {
     const isNew = editing === "__new__";
     return html`
       <div className="card" style=${{ marginBottom: "12px" }}>
         <div className="form-grid">
-          ${isNew ? html`<div><label>Username</label><input value=${draft.username} onInput=${(e) => setDraft({ ...draft, username: e.target.value })} placeholder="e.g. alice" /></div>` : html`<div><label>Username</label><input value=${draft.username} disabled /></div>`}
-          <div className="full"><label>Allowed presets (comma-separated, empty = all)</label><input value=${draft.allowedPresets.join(", ")} onInput=${(e) => setDraft({ ...draft, allowedPresets: e.target.value.split(",").map((s) => s.trim()).filter(Boolean) })} placeholder="coding-premium, fastest" /></div>
-          <div className="full"><label>Allowed pools (comma-separated, empty = all)</label><input value=${draft.allowedPools.join(", ")} onInput=${(e) => setDraft({ ...draft, allowedPools: e.target.value.split(",").map((s) => s.trim()).filter(Boolean) })} placeholder="codex-pool, google-pool" /></div>
+          ${isNew ? html`<div className="full"><label>Username</label><input value=${draft.username} onInput=${(e) => setDraft({ ...draft, username: e.target.value })} placeholder="e.g. alice" /></div>` : html`<div className="full"><label>Username</label><input value=${draft.username} disabled style=${{ opacity: 0.6 }} /></div>`}
+          <${ChipPicker}
+            label="Allowed presets (empty = all access)"
+            items=${draft.allowedPresets}
+            available=${availablePresetNames}
+            onChange=${(v) => setDraft({ ...draft, allowedPresets: v })}
+            emptyText="No restrictions -- all presets allowed"
+          />
+          <${ChipPicker}
+            label="Allowed pools (empty = all access)"
+            items=${draft.allowedPools}
+            available=${availablePoolNames}
+            onChange=${(v) => setDraft({ ...draft, allowedPools: v })}
+            emptyText="No restrictions -- all pools allowed"
+          />
         </div>
         <div className="actions" style=${{ marginTop: "10px" }}><button className="btn primary" onClick=${save} disabled=${busy}>${isNew ? "Create" : "Save"}</button><button className="btn" onClick=${cancelForm}>Cancel</button></div>
       </div>

--- a/web/admin/app.js
+++ b/web/admin/app.js
@@ -1290,15 +1290,24 @@ function TraceView({ trace }) {
 function AiEditPanel({ config, onApplied }) {
   const [open, setOpen] = useState(false);
   const [instruction, setInstruction] = useState("");
-  const [model, setModel] = useState("coding-premium");
+  const [model, setModel] = useState("");
   const [busy, setBusy] = useState(false);
   const [result, setResult] = useState(null);
   const [err, setErr] = useState("");
+  const [routing, setRouting] = useState({ groups: [] });
 
-  const targets = [
-    ...(config.presets || []).map((p) => p.id || p.name),
-    ...(config.modes || []).map((m) => m.id),
-  ];
+  // Load /v1/routing -- same source as chat UI dropdown
+  useEffect(() => {
+    if (!open) return;
+    api("/v1/routing").then((d) => {
+      setRouting(d || { groups: [] });
+      // Auto-pick first usable model if none chosen
+      if (!model) {
+        const first = (d?.groups || []).flatMap((g) => g.items || [])[0]?.id;
+        if (first) setModel(first);
+      }
+    }).catch(() => {});
+  }, [open]);
 
   async function generate() {
     if (!instruction.trim()) return;
@@ -1347,10 +1356,15 @@ function AiEditPanel({ config, onApplied }) {
           <label>Your request</label>
           <textarea value=${instruction} onInput=${(e) => setInstruction(e.target.value)} placeholder="e.g. Add a routing rule that prefers Anthropic on Friday evenings, and add it to coding-premium mode" rows="4" />
         </div>
-        <div>
-          <label>Use this preset/model to think</label>
+        <div className="full">
+          <label>Use this model/preset to think</label>
           <select value=${model} onChange=${(e) => setModel(e.target.value)}>
-            ${targets.map((t) => html`<option key=${t} value=${t}>${t}</option>`)}
+            <option value="">-- pick a model --</option>
+            ${(routing.groups || []).map((g) => html`
+              <optgroup key=${g.label} label=${g.label}>
+                ${(g.items || []).map((it) => html`<option key=${it.id} value=${it.id}>${it.name || it.id}</option>`)}
+              </optgroup>
+            `)}
           </select>
         </div>
       </div>

--- a/web/admin/app.js
+++ b/web/admin/app.js
@@ -590,16 +590,32 @@ function ChainEditor({ chains, names, onSave }) {
 
 // ── Presets ──
 
-function PresetEditor({ presets, names, onSave }) {
+function PresetEditor({ presets, modes, names, onSave, readOnly }) {
   const [editing, setEditing] = useState(null);
   const [draft, setDraft] = useState({});
+  const [modelDraft, setModelDraft] = useState("");
+  const [fallbackDraft, setFallbackDraft] = useState("");
+  const [presetMode, setPresetMode] = useState("v2"); // v2 | v1 (legacy)
 
-  function startEdit(p) { setEditing(p.name); setDraft({ ...p, entries: [...(p.entries || [])] }); }
-  function startNew() { setEditing("__new__"); setDraft({ name: "", enabled: true, entries: [] }); }
+  function startEdit(p) {
+    setEditing(p.name);
+    const isV2 = !!p.mode;
+    setPresetMode(isV2 ? "v2" : "v1");
+    setDraft({ ...p, entries: [...(p.entries || [])], preferredModels: [...(p.preferredModels || [])], fallbackModels: [...(p.fallbackModels || [])] });
+  }
+  function startNew() {
+    setEditing("__new__");
+    setPresetMode("v2");
+    setDraft({ name: "", enabled: true, entries: [], mode: "", preferredModels: [], fallbackModels: [] });
+  }
   function cancel() { setEditing(null); }
   async function save() {
-    if (editing === "__new__") { await api("/v1/config/presets", jpost(draft)); }
-    else { await api(`/v1/config/presets/${encodeURIComponent(editing)}`, jput(draft)); }
+    const payload = { ...draft };
+    // Strip the "other" mode's fields based on chosen type
+    if (presetMode === "v2") { delete payload.entries; }
+    else { delete payload.mode; delete payload.preferredModels; delete payload.fallbackModels; }
+    if (editing === "__new__") { await api("/v1/config/presets", jpost(payload)); }
+    else { await api(`/v1/config/presets/${encodeURIComponent(editing)}`, jput(payload)); }
     setEditing(null); onSave();
   }
   async function del(name) { if (confirm(`Delete preset "${name}"?`)) { await api(`/v1/config/presets/${encodeURIComponent(name)}`, { method: "DELETE" }); onSave(); } }
@@ -608,21 +624,177 @@ function PresetEditor({ presets, names, onSave }) {
   function addEntry() { setDraft({ ...draft, entries: [...draft.entries, { provider: "", enabled: true }] }); }
   function removeEntry(i) { setDraft({ ...draft, entries: draft.entries.filter((_, idx) => idx !== i) }); }
 
+  function addModel(target) {
+    const v = target === "preferred" ? modelDraft : fallbackDraft;
+    if (!v.trim()) return;
+    const arr = target === "preferred" ? draft.preferredModels : draft.fallbackModels;
+    if (!arr.includes(v.trim())) {
+      setDraft({ ...draft, [target === "preferred" ? "preferredModels" : "fallbackModels"]: [...arr, v.trim()] });
+    }
+    if (target === "preferred") setModelDraft(""); else setFallbackDraft("");
+  }
+  function removeModel(target, i) {
+    const arr = target === "preferred" ? draft.preferredModels : draft.fallbackModels;
+    setDraft({ ...draft, [target === "preferred" ? "preferredModels" : "fallbackModels"]: arr.filter((_, idx) => idx !== i) });
+  }
+
   function renderForm(isNew) {
     return html`
       <div className="card">
         <div className="form-grid">
           <div><label>Name</label><input value=${draft.name} onInput=${(e) => setDraft({ ...draft, name: e.target.value })} placeholder="e.g. coding-premium" /></div>
           <div><label>Enabled</label><select value=${String(draft.enabled)} onChange=${(e) => setDraft({ ...draft, enabled: e.target.value === "true" })}><option value="true">Yes</option><option value="false">No</option></select></div>
+          <div className="full">
+            <label>Type</label>
+            <select value=${presetMode} onChange=${(e) => setPresetMode(e.target.value)}>
+              <option value="v2">v2: route via mode + preferred models (recommended)</option>
+              <option value="v1">v1: ordered list of provider/model entries (legacy)</option>
+            </select>
+          </div>
         </div>
-        <div style=${{ marginTop: "10px" }}>
-          <label>Entries (drag to reorder)</label>
-          <${SortableList} items=${draft.entries} onReorder=${(arr) => setDraft({ ...draft, entries: arr })} renderItem=${(e, i) => html`
-            <${ProviderSelect} value=${e.provider} onChange=${(v) => updateEntry(i, "provider", v)} names=${names} allowPools=${true} allowChains=${true} placeholder="provider, pool, or chain" />
-            <select value=${String(e.enabled !== false)} onChange=${(ev) => updateEntry(i, "enabled", ev.target.value)} style=${{ width: "60px", fontSize: "12px" }}><option value="true">On</option><option value="false">Off</option></select>
-            <button className="btn danger" onClick=${() => removeEntry(i)} style=${{ padding: "4px 8px" }}>x</button>
-          `} />
-          <button className="btn" onClick=${addEntry} style=${{ marginTop: "4px" }}>+ Add entry</button>
+
+        ${presetMode === "v2" ? html`
+          <div style=${{ marginTop: "10px" }}>
+            <label>Mode</label>
+            <select value=${draft.mode || ""} onChange=${(e) => setDraft({ ...draft, mode: e.target.value })}>
+              <option value="">-- pick a mode --</option>
+              ${(modes || []).map((m) => html`<option key=${m.id} value=${m.id}>${m.id}${m.description ? " -- " + m.description : ""}</option>`)}
+            </select>
+          </div>
+          <div style=${{ marginTop: "10px" }}>
+            <label>Preferred models (tried in order)</label>
+            <div style=${{ display: "flex", flexWrap: "wrap", gap: "4px", marginBottom: "6px" }}>
+              ${draft.preferredModels.map((m, i) => html`<span key=${m} className="badge on" style=${{ cursor: "pointer", fontSize: "12px", padding: "3px 8px" }} onClick=${() => removeModel("preferred", i)}>${m} x</span>`)}
+              ${draft.preferredModels.length === 0 ? html`<span style=${{ color: "#52525b", fontSize: "12px" }}>None -- candidate's first model used</span>` : null}
+            </div>
+            <div style=${{ display: "flex", gap: "6px" }}>
+              <input value=${modelDraft} onInput=${(e) => setModelDraft(e.target.value)} onKeyDown=${(e) => { if (e.key === "Enter") { e.preventDefault(); addModel("preferred"); } }} placeholder="e.g. claude-opus, gpt-5.4" style=${{ flex: 1 }} />
+              <button className="btn" onClick=${() => addModel("preferred")}>+</button>
+            </div>
+          </div>
+          <div style=${{ marginTop: "10px" }}>
+            <label>Fallback models</label>
+            <div style=${{ display: "flex", flexWrap: "wrap", gap: "4px", marginBottom: "6px" }}>
+              ${draft.fallbackModels.map((m, i) => html`<span key=${m} className="badge neutral" style=${{ cursor: "pointer", fontSize: "12px", padding: "3px 8px" }} onClick=${() => removeModel("fallback", i)}>${m} x</span>`)}
+              ${draft.fallbackModels.length === 0 ? html`<span style=${{ color: "#52525b", fontSize: "12px" }}>None</span>` : null}
+            </div>
+            <div style=${{ display: "flex", gap: "6px" }}>
+              <input value=${fallbackDraft} onInput=${(e) => setFallbackDraft(e.target.value)} onKeyDown=${(e) => { if (e.key === "Enter") { e.preventDefault(); addModel("fallback"); } }} placeholder="e.g. claude-sonnet, gpt-5-mini" style=${{ flex: 1 }} />
+              <button className="btn" onClick=${() => addModel("fallback")}>+</button>
+            </div>
+          </div>
+        ` : html`
+          <div style=${{ marginTop: "10px" }}>
+            <label>Entries (drag to reorder)</label>
+            <${SortableList} items=${draft.entries} onReorder=${(arr) => setDraft({ ...draft, entries: arr })} renderItem=${(e, i) => html`
+              <${ProviderSelect} value=${e.provider} onChange=${(v) => updateEntry(i, "provider", v)} names=${names} allowPools=${true} allowChains=${true} placeholder="provider, pool, or chain" />
+              <select value=${String(e.enabled !== false)} onChange=${(ev) => updateEntry(i, "enabled", ev.target.value)} style=${{ width: "60px", fontSize: "12px" }}><option value="true">On</option><option value="false">Off</option></select>
+              <button className="btn danger" onClick=${() => removeEntry(i)} style=${{ padding: "4px 8px" }}>x</button>
+            `} />
+            <button className="btn" onClick=${addEntry} style=${{ marginTop: "4px" }}>+ Add entry</button>
+          </div>
+        `}
+
+        <div className="actions" style=${{ marginTop: "10px" }}><button className="btn primary" onClick=${save}>${isNew ? "Create" : "Save"}</button><button className="btn" onClick=${cancel}>Cancel</button></div>
+      </div>
+    `;
+  }
+
+  return html`<div>
+    <div className="card-row" style=${{ marginBottom: "10px" }}><h2 style=${{ margin: 0 }}>Presets</h2>${!readOnly ? html`<button className="btn primary" onClick=${startNew}>+ Add</button>` : null}</div>
+    ${presets.map((p) => editing === p.name ? renderForm(false) : html`
+      <div className="card" key=${p.name}>
+        <div className="card-row">
+          <div>
+            <span className="name">${p.name}</span>
+            <span className=${`badge ${p.enabled !== false ? "on" : "off"}`}>${p.enabled !== false ? "on" : "off"}</span>
+            ${p.mode ? html`<span className="badge info">v2 mode: ${p.mode}</span>` : html`<span className="badge neutral">v1: ${(p.entries || []).length} entries</span>`}
+          </div>
+          ${!readOnly ? html`<div className="actions"><button className="btn" onClick=${() => startEdit(p)}>Edit</button><button className="btn danger" onClick=${() => del(p.name)}>Del</button></div>` : null}
+        </div>
+        <div className="meta">${
+          p.mode
+            ? `mode: ${p.mode}${p.preferredModels?.length ? " | preferred: " + p.preferredModels.join(", ") : ""}${p.fallbackModels?.length ? " | fallback: " + p.fallbackModels.join(", ") : ""}`
+            : ((p.entries || []).filter((e) => e.enabled !== false).map((e) => e.provider).join(" -> ") || "no entries")
+        }</div>
+      </div>
+    `)}
+    ${editing === "__new__" ? renderForm(true) : null}
+  </div>`;
+}
+
+// ── Routing rules editor ──
+
+const RULE_TYPES = [
+  { value: "time-window", label: "time-window (boost during hours/days)" },
+  { value: "quota-burn", label: "quota-burn (prefer expiring soon)" },
+  { value: "cost-tier", label: "cost-tier (prefer cheap targets)" },
+  { value: "model-fit", label: "model-fit (filter by capability)" },
+  { value: "error-blacklist", label: "error-blacklist (skip recent errors)" },
+  { value: "cooldown", label: "cooldown (skip exhausted)" },
+  { value: "custom", label: "custom (JS file path)" },
+];
+
+function RoutingRuleEditor({ rules, names, onSave, readOnly }) {
+  const [editing, setEditing] = useState(null);
+  const [draft, setDraft] = useState({});
+
+  function startNew() { setEditing("__new__"); setDraft({ id: "", type: "time-window", description: "", params: { boost: 50, targets: [], windows: [{ hours: [9, 17], days: ["mon", "tue", "wed", "thu", "fri"] }] } }); }
+  function startEdit(r) { setEditing(r.id); setDraft({ ...r, params: { ...(r.params || {}) } }); }
+  function cancel() { setEditing(null); }
+
+  async function save() {
+    const cfg = await api("/v1/config");
+    const all = [...(cfg.routingRules || [])];
+    if (editing === "__new__") all.push(draft);
+    else {
+      const i = all.findIndex((r) => r.id === editing);
+      if (i >= 0) all[i] = draft;
+    }
+    await api("/v1/config", jput({ routingRules: all }));
+    setEditing(null); onSave();
+  }
+  async function del(id) {
+    if (!confirm(`Delete rule "${id}"?`)) return;
+    const cfg = await api("/v1/config");
+    const all = (cfg.routingRules || []).filter((r) => r.id !== id);
+    await api("/v1/config", jput({ routingRules: all }));
+    onSave();
+  }
+
+  function updateParam(field, value) { setDraft({ ...draft, params: { ...draft.params, [field]: value } }); }
+
+  function renderForm(isNew) {
+    const t = draft.type;
+    return html`
+      <div className="card">
+        <div className="form-grid">
+          <div><label>ID</label><input value=${draft.id} onInput=${(e) => setDraft({ ...draft, id: e.target.value })} placeholder="e.g. prefer-anthropic-evening" disabled=${!isNew} /></div>
+          <div><label>Type</label><select value=${draft.type} onChange=${(e) => setDraft({ ...draft, type: e.target.value, params: {} })}>${RULE_TYPES.map((r) => html`<option key=${r.value} value=${r.value}>${r.label}</option>`)}</select></div>
+          <div className="full"><label>Description (optional)</label><input value=${draft.description || ""} onInput=${(e) => setDraft({ ...draft, description: e.target.value })} placeholder="What this rule does" /></div>
+
+          ${(t === "time-window" || t === "cost-tier") ? html`
+            <div><label>Boost score</label><input type="number" value=${draft.params?.boost ?? 50} onInput=${(e) => updateParam("boost", parseInt(e.target.value) || 0)} /></div>
+            <div className="full"><label>Targets (comma-separated provider/pool/account IDs)</label><input value=${(draft.params?.targets || []).join(", ")} onInput=${(e) => updateParam("targets", e.target.value.split(",").map((s) => s.trim()).filter(Boolean))} placeholder="anthropic, codex-pool" /></div>
+          ` : null}
+
+          ${t === "time-window" ? html`
+            <div className="full"><label>Windows (JSON: [{ days: ["mon-fri"], hours: [9, 17], tz: "Europe/Vienna" }])</label><textarea rows="4" value=${JSON.stringify(draft.params?.windows || [], null, 2)} onInput=${(e) => { try { updateParam("windows", JSON.parse(e.target.value)); } catch {} }} /></div>
+          ` : null}
+
+          ${t === "error-blacklist" ? html`
+            <div><label>Window (minutes)</label><input type="number" value=${draft.params?.windowMinutes || 5} onInput=${(e) => updateParam("windowMinutes", parseInt(e.target.value) || 5)} /></div>
+          ` : null}
+
+          ${t === "model-fit" ? [
+            html`<div key="ctx"><label>Min context</label><input type="number" value=${draft.params?.minContext || 0} onInput=${(e) => updateParam("minContext", parseInt(e.target.value) || 0)} /></div>`,
+            html`<div key="tools"><label>Require tools</label><select value=${String(!!draft.params?.requireTools)} onChange=${(e) => updateParam("requireTools", e.target.value === "true")}><option value="false">No</option><option value="true">Yes</option></select></div>`,
+            html`<div key="vis"><label>Require vision</label><select value=${String(!!draft.params?.requireVision)} onChange=${(e) => updateParam("requireVision", e.target.value === "true")}><option value="false">No</option><option value="true">Yes</option></select></div>`,
+          ] : null}
+
+          ${t === "custom" ? html`
+            <div className="full"><label>Script path (relative to ~/.pi/agent/)</label><input value=${draft.params?.code || ""} onInput=${(e) => updateParam("code", e.target.value)} placeholder="rules/my-rule.js" /></div>
+          ` : null}
         </div>
         <div className="actions" style=${{ marginTop: "10px" }}><button className="btn primary" onClick=${save}>${isNew ? "Create" : "Save"}</button><button className="btn" onClick=${cancel}>Cancel</button></div>
       </div>
@@ -630,17 +802,149 @@ function PresetEditor({ presets, names, onSave }) {
   }
 
   return html`<div>
-    <div className="card-row" style=${{ marginBottom: "10px" }}><h2 style=${{ margin: 0 }}>Presets</h2><button className="btn primary" onClick=${startNew}>+ Add</button></div>
-    ${presets.map((p) => editing === p.name ? renderForm(false) : html`
-      <div className="card" key=${p.name}>
+    <div className="card-row" style=${{ marginBottom: "10px" }}><h2 style=${{ margin: 0 }}>Routing rules</h2>${!readOnly ? html`<button className="btn primary" onClick=${startNew}>+ Add rule</button>` : null}</div>
+    <div style=${{ marginBottom: "10px", fontSize: "11px", color: "#52525b" }}>Reusable decision pieces. Used by modes to filter and rank candidates per request.</div>
+    ${rules.length === 0 && editing !== "__new__" ? html`<div className="empty">No routing rules. Add a time-window rule to boost a provider during specific hours, or a quota-burn rule to use expiring quotas first.</div>` : null}
+    ${rules.map((r) => editing === r.id ? renderForm(false) : html`
+      <div className="card" key=${r.id}>
         <div className="card-row">
-          <div><span className="name">${p.name}</span><span className=${`badge ${p.enabled !== false ? "on" : "off"}`}>${p.enabled !== false ? "on" : "off"}</span><span className="badge neutral">${(p.entries || []).length} entries</span></div>
-          <div className="actions"><button className="btn" onClick=${() => startEdit(p)}>Edit</button><button className="btn danger" onClick=${() => del(p.name)}>Del</button></div>
+          <div><span className="name">${r.id}</span><span className="badge neutral">${r.type}</span></div>
+          ${!readOnly ? html`<div className="actions"><button className="btn" onClick=${() => startEdit(r)}>Edit</button><button className="btn danger" onClick=${() => del(r.id)}>Del</button></div>` : null}
         </div>
-        <div className="meta">${(p.entries || []).filter((e) => e.enabled !== false).map((e) => e.provider).join(" -> ") || "no entries"}</div>
+        ${r.description ? html`<div className="meta">${r.description}</div>` : null}
+        <div className="meta" style=${{ fontFamily: "monospace", fontSize: "11px" }}>${JSON.stringify(r.params || {})}</div>
       </div>
     `)}
     ${editing === "__new__" ? renderForm(true) : null}
+  </div>`;
+}
+
+// ── Modes editor ──
+
+function ModeEditor({ modes, rules, names, onSave, readOnly }) {
+  const [editing, setEditing] = useState(null);
+  const [draft, setDraft] = useState({});
+
+  function startNew() { setEditing("__new__"); setDraft({ id: "", description: "", candidates: [], rules: [], onError: "next-in-order", enabled: true }); }
+  function startEdit(m) { setEditing(m.id); setDraft({ ...m, candidates: [...(m.candidates || [])], rules: [...(m.rules || [])] }); }
+  function cancel() { setEditing(null); }
+
+  async function save() {
+    const cfg = await api("/v1/config");
+    const all = [...(cfg.modes || [])];
+    if (editing === "__new__") all.push(draft);
+    else {
+      const i = all.findIndex((m) => m.id === editing);
+      if (i >= 0) all[i] = draft;
+    }
+    await api("/v1/config", jput({ modes: all }));
+    setEditing(null); onSave();
+  }
+  async function del(id) {
+    if (!confirm(`Delete mode "${id}"?`)) return;
+    const cfg = await api("/v1/config");
+    const all = (cfg.modes || []).filter((m) => m.id !== id);
+    await api("/v1/config", jput({ modes: all }));
+    onSave();
+  }
+
+  function addCandidate(val) { if (val && !draft.candidates.includes(val)) setDraft({ ...draft, candidates: [...draft.candidates, val] }); }
+  function removeCandidate(i) { setDraft({ ...draft, candidates: draft.candidates.filter((_, idx) => idx !== i) }); }
+  function addRule(val) { if (val && !draft.rules.includes(val)) setDraft({ ...draft, rules: [...draft.rules, val] }); }
+  function removeRule(i) { setDraft({ ...draft, rules: draft.rules.filter((_, idx) => idx !== i) }); }
+
+  function renderForm(isNew) {
+    const allRefs = [
+      ...((names?.providers || []).map((p) => p.id)),
+      ...((names?.pools || []).map((p) => p.label)),
+      ...modes.filter((m) => m.id !== draft.id).map((m) => m.id),
+    ];
+    const remainingCandidates = allRefs.filter((r) => !draft.candidates.includes(r));
+    const remainingRules = rules.map((r) => r.id).filter((r) => !draft.rules.includes(r));
+
+    return html`
+      <div className="card">
+        <div className="form-grid">
+          <div><label>ID</label><input value=${draft.id} onInput=${(e) => setDraft({ ...draft, id: e.target.value })} placeholder="e.g. coding-premium" disabled=${!isNew} /></div>
+          <div><label>On error</label><select value=${draft.onError} onChange=${(e) => setDraft({ ...draft, onError: e.target.value })}><option value="next-in-order">next-in-order</option><option value="re-evaluate">re-evaluate</option><option value="fail-fast">fail-fast</option></select></div>
+          <div className="full"><label>Description</label><input value=${draft.description || ""} onInput=${(e) => setDraft({ ...draft, description: e.target.value })} /></div>
+
+          <div className="full">
+            <label>Candidates (drag to reorder; accounts, pools, or other modes)</label>
+            <${SortableList} items=${draft.candidates} onReorder=${(arr) => setDraft({ ...draft, candidates: arr })} renderItem=${(c, i) => html`
+              <span style=${{ flex: 1, fontSize: "13px", color: "#e4e4e7" }}>${c}</span>
+              <button className="btn danger" onClick=${() => removeCandidate(i)} style=${{ padding: "2px 8px", fontSize: "11px" }}>x</button>
+            `} />
+            ${remainingCandidates.length > 0 ? html`
+              <select onChange=${(e) => { addCandidate(e.target.value); e.target.value = ""; }} style=${{ width: "100%", marginTop: "4px" }}>
+                <option value="">+ Add candidate...</option>
+                ${remainingCandidates.map((r) => html`<option key=${r} value=${r}>${r}</option>`)}
+              </select>
+            ` : null}
+          </div>
+
+          <div className="full">
+            <label>Rules (applied in order)</label>
+            <${SortableList} items=${draft.rules} onReorder=${(arr) => setDraft({ ...draft, rules: arr })} renderItem=${(r, i) => html`
+              <span style=${{ flex: 1, fontSize: "13px", color: "#e4e4e7" }}>${r}</span>
+              <button className="btn danger" onClick=${() => removeRule(i)} style=${{ padding: "2px 8px", fontSize: "11px" }}>x</button>
+            `} />
+            ${remainingRules.length > 0 ? html`
+              <select onChange=${(e) => { addRule(e.target.value); e.target.value = ""; }} style=${{ width: "100%", marginTop: "4px" }}>
+                <option value="">+ Add rule...</option>
+                ${remainingRules.map((r) => html`<option key=${r} value=${r}>${r}</option>`)}
+              </select>
+            ` : null}
+          </div>
+        </div>
+        <div className="actions" style=${{ marginTop: "10px" }}><button className="btn primary" onClick=${save}>${isNew ? "Create" : "Save"}</button><button className="btn" onClick=${cancel}>Cancel</button></div>
+      </div>
+    `;
+  }
+
+  return html`<div>
+    <div className="card-row" style=${{ marginBottom: "10px" }}><h2 style=${{ margin: 0 }}>Modes</h2>${!readOnly ? html`<button className="btn primary" onClick=${startNew}>+ Add mode</button>` : null}</div>
+    <div style=${{ marginBottom: "10px", fontSize: "11px", color: "#52525b" }}>Cross-provider routing pipelines. Modes declare candidates + rules, then per-request the rules filter and rank to pick the best one.</div>
+    ${modes.length === 0 && editing !== "__new__" ? html`<div className="empty">No modes. Create a mode that mixes Anthropic, OpenAI, and your pools, then attach rules to control selection.</div>` : null}
+    ${modes.map((m) => editing === m.id ? renderForm(false) : html`
+      <div className="card" key=${m.id}>
+        <div className="card-row">
+          <div><span className="name">${m.id}</span><span className="badge neutral">${(m.candidates || []).length} candidates</span><span className="badge neutral">${(m.rules || []).length} rules</span><span className="badge neutral">on error: ${m.onError}</span></div>
+          ${!readOnly ? html`<div className="actions"><button className="btn" onClick=${() => startEdit(m)}>Edit</button><button className="btn danger" onClick=${() => del(m.id)}>Del</button></div>` : null}
+        </div>
+        ${m.description ? html`<div className="meta">${m.description}</div>` : null}
+        <div className="meta">candidates: ${(m.candidates || []).join(", ")}</div>
+        ${m.rules?.length ? html`<div className="meta">rules: ${m.rules.join(" -> ")}</div>` : null}
+      </div>
+    `)}
+    ${editing === "__new__" ? renderForm(true) : null}
+  </div>`;
+}
+
+// ── Routing tab combines rules + modes ──
+
+function RoutingPanel({ onRefresh }) {
+  const [config, setConfig] = useState(null);
+  const [err, setErr] = useState("");
+  const { names, reloadNames } = useNames();
+
+  async function load() { setErr(""); try { setConfig(await api("/v1/config")); } catch (e) { setErr(e.message); } }
+  useEffect(() => { load(); }, []);
+
+  async function refresh() { await load(); reloadNames(); if (onRefresh) onRefresh(); }
+
+  if (!config) return html`<div className="empty">${err || "Loading..."}</div>`;
+
+  const readOnly = !!config._readOnly;
+
+  return html`<div>
+    ${err ? html`<div className="card" style=${{ color: "#ef4444", borderColor: "#7f1d1d" }}>Error: ${err}</div>` : null}
+    ${readOnly ? html`<div className="card" style=${{ borderColor: "#92400e", background: "#1c1508", marginBottom: "16px" }}><span style=${{ color: "#f59e0b", fontWeight: 600 }}>Read-only:</span> config managed by ${config._source}. Edit the file directly to make changes.</div>` : null}
+    <${RoutingRuleEditor} rules=${config.routingRules || []} names=${names} onSave=${refresh} readOnly=${readOnly} />
+    <div style=${{ marginTop: "24px" }} />
+    <${ModeEditor} modes=${config.modes || []} rules=${config.routingRules || []} names=${names} onSave=${refresh} readOnly=${readOnly} />
+    <div style=${{ marginTop: "24px" }} />
+    <${PresetEditor} presets=${config.presets || []} modes=${config.modes || []} names=${names} onSave=${refresh} readOnly=${readOnly} />
   </div>`;
 }
 
@@ -658,18 +962,21 @@ function ConfigPanel({ onRefresh }) {
 
   if (!config) return html`<div className="empty">${err || "Loading..."}</div>`;
 
+  const readOnly = !!config._readOnly;
+
   return html`<div>
     ${err ? html`<div className="card" style=${{ color: "#ef4444", borderColor: "#7f1d1d" }}>Error: ${err}</div>` : null}
+    ${readOnly ? html`<div className="card" style=${{ borderColor: "#92400e", background: "#1c1508", marginBottom: "16px" }}><span style=${{ color: "#f59e0b", fontWeight: 600 }}>Read-only:</span> config managed by ${config._source}. Edit the JS file directly to make changes.</div>` : null}
     <${AuthPanel} onRefresh=${refresh} reloadNames=${reloadNames} />
     <div style=${{ marginTop: "24px" }} />
     <${ApiKeyEditor} apiKeys=${config.apiKeys || []} onSave=${refresh} />
     <div style=${{ marginTop: "24px" }} />
-    <div style=${{ marginBottom: "6px", fontSize: "11px", color: "#52525b" }}>Editing: ~/.pi/agent/multi-pass.json</div>
+    <div style=${{ marginBottom: "6px", fontSize: "11px", color: "#52525b" }}>Editing: ${config._source || "~/.pi/agent/multi-pass.json"}</div>
     <${PoolEditor} pools=${config.pools || []} names=${names} onSave=${refresh} />
     <div style=${{ marginTop: "20px" }} />
     <${ChainEditor} chains=${config.chains || []} names=${names} onSave=${refresh} />
     <div style=${{ marginTop: "20px" }} />
-    <${PresetEditor} presets=${config.presets || []} names=${names} onSave=${refresh} />
+    <div style=${{ fontSize: "11px", color: "#52525b", marginBottom: "6px" }}>Tip: for cross-provider intent routing with rules, use the <strong>Routing</strong> tab.</div>
   </div>`;
 }
 
@@ -1042,7 +1349,7 @@ function App() {
 
   function logout() { localStorage.removeItem(TOKEN_KEY); location.reload(); }
 
-  const tabs = ["dashboard", "config", "users", "rules", "audit"];
+  const tabs = ["dashboard", "config", "routing", "users", "rules", "audit"];
 
   return html`
     <div className="app">
@@ -1058,6 +1365,7 @@ function App() {
         ${error ? html`<div className="card" style=${{ color: "#ef4444", borderColor: "#7f1d1d" }}>Error: ${error}</div>` : null}
         ${tab === "dashboard" ? html`<${DashboardPanel} data=${dash} />` : null}
         ${tab === "config" ? html`<${ConfigPanel} onRefresh=${() => load("dashboard", true)} />` : null}
+        ${tab === "routing" ? html`<${RoutingPanel} onRefresh=${() => load("dashboard", true)} />` : null}
         ${tab === "users" ? html`<${UsersPanel} />` : null}
         ${tab === "rules" ? html`<${RulesPanel} rules=${rules} onRefresh=${() => load("rules")} />` : null}
         ${tab === "audit" ? html`<${AuditPanel} entries=${audit} onRefresh=${() => load("audit")} />` : null}

--- a/web/admin/app.js
+++ b/web/admin/app.js
@@ -1,6 +1,7 @@
-import React, { useEffect, useState, useCallback } from "https://esm.sh/react@18.3.1";
+import React, { useEffect, useState, useCallback, useRef } from "https://esm.sh/react@18.3.1";
 import { createRoot } from "https://esm.sh/react-dom@18.3.1/client";
 import htm from "https://esm.sh/htm@3.1.1";
+import DiffMatchPatch from "https://esm.sh/diff-match-patch@1.0.5";
 
 const html = htm.bind(React.createElement);
 const BASE = location.origin;
@@ -648,9 +649,39 @@ function RulesPanel({ rules, onRefresh }) {
 // AUDIT
 // ════════════════════════════════════════════════════════════════════════════════
 
+const dmp = new DiffMatchPatch();
+
+function InlineDiff({ before, after }) {
+  const ref = useRef(null);
+  useEffect(() => {
+    if (!ref.current || !before || !after) return;
+    const diffs = dmp.diff_main(before, after);
+    dmp.diff_cleanupSemantic(diffs);
+    let html = "";
+    for (const [op, text] of diffs) {
+      const esc = text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+      if (op === -1) html += '<span class="diff-del">' + esc + "</span>";
+      else if (op === 1) html += '<span class="diff-ins">' + esc + "</span>";
+      else html += '<span class="diff-eq">' + esc + "</span>";
+    }
+    ref.current.innerHTML = html;
+  }, [before, after]);
+  return React.createElement("pre", { ref, className: "diff-view" });
+}
+
 function AuditPanel({ entries, onRefresh }) {
   const [filter, setFilter] = useState("");
-  const filtered = filter ? entries.filter((e) => e.rule?.includes(filter) || e.action?.includes(filter) || e.detail?.includes(filter)) : entries;
+  const filtered = filter ? entries.filter((e) => e.rule?.includes(filter) || e.action?.includes(filter) || e.detail?.includes(filter) || e.matched_text?.includes(filter)) : entries;
+
+  function renderContent(e) {
+    if (e.full_message && e.redacted_message && e.full_message !== e.redacted_message) {
+      return html`<details><summary>diff</summary><${InlineDiff} before=${e.full_message} after=${e.redacted_message} /></details>`;
+    }
+    if (e.full_message) {
+      return html`<details><summary>view</summary><pre>${e.full_message}</pre></details>`;
+    }
+    return "--";
+  }
 
   return html`<div>
     <div className="card-row" style=${{ marginBottom: "12px" }}>
@@ -663,9 +694,17 @@ function AuditPanel({ entries, onRefresh }) {
     <div style=${{ marginBottom: "6px", fontSize: "11px", color: "#52525b" }}>Persisted to: ~/.pi/agent/leeloo-audit.jsonl</div>
     ${filtered.length === 0 ? html`<div className="empty">No audit events${filter ? " matching filter" : ""}.</div>` : html`
       <div className="table-wrap"><table>
-        <thead><tr><th>Time</th><th>Rule</th><th>Type</th><th>Action</th><th>Source</th><th>Matched</th><th>Before</th><th>After</th></tr></thead>
+        <thead><tr><th>Time</th><th>Rule</th><th>Type</th><th>Action</th><th>Source</th><th>Matched</th><th>Content</th></tr></thead>
         <tbody>${filtered.map((e, i) => html`
-          <tr key=${i}><td>${ago(e.timestamp)}</td><td style=${{ fontWeight: 600 }}>${e.rule}</td><td><span className=${`badge ${e.type}`}>${e.type}</span></td><td>${e.action}</td><td>${e.source || "--"}</td><td style=${{ color: "#ef4444", fontFamily: "monospace", fontSize: "11px" }}>${e.matched_text || "--"}</td><td>${e.full_message ? html`<details><summary>view</summary><pre>${e.full_message}</pre></details>` : "--"}</td><td>${e.redacted_message ? html`<details><summary>view</summary><pre>${e.redacted_message}</pre></details>` : "--"}</td></tr>
+          <tr key=${i}>
+            <td>${ago(e.timestamp)}</td>
+            <td style=${{ fontWeight: 600 }}>${e.rule}</td>
+            <td><span className=${`badge ${e.type}`}>${e.type}</span></td>
+            <td>${e.action}</td>
+            <td>${e.source || "--"}</td>
+            <td style=${{ color: "#ef4444", fontFamily: "monospace", fontSize: "11px" }}>${e.matched_text || "--"}</td>
+            <td>${renderContent(e)}</td>
+          </tr>
         `)}</tbody>
       </table></div>
     `}

--- a/web/admin/app.js
+++ b/web/admin/app.js
@@ -223,50 +223,6 @@ function AuthPanel({ onRefresh, reloadNames }) {
   </div>`;
 }
 
-// ── Subscriptions ──
-
-function SubEditor({ subs, onSave }) {
-  const [editing, setEditing] = useState(null);
-  const [draft, setDraft] = useState({});
-
-  function startEdit(s) { setEditing(s.name); setDraft({ ...s }); }
-  function startNew() { setEditing("__new__"); setDraft({ name: "", provider: BASE_PROVIDERS[0], enabled: true, alias: "" }); }
-  function cancel() { setEditing(null); }
-  async function save() {
-    if (editing === "__new__") { await api("/v1/config/subscriptions", jpost(draft)); }
-    else { await api(`/v1/config/subscriptions/${encodeURIComponent(editing)}`, jput(draft)); }
-    setEditing(null); onSave();
-  }
-  async function del(name) { if (confirm(`Delete subscription "${name}"?`)) { await api(`/v1/config/subscriptions/${encodeURIComponent(name)}`, { method: "DELETE" }); onSave(); } }
-
-  function renderForm(isNew) {
-    return html`
-      <div className="card">
-        <div className="form-grid">
-          <div><label>Name</label><input value=${draft.name} onInput=${(e) => setDraft({ ...draft, name: e.target.value })} placeholder="e.g. openai-codex-2" /></div>
-          <div><label>Base provider</label><select value=${draft.provider} onChange=${(e) => setDraft({ ...draft, provider: e.target.value })}>${BASE_PROVIDERS.map((p) => html`<option key=${p} value=${p}>${p}</option>`)}</select></div>
-          <div><label>Alias</label><input value=${draft.alias || ""} onInput=${(e) => setDraft({ ...draft, alias: e.target.value })} /></div>
-          <div><label>Enabled</label><select value=${String(draft.enabled)} onChange=${(e) => setDraft({ ...draft, enabled: e.target.value === "true" })}><option value="true">Yes</option><option value="false">No</option></select></div>
-        </div>
-        <div className="actions" style=${{ marginTop: "10px" }}><button className="btn primary" onClick=${save}>${isNew ? "Create" : "Save"}</button><button className="btn" onClick=${cancel}>Cancel</button></div>
-      </div>
-    `;
-  }
-
-  return html`<div>
-    <div className="card-row" style=${{ marginBottom: "10px" }}><h2 style=${{ margin: 0 }}>Subscriptions</h2><button className="btn primary" onClick=${startNew}>+ Add</button></div>
-    ${subs.map((s) => editing === s.name ? renderForm(false) : html`
-      <div className="card" key=${s.name}>
-        <div className="card-row">
-          <div><span className="name">${s.name}</span><span className="badge neutral">${s.provider}</span><span className=${`badge ${s.enabled !== false ? "on" : "off"}`}>${s.enabled !== false ? "on" : "off"}</span>${s.alias ? html`<span className="badge neutral">${s.alias}</span>` : null}</div>
-          <div className="actions"><button className="btn" onClick=${() => startEdit(s)}>Edit</button><button className="btn danger" onClick=${() => del(s.name)}>Del</button></div>
-        </div>
-      </div>
-    `)}
-    ${editing === "__new__" ? renderForm(true) : null}
-  </div>`;
-}
-
 // ── Pools ──
 
 function PoolEditor({ pools, names, onSave }) {
@@ -471,8 +427,6 @@ function ConfigPanel({ onRefresh }) {
     <${AuthPanel} onRefresh=${refresh} reloadNames=${reloadNames} />
     <div style=${{ marginTop: "24px" }} />
     <div style=${{ marginBottom: "6px", fontSize: "11px", color: "#52525b" }}>Editing: ~/.pi/agent/multi-pass.json</div>
-    <${SubEditor} subs=${config.subscriptions || []} onSave=${refresh} />
-    <div style=${{ marginTop: "20px" }} />
     <${PoolEditor} pools=${config.pools || []} names=${names} onSave=${refresh} />
     <div style=${{ marginTop: "20px" }} />
     <${ChainEditor} chains=${config.chains || []} names=${names} onSave=${refresh} />

--- a/web/admin/app.js
+++ b/web/admin/app.js
@@ -43,15 +43,24 @@ function useNames() {
 
 /** Dropdown for selecting a provider/subscription */
 function ProviderSelect({ value, onChange, names, allowPools, allowChains, placeholder }) {
-  const provs = names?.providers || [];
+  const allProvs = names?.providers || [];
+  const oauthProvs = allProvs.filter((p) => p.type !== "apikey");
+  const apiKeyProvs = allProvs.filter((p) => p.type === "apikey");
   const pools = names?.pools || [];
   const chains = names?.chains || [];
   return html`
     <select value=${value || ""} onChange=${(e) => onChange(e.target.value)}>
       <option value="">${placeholder || "-- select --"}</option>
-      <optgroup label="Providers">
-        ${provs.map((p) => html`<option key=${p.id} value=${p.id}>${p.label}${p.authenticated ? "" : " (no auth)"}</option>`)}
-      </optgroup>
+      ${oauthProvs.length ? html`
+        <optgroup label="OAuth providers">
+          ${oauthProvs.map((p) => html`<option key=${p.id} value=${p.id}>${p.label}${p.authenticated ? "" : " (no auth)"}</option>`)}
+        </optgroup>
+      ` : null}
+      ${apiKeyProvs.length ? html`
+        <optgroup label="API keys">
+          ${apiKeyProvs.map((p) => html`<option key=${p.id} value=${p.id}>${p.label}</option>`)}
+        </optgroup>
+      ` : null}
       ${allowPools && pools.length ? html`
         <optgroup label="Pools">
           ${pools.map((p) => html`<option key=${p.id} value=${p.id}>${p.label}</option>`)}
@@ -458,7 +467,9 @@ function ApiKeyEditor({ apiKeys, onSave }) {
 function PoolEditor({ pools, names, onSave }) {
   const [editing, setEditing] = useState(null);
   const [draft, setDraft] = useState({});
-  const providerNames = (names?.providers || []).map((p) => p.id);
+  const allProviders = names?.providers || [];
+  const providerNames = allProviders.map((p) => p.id);
+  const apiKeyNames = allProviders.filter((p) => p.type === "apikey").map((p) => p.id);
 
   function startEdit(p) { setEditing(p.name); setDraft({ ...p, members: [...(p.members || [])] }); }
   function startNew() { setEditing("__new__"); setDraft({ name: "", enabled: true, baseProvider: BASE_PROVIDERS[0], members: [], strategy: "round-robin" }); }
@@ -475,7 +486,8 @@ function PoolEditor({ pools, names, onSave }) {
 
   function renderForm(isNew) {
     // Filter providers to those matching the base provider
-    const eligible = providerNames.filter((n) => n === draft.baseProvider || n.startsWith(draft.baseProvider + "-"));
+    // OAuth providers matching the base provider + all API key entries
+    const eligible = providerNames.filter((n) => n === draft.baseProvider || n.startsWith(draft.baseProvider + "-") || apiKeyNames.includes(n));
     return html`
       <div className="card">
         <div className="form-grid">

--- a/web/admin/app.js
+++ b/web/admin/app.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "https://esm.sh/react@18.3.1";
+import React, { useEffect, useState } from "https://esm.sh/react@18.3.1";
 import { createRoot } from "https://esm.sh/react-dom@18.3.1/client";
 import htm from "https://esm.sh/htm@3.1.1";
 
@@ -79,13 +79,16 @@ function DashboardPanel({ data }) {
         </table>
       </div>
 
-      <h2 style=${{ marginTop: "14px" }}>Recent requests</h2>
+      <h2 style=${{ marginTop: "14px" }}>Recent chats</h2>
       <div className="table-wrap">
         <table>
           <thead>
-            <tr><th>Time</th><th>Provider</th><th>Model</th><th>Tokens</th><th>Duration</th><th>Error</th></tr>
+            <tr><th>Time</th><th>Provider</th><th>Model</th><th>Tokens</th><th>Duration</th><th>Error</th><th>Request</th><th>Response</th></tr>
           </thead>
           <tbody>
+            ${recent.length === 0 ? html`
+              <tr><td colSpan="8" style=${{ color: "#666", fontStyle: "italic" }}>No chat requests yet.</td></tr>
+            ` : null}
             ${recent.slice(0, 30).map((r, idx) => html`
               <tr key=${idx}>
                 <td>${ago(r.timestamp)}</td>
@@ -94,6 +97,16 @@ function DashboardPanel({ data }) {
                 <td>${r.tokens_in} / ${r.tokens_out}</td>
                 <td>${r.duration_ms}ms</td>
                 <td>${r.error || "--"}</td>
+                <td>
+                  ${r.request_text
+                    ? html`<details><summary>view (${r.request_text.length})</summary><pre>${r.request_text}</pre></details>`
+                    : "--"}
+                </td>
+                <td>
+                  ${r.response_text
+                    ? html`<details><summary>view (${r.response_text.length})</summary><pre>${r.response_text}</pre></details>`
+                    : "--"}
+                </td>
               </tr>
             `)}
           </tbody>
@@ -399,16 +412,34 @@ function App() {
     refreshTab(active);
   }, [active]);
 
-  async function refreshTab(tab = active) {
-    setError("");
+  useEffect(() => {
+    const intervalMs = active === "dashboard" ? 3000 : active === "audit" ? 5000 : 0;
+    if (!intervalMs) return;
+    const timer = setInterval(() => {
+      refreshTab(active, true);
+    }, intervalMs);
+    return () => clearInterval(timer);
+  }, [active]);
+
+  async function refreshTab(tab = active, silent = false) {
+    if (!silent) setError("");
     try {
       if (tab === "dashboard") {
-        const [stats, quota, healthData] = await Promise.all([
+        const [statsRes, quotaRes, healthRes] = await Promise.allSettled([
           fetchJson("/v1/stats"),
           fetchJson("/v1/quota"),
           fetchJson("/health"),
         ]);
-        setDashboard({ stats, quota, health: healthData });
+
+        setDashboard((prev) => ({
+          stats: statsRes.status === "fulfilled" ? statsRes.value : prev.stats,
+          quota: quotaRes.status === "fulfilled" ? quotaRes.value : prev.quota,
+          health: healthRes.status === "fulfilled" ? healthRes.value : prev.health,
+        }));
+
+        if (statsRes.status !== "fulfilled" && quotaRes.status !== "fulfilled" && healthRes.status !== "fulfilled") {
+          throw new Error("Dashboard data unavailable");
+        }
       } else if (tab === "rules") {
         const data = await fetchJson("/v1/rules");
         setRules(data.rules || []);
@@ -420,7 +451,7 @@ function App() {
         setHealth(h);
       }
     } catch (e) {
-      setError(e.message);
+      if (!silent) setError(e.message);
     }
   }
 

--- a/web/admin/app.js
+++ b/web/admin/app.js
@@ -5,15 +5,15 @@ import htm from "https://esm.sh/htm@3.1.1";
 const html = htm.bind(React.createElement);
 const BASE = location.origin;
 const STRATEGIES = ["round-robin", "quota-first", "scheduled", "custom"];
-const PROVIDERS = ["anthropic", "openai-codex", "github-copilot", "google-gemini-cli", "google-antigravity"];
+const BASE_PROVIDERS = ["anthropic", "openai-codex", "github-copilot", "google-gemini-cli", "google-antigravity"];
 
 async function api(path, init) {
   const r = await fetch(`${BASE}${path}`, init);
   if (!r.ok) { const e = await r.json().catch(() => ({})); throw new Error(e?.error?.message || `HTTP ${r.status}`); }
   return r.json();
 }
-function jpost(data) { return { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(data) }; }
-function jput(data) { return { method: "PUT", headers: { "Content-Type": "application/json" }, body: JSON.stringify(data) }; }
+function jpost(d) { return { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(d) }; }
+function jput(d) { return { method: "PUT", headers: { "Content-Type": "application/json" }, body: JSON.stringify(d) }; }
 
 function ago(ts) {
   if (!ts) return "--";
@@ -24,6 +24,41 @@ function ago(ts) {
 }
 function qColor(s) { return s == null ? "#3f3f46" : s > 50 ? "#22c55e" : s > 20 ? "#eab308" : "#ef4444"; }
 function QuotaBar({ score }) { return html`<span className="q-bar"><span className="q-fill" style=${{ width: `${score ?? 0}%`, background: qColor(score) }} /></span>`; }
+
+/** Shared hook: load known provider/pool/chain names for dropdowns */
+function useNames() {
+  const [names, setNames] = useState({ providers: [], pools: [], chains: [] });
+  const load = useCallback(async () => {
+    try { setNames(await api("/v1/auth/names")); } catch {}
+  }, []);
+  useEffect(() => { load(); }, []);
+  return { names, reloadNames: load };
+}
+
+/** Dropdown for selecting a provider/subscription */
+function ProviderSelect({ value, onChange, names, allowPools, allowChains, placeholder }) {
+  const provs = names?.providers || [];
+  const pools = names?.pools || [];
+  const chains = names?.chains || [];
+  return html`
+    <select value=${value || ""} onChange=${(e) => onChange(e.target.value)}>
+      <option value="">${placeholder || "-- select --"}</option>
+      <optgroup label="Providers">
+        ${provs.map((p) => html`<option key=${p.id} value=${p.id}>${p.label}${p.authenticated ? "" : " (no auth)"}</option>`)}
+      </optgroup>
+      ${allowPools && pools.length ? html`
+        <optgroup label="Pools">
+          ${pools.map((p) => html`<option key=${p.id} value=${p.id}>${p.label}</option>`)}
+        </optgroup>
+      ` : null}
+      ${allowChains && chains.length ? html`
+        <optgroup label="Chains">
+          ${chains.map((c) => html`<option key=${c.id} value=${c.id}>${c.label}</option>`)}
+        </optgroup>
+      ` : null}
+    </select>
+  `;
+}
 
 // ════════════════════════════════════════════════════════════════════════════════
 // DASHBOARD
@@ -64,25 +99,122 @@ function DashboardPanel({ data }) {
 // CONFIG EDITOR
 // ════════════════════════════════════════════════════════════════════════════════
 
-function InlineEdit({ value, onChange, placeholder, mono }) {
-  return html`<input className=${mono ? "mono" : ""} value=${value || ""} onInput=${(e) => onChange(e.target.value)} placeholder=${placeholder} />`;
-}
+// ── Auth / OAuth ──
 
-function TagList({ items, onChange, placeholder }) {
-  const [draft, setDraft] = useState("");
-  function add() { if (draft.trim()) { onChange([...items, draft.trim()]); setDraft(""); } }
-  function remove(i) { onChange(items.filter((_, idx) => idx !== i)); }
-  return html`
-    <div>
-      <div style=${{ display: "flex", flexWrap: "wrap", gap: "4px", marginBottom: "6px" }}>
-        ${items.map((item, i) => html`<span key=${i} className="badge neutral" style=${{ cursor: "pointer" }} onClick=${() => remove(i)}>${item} x</span>`)}
-      </div>
-      <div style=${{ display: "flex", gap: "6px" }}>
-        <input value=${draft} onInput=${(e) => setDraft(e.target.value)} placeholder=${placeholder} onKeyDown=${(e) => { if (e.key === "Enter") { e.preventDefault(); add(); } }} style=${{ flex: 1 }} />
-        <button className="btn" onClick=${add}>+</button>
-      </div>
+function AuthPanel({ onRefresh, reloadNames }) {
+  const [providers, setProviders] = useState([]);
+  const [busy, setBusy] = useState({});
+  const [showAdd, setShowAdd] = useState(false);
+  const [newBase, setNewBase] = useState(BASE_PROVIDERS[0]);
+  const [newName, setNewName] = useState("");
+
+  async function loadProviders() {
+    try { const d = await api("/v1/auth/providers"); setProviders(d.providers || []); } catch {}
+  }
+  useEffect(() => { loadProviders(); }, []);
+
+  async function startLogin(providerId) {
+    setBusy((b) => ({ ...b, [providerId]: "connecting..." }));
+    try {
+      const res = await api(`/v1/auth/login/${encodeURIComponent(providerId)}`, { method: "POST" });
+      if (res.authUrl) {
+        window.open(res.authUrl, "_blank");
+        setBusy((b) => ({ ...b, [providerId]: "waiting for browser..." }));
+        pollLogin(providerId);
+      }
+    } catch (e) {
+      setBusy((b) => ({ ...b, [providerId]: `error: ${e.message}` }));
+      setTimeout(() => setBusy((b) => { const n = { ...b }; delete n[providerId]; return n; }), 3000);
+    }
+  }
+
+  async function pollLogin(providerId) {
+    for (let i = 0; i < 120; i++) {
+      await new Promise((r) => setTimeout(r, 2000));
+      try {
+        const s = await api(`/v1/auth/login/${encodeURIComponent(providerId)}`);
+        if (s.status === "authenticated" || s.hasAuth) {
+          setBusy((b) => { const n = { ...b }; delete n[providerId]; return n; });
+          await loadProviders();
+          if (reloadNames) reloadNames();
+          if (onRefresh) onRefresh();
+          return;
+        }
+      } catch {}
+    }
+    setBusy((b) => ({ ...b, [providerId]: "timed out" }));
+  }
+
+  async function logout(providerId) {
+    if (!confirm(`Logout from ${providerId}?`)) return;
+    try {
+      await api(`/v1/auth/logout/${encodeURIComponent(providerId)}`, { method: "POST" });
+      await loadProviders();
+      if (reloadNames) reloadNames();
+      if (onRefresh) onRefresh();
+    } catch {}
+  }
+
+  async function addAccount() {
+    const name = newName.trim() || `${newBase}-${Date.now()}`;
+    setBusy((b) => ({ ...b, __new__: "creating..." }));
+    try {
+      // 1. Create subscription entry
+      await api("/v1/config/subscriptions", jpost({ name, provider: newBase, enabled: true, alias: name }));
+      // 2. Start OAuth login for the new subscription name
+      setShowAdd(false);
+      setNewName("");
+      if (onRefresh) onRefresh();
+      if (reloadNames) reloadNames();
+      await loadProviders();
+      // 3. Auto-start login for the new account (use base provider OAuth since it shares the flow)
+      startLogin(newBase);
+    } catch (e) {
+      setBusy((b) => ({ ...b, __new__: `error: ${e.message}` }));
+    }
+    setBusy((b) => { const n = { ...b }; delete n.__new__; return n; });
+  }
+
+  return html`<div>
+    <div className="card-row" style=${{ marginBottom: "10px" }}>
+      <h2 style=${{ margin: 0 }}>OAuth accounts</h2>
+      <button className="btn primary" onClick=${() => setShowAdd((v) => !v)}>${showAdd ? "Cancel" : "+ Add account"}</button>
     </div>
-  `;
+    <div style=${{ marginBottom: "10px", fontSize: "11px", color: "#52525b" }}>Login to providers to enable routing. Add extra accounts for the same provider to enable pool rotation.</div>
+
+    ${showAdd ? html`
+      <div className="card" style=${{ marginBottom: "12px" }}>
+        <div className="form-grid">
+          <div><label>Base provider</label><select value=${newBase} onChange=${(e) => setNewBase(e.target.value)}>${BASE_PROVIDERS.map((p) => html`<option key=${p} value=${p}>${p}</option>`)}</select></div>
+          <div><label>Account name</label><input value=${newName} onInput=${(e) => setNewName(e.target.value)} placeholder=${`e.g. ${newBase}-2`} /></div>
+        </div>
+        <div className="actions" style=${{ marginTop: "10px" }}>
+          <button className="btn primary" onClick=${addAccount} disabled=${!!busy.__new__}>${busy.__new__ || "Create & Login"}</button>
+        </div>
+      </div>
+    ` : null}
+
+    ${providers.map((p) => html`
+      <div className="card" key=${p.id}>
+        <div className="card-row">
+          <div>
+            <span className="name">${p.name}</span>
+            <span className="badge neutral" style=${{ fontFamily: "monospace" }}>${p.id}</span>
+            <span className=${`badge ${p.authenticated ? "on" : "off"}`}>${p.authenticated ? "logged in" : "not logged in"}</span>
+          </div>
+          <div className="actions">
+            ${busy[p.id]
+              ? html`<span style=${{ fontSize: "12px", color: "#f59e0b" }}>${busy[p.id]}</span>`
+              : html`
+                <button className="btn primary" onClick=${() => startLogin(p.isBuiltin ? p.id : p.baseProvider)}>${p.authenticated ? "Re-login" : "Login"}</button>
+                ${p.authenticated ? html`<button className="btn danger" onClick=${() => logout(p.id)}>Logout</button>` : null}
+              `}
+          </div>
+        </div>
+      </div>
+    `)}
+    ${providers.length === 0 ? html`<div className="empty">Loading providers...</div>` : null}
+  </div>`;
 }
 
 // ── Subscriptions ──
@@ -92,32 +224,32 @@ function SubEditor({ subs, onSave }) {
   const [draft, setDraft] = useState({});
 
   function startEdit(s) { setEditing(s.name); setDraft({ ...s }); }
-  function startNew() { setEditing("__new__"); setDraft({ name: "", provider: PROVIDERS[0], enabled: true, alias: "" }); }
+  function startNew() { setEditing("__new__"); setDraft({ name: "", provider: BASE_PROVIDERS[0], enabled: true, alias: "" }); }
   function cancel() { setEditing(null); }
   async function save() {
-    if (editing === "__new__") {
-      await api("/v1/config/subscriptions", jpost(draft));
-    } else {
-      await api(`/v1/config/subscriptions/${encodeURIComponent(editing)}`, jput(draft));
-    }
-    setEditing(null);
-    onSave();
+    if (editing === "__new__") { await api("/v1/config/subscriptions", jpost(draft)); }
+    else { await api(`/v1/config/subscriptions/${encodeURIComponent(editing)}`, jput(draft)); }
+    setEditing(null); onSave();
   }
   async function del(name) { if (confirm(`Delete subscription "${name}"?`)) { await api(`/v1/config/subscriptions/${encodeURIComponent(name)}`, { method: "DELETE" }); onSave(); } }
 
-  return html`<div>
-    <div className="card-row" style=${{ marginBottom: "10px" }}><h2 style=${{ margin: 0 }}>Subscriptions</h2><button className="btn primary" onClick=${startNew}>+ Add</button></div>
-    ${subs.map((s) => editing === s.name ? html`
-      <div className="card" key=${s.name}>
+  function renderForm(isNew) {
+    return html`
+      <div className="card">
         <div className="form-grid">
-          <div><label>Name</label><input value=${draft.name} onInput=${(e) => setDraft({ ...draft, name: e.target.value })} /></div>
-          <div><label>Provider</label><select value=${draft.provider} onChange=${(e) => setDraft({ ...draft, provider: e.target.value })}>${PROVIDERS.map((p) => html`<option key=${p} value=${p}>${p}</option>`)}</select></div>
+          <div><label>Name</label><input value=${draft.name} onInput=${(e) => setDraft({ ...draft, name: e.target.value })} placeholder="e.g. openai-codex-2" /></div>
+          <div><label>Base provider</label><select value=${draft.provider} onChange=${(e) => setDraft({ ...draft, provider: e.target.value })}>${BASE_PROVIDERS.map((p) => html`<option key=${p} value=${p}>${p}</option>`)}</select></div>
           <div><label>Alias</label><input value=${draft.alias || ""} onInput=${(e) => setDraft({ ...draft, alias: e.target.value })} /></div>
           <div><label>Enabled</label><select value=${String(draft.enabled)} onChange=${(e) => setDraft({ ...draft, enabled: e.target.value === "true" })}><option value="true">Yes</option><option value="false">No</option></select></div>
         </div>
-        <div className="actions" style=${{ marginTop: "10px" }}><button className="btn primary" onClick=${save}>Save</button><button className="btn" onClick=${cancel}>Cancel</button></div>
+        <div className="actions" style=${{ marginTop: "10px" }}><button className="btn primary" onClick=${save}>${isNew ? "Create" : "Save"}</button><button className="btn" onClick=${cancel}>Cancel</button></div>
       </div>
-    ` : html`
+    `;
+  }
+
+  return html`<div>
+    <div className="card-row" style=${{ marginBottom: "10px" }}><h2 style=${{ margin: 0 }}>Subscriptions</h2><button className="btn primary" onClick=${startNew}>+ Add</button></div>
+    ${subs.map((s) => editing === s.name ? renderForm(false) : html`
       <div className="card" key=${s.name}>
         <div className="card-row">
           <div><span className="name">${s.name}</span><span className="badge neutral">${s.provider}</span><span className=${`badge ${s.enabled !== false ? "on" : "off"}`}>${s.enabled !== false ? "on" : "off"}</span>${s.alias ? html`<span className="badge neutral">${s.alias}</span>` : null}</div>
@@ -125,28 +257,19 @@ function SubEditor({ subs, onSave }) {
         </div>
       </div>
     `)}
-    ${editing === "__new__" ? html`
-      <div className="card">
-        <div className="form-grid">
-          <div><label>Name</label><input value=${draft.name} onInput=${(e) => setDraft({ ...draft, name: e.target.value })} placeholder="e.g. openai-codex-2" /></div>
-          <div><label>Provider</label><select value=${draft.provider} onChange=${(e) => setDraft({ ...draft, provider: e.target.value })}>${PROVIDERS.map((p) => html`<option key=${p} value=${p}>${p}</option>`)}</select></div>
-          <div><label>Alias</label><input value=${draft.alias} onInput=${(e) => setDraft({ ...draft, alias: e.target.value })} /></div>
-          <div><label>Enabled</label><select value=${String(draft.enabled)} onChange=${(e) => setDraft({ ...draft, enabled: e.target.value === "true" })}><option value="true">Yes</option><option value="false">No</option></select></div>
-        </div>
-        <div className="actions" style=${{ marginTop: "10px" }}><button className="btn primary" onClick=${save}>Create</button><button className="btn" onClick=${cancel}>Cancel</button></div>
-      </div>
-    ` : null}
+    ${editing === "__new__" ? renderForm(true) : null}
   </div>`;
 }
 
 // ── Pools ──
 
-function PoolEditor({ pools, onSave }) {
+function PoolEditor({ pools, names, onSave }) {
   const [editing, setEditing] = useState(null);
   const [draft, setDraft] = useState({});
+  const providerNames = (names?.providers || []).map((p) => p.id);
 
   function startEdit(p) { setEditing(p.name); setDraft({ ...p, members: [...(p.members || [])] }); }
-  function startNew() { setEditing("__new__"); setDraft({ name: "", enabled: true, baseProvider: PROVIDERS[0], members: [], strategy: "round-robin" }); }
+  function startNew() { setEditing("__new__"); setDraft({ name: "", enabled: true, baseProvider: BASE_PROVIDERS[0], members: [], strategy: "round-robin" }); }
   function cancel() { setEditing(null); }
   async function save() {
     if (editing === "__new__") { await api("/v1/config/pools", jpost(draft)); }
@@ -155,15 +278,32 @@ function PoolEditor({ pools, onSave }) {
   }
   async function del(name) { if (confirm(`Delete pool "${name}"?`)) { await api(`/v1/config/pools/${encodeURIComponent(name)}`, { method: "DELETE" }); onSave(); } }
 
+  function addMember(val) { if (val && !draft.members.includes(val)) setDraft({ ...draft, members: [...draft.members, val] }); }
+  function removeMember(i) { setDraft({ ...draft, members: draft.members.filter((_, idx) => idx !== i) }); }
+
   function renderForm(isNew) {
+    // Filter providers to those matching the base provider
+    const eligible = providerNames.filter((n) => n === draft.baseProvider || n.startsWith(draft.baseProvider + "-"));
     return html`
       <div className="card">
         <div className="form-grid">
           <div><label>Name</label><input value=${draft.name} onInput=${(e) => setDraft({ ...draft, name: e.target.value })} placeholder="e.g. codex-pool" /></div>
-          <div><label>Base Provider</label><select value=${draft.baseProvider} onChange=${(e) => setDraft({ ...draft, baseProvider: e.target.value })}>${PROVIDERS.map((p) => html`<option key=${p} value=${p}>${p}</option>`)}</select></div>
+          <div><label>Base provider</label><select value=${draft.baseProvider} onChange=${(e) => setDraft({ ...draft, baseProvider: e.target.value })}>${BASE_PROVIDERS.map((p) => html`<option key=${p} value=${p}>${p}</option>`)}</select></div>
           <div><label>Strategy</label><select value=${draft.strategy} onChange=${(e) => setDraft({ ...draft, strategy: e.target.value })}>${STRATEGIES.map((s) => html`<option key=${s} value=${s}>${s}</option>`)}</select></div>
           <div><label>Enabled</label><select value=${String(draft.enabled)} onChange=${(e) => setDraft({ ...draft, enabled: e.target.value === "true" })}><option value="true">Yes</option><option value="false">No</option></select></div>
-          <div className="full"><label>Members</label><${TagList} items=${draft.members} onChange=${(m) => setDraft({ ...draft, members: m })} placeholder="Add member name..." /></div>
+          <div className="full">
+            <label>Members</label>
+            <div style=${{ display: "flex", flexWrap: "wrap", gap: "4px", marginBottom: "6px" }}>
+              ${draft.members.map((m, i) => html`<span key=${i} className="badge on" style=${{ cursor: "pointer" }} onClick=${() => removeMember(i)}>${m} x</span>`)}
+              ${draft.members.length === 0 ? html`<span style=${{ color: "#52525b", fontSize: "12px" }}>No members yet</span>` : null}
+            </div>
+            <div style=${{ display: "flex", gap: "6px" }}>
+              <select onChange=${(e) => { addMember(e.target.value); e.target.value = ""; }} style=${{ flex: 1 }}>
+                <option value="">+ Add member...</option>
+                ${eligible.filter((n) => !draft.members.includes(n)).map((n) => html`<option key=${n} value=${n}>${n}</option>`)}
+              </select>
+            </div>
+          </div>
           ${draft.strategy === "scheduled" ? html`<div className="full"><label>Schedule (JSON)</label><textarea value=${JSON.stringify(draft.memberSchedule || {}, null, 2)} onInput=${(e) => { try { setDraft({ ...draft, memberSchedule: JSON.parse(e.target.value) }); } catch {} }} rows="4" /></div>` : null}
           ${draft.strategy === "custom" ? html`<div className="full"><label>Selector Script Path</label><input value=${draft.selectorScript || ""} onInput=${(e) => setDraft({ ...draft, selectorScript: e.target.value })} placeholder="./my-selector.js" /></div>` : null}
         </div>
@@ -189,7 +329,7 @@ function PoolEditor({ pools, onSave }) {
 
 // ── Chains ──
 
-function ChainEditor({ chains, onSave }) {
+function ChainEditor({ chains, names, onSave }) {
   const [editing, setEditing] = useState(null);
   const [draft, setDraft] = useState({});
 
@@ -203,11 +343,7 @@ function ChainEditor({ chains, onSave }) {
   }
   async function del(name) { if (confirm(`Delete chain "${name}"?`)) { await api(`/v1/config/chains/${encodeURIComponent(name)}`, { method: "DELETE" }); onSave(); } }
 
-  function updateStep(i, field, value) {
-    const steps = [...draft.steps];
-    steps[i] = { ...steps[i], [field]: value };
-    setDraft({ ...draft, steps });
-  }
+  function updateStep(i, field, value) { const steps = [...draft.steps]; steps[i] = { ...steps[i], [field]: value }; setDraft({ ...draft, steps }); }
   function addStep() { setDraft({ ...draft, steps: [...draft.steps, { provider: "", model: "", enabled: true }] }); }
   function removeStep(i) { setDraft({ ...draft, steps: draft.steps.filter((_, idx) => idx !== i) }); }
 
@@ -219,11 +355,11 @@ function ChainEditor({ chains, onSave }) {
           <div><label>Enabled</label><select value=${String(draft.enabled)} onChange=${(e) => setDraft({ ...draft, enabled: e.target.value === "true" })}><option value="true">Yes</option><option value="false">No</option></select></div>
         </div>
         <div style=${{ marginTop: "10px" }}>
-          <label>Steps (in order)</label>
+          <label>Steps (failover order)</label>
           ${draft.steps.map((s, i) => html`
             <div key=${i} style=${{ display: "flex", gap: "6px", marginBottom: "6px", alignItems: "center" }}>
               <span style=${{ color: "#52525b", fontSize: "11px", width: "20px" }}>${i + 1}.</span>
-              <input value=${s.provider || ""} onInput=${(e) => updateStep(i, "provider", e.target.value)} placeholder="provider or pool:name" style=${{ flex: 1 }} />
+              <${ProviderSelect} value=${s.provider} onChange=${(v) => updateStep(i, "provider", v)} names=${names} allowPools=${true} placeholder="provider or pool" />
               <input value=${s.model || ""} onInput=${(e) => updateStep(i, "model", e.target.value)} placeholder="model (optional)" style=${{ flex: 1 }} />
               <button className="btn danger" onClick=${() => removeStep(i)} style=${{ padding: "4px 8px" }}>x</button>
             </div>
@@ -252,7 +388,7 @@ function ChainEditor({ chains, onSave }) {
 
 // ── Presets ──
 
-function PresetEditor({ presets, onSave }) {
+function PresetEditor({ presets, names, onSave }) {
   const [editing, setEditing] = useState(null);
   const [draft, setDraft] = useState({});
 
@@ -266,11 +402,7 @@ function PresetEditor({ presets, onSave }) {
   }
   async function del(name) { if (confirm(`Delete preset "${name}"?`)) { await api(`/v1/config/presets/${encodeURIComponent(name)}`, { method: "DELETE" }); onSave(); } }
 
-  function updateEntry(i, field, value) {
-    const entries = [...draft.entries];
-    entries[i] = { ...entries[i], [field]: field === "enabled" ? value === "true" : value };
-    setDraft({ ...draft, entries });
-  }
+  function updateEntry(i, field, value) { const entries = [...draft.entries]; entries[i] = { ...entries[i], [field]: field === "enabled" ? value === "true" : value }; setDraft({ ...draft, entries }); }
   function addEntry() { setDraft({ ...draft, entries: [...draft.entries, { provider: "", model: "", enabled: true }] }); }
   function removeEntry(i) { setDraft({ ...draft, entries: draft.entries.filter((_, idx) => idx !== i) }); }
 
@@ -286,7 +418,7 @@ function PresetEditor({ presets, onSave }) {
           ${draft.entries.map((e, i) => html`
             <div key=${i} style=${{ display: "flex", gap: "6px", marginBottom: "6px", alignItems: "center" }}>
               <span style=${{ color: "#52525b", fontSize: "11px", width: "20px" }}>${i + 1}.</span>
-              <input value=${e.provider || ""} onInput=${(ev) => updateEntry(i, "provider", ev.target.value)} placeholder="provider or pool:name" style=${{ flex: 1 }} />
+              <${ProviderSelect} value=${e.provider} onChange=${(v) => updateEntry(i, "provider", v)} names=${names} allowPools=${true} allowChains=${true} placeholder="provider, pool, or chain" />
               <input value=${e.model || ""} onInput=${(ev) => updateEntry(i, "model", ev.target.value)} placeholder="model" style=${{ flex: 1 }} />
               <select value=${String(e.enabled !== false)} onChange=${(ev) => updateEntry(i, "enabled", ev.target.value)} style=${{ width: "70px" }}><option value="true">On</option><option value="false">Off</option></select>
               <button className="btn danger" onClick=${() => removeEntry(i)} style=${{ padding: "4px 8px" }}>x</button>
@@ -314,111 +446,32 @@ function PresetEditor({ presets, onSave }) {
   </div>`;
 }
 
-// ── Auth / OAuth ──
-
-function AuthPanel({ onRefresh }) {
-  const [providers, setProviders] = useState([]);
-  const [busy, setBusy] = useState({});
-  const [polling, setPolling] = useState({});
-
-  async function loadProviders() {
-    try { const d = await api("/v1/auth/providers"); setProviders(d.providers || []); } catch {}
-  }
-  useEffect(() => { loadProviders(); }, []);
-
-  async function startLogin(providerId) {
-    setBusy((b) => ({ ...b, [providerId]: "connecting..." }));
-    try {
-      const res = await api(`/v1/auth/login/${encodeURIComponent(providerId)}`, { method: "POST" });
-      if (res.authUrl) {
-        window.open(res.authUrl, "_blank");
-        setBusy((b) => ({ ...b, [providerId]: "waiting for browser..." }));
-        // Poll for completion
-        setPolling((p) => ({ ...p, [providerId]: true }));
-        pollLogin(providerId);
-      }
-    } catch (e) {
-      setBusy((b) => ({ ...b, [providerId]: `error: ${e.message}` }));
-      setTimeout(() => setBusy((b) => { const n = { ...b }; delete n[providerId]; return n; }), 3000);
-    }
-  }
-
-  async function pollLogin(providerId) {
-    for (let i = 0; i < 120; i++) {
-      await new Promise((r) => setTimeout(r, 2000));
-      try {
-        const s = await api(`/v1/auth/login/${encodeURIComponent(providerId)}`);
-        if (s.status === "authenticated" || s.hasAuth) {
-          setBusy((b) => { const n = { ...b }; delete n[providerId]; return n; });
-          setPolling((p) => { const n = { ...p }; delete n[providerId]; return n; });
-          await loadProviders();
-          if (onRefresh) onRefresh();
-          return;
-        }
-      } catch {}
-    }
-    setBusy((b) => ({ ...b, [providerId]: "timed out" }));
-    setPolling((p) => { const n = { ...p }; delete n[providerId]; return n; });
-  }
-
-  async function logout(providerId) {
-    if (!confirm(`Logout from ${providerId}?`)) return;
-    try {
-      await api(`/v1/auth/logout/${encodeURIComponent(providerId)}`, { method: "POST" });
-      await loadProviders();
-      if (onRefresh) onRefresh();
-    } catch {}
-  }
-
-  return html`<div>
-    <h2>OAuth accounts</h2>
-    <div style=${{ marginBottom: "10px", fontSize: "11px", color: "#52525b" }}>Login to providers to enable routing. OAuth tokens stored in ~/.pi/agent/auth.json</div>
-    ${providers.map((p) => html`
-      <div className="card" key=${p.id}>
-        <div className="card-row">
-          <div>
-            <span className="name">${p.name}</span>
-            <span className="badge neutral" style=${{ fontFamily: "monospace" }}>${p.id}</span>
-            <span className=${`badge ${p.authenticated ? "on" : "off"}`}>${p.authenticated ? "logged in" : "not logged in"}</span>
-          </div>
-          <div className="actions">
-            ${busy[p.id]
-              ? html`<span style=${{ fontSize: "12px", color: "#f59e0b" }}>${busy[p.id]}</span>`
-              : html`
-                ${!p.authenticated ? html`<button className="btn primary" onClick=${() => startLogin(p.id)}>Login</button>` : null}
-                ${p.authenticated ? html`<button className="btn danger" onClick=${() => logout(p.id)}>Logout</button>` : null}
-              `}
-          </div>
-        </div>
-      </div>
-    `)}
-    ${providers.length === 0 ? html`<div className="empty">Loading providers...</div>` : null}
-  </div>`;
-}
+// ── ConfigPanel (combines all) ──
 
 function ConfigPanel({ onRefresh }) {
   const [config, setConfig] = useState(null);
   const [err, setErr] = useState("");
+  const { names, reloadNames } = useNames();
 
   async function load() { setErr(""); try { setConfig(await api("/v1/config")); } catch (e) { setErr(e.message); } }
   useEffect(() => { load(); }, []);
 
-  async function refresh() { await load(); if (onRefresh) onRefresh(); }
+  async function refresh() { await load(); reloadNames(); if (onRefresh) onRefresh(); }
 
   if (!config) return html`<div className="empty">${err || "Loading..."}</div>`;
 
   return html`<div>
     ${err ? html`<div className="card" style=${{ color: "#ef4444", borderColor: "#7f1d1d" }}>Error: ${err}</div>` : null}
-    <${AuthPanel} onRefresh=${refresh} />
+    <${AuthPanel} onRefresh=${refresh} reloadNames=${reloadNames} />
     <div style=${{ marginTop: "24px" }} />
     <div style=${{ marginBottom: "6px", fontSize: "11px", color: "#52525b" }}>Editing: ~/.pi/agent/multi-pass.json</div>
     <${SubEditor} subs=${config.subscriptions || []} onSave=${refresh} />
     <div style=${{ marginTop: "20px" }} />
-    <${PoolEditor} pools=${config.pools || []} onSave=${refresh} />
+    <${PoolEditor} pools=${config.pools || []} names=${names} onSave=${refresh} />
     <div style=${{ marginTop: "20px" }} />
-    <${ChainEditor} chains=${config.chains || []} onSave=${refresh} />
+    <${ChainEditor} chains=${config.chains || []} names=${names} onSave=${refresh} />
     <div style=${{ marginTop: "20px" }} />
-    <${PresetEditor} presets=${config.presets || []} onSave=${refresh} />
+    <${PresetEditor} presets=${config.presets || []} names=${names} onSave=${refresh} />
   </div>`;
 }
 
@@ -485,12 +538,7 @@ function RulesPanel({ rules, onRefresh }) {
           <div className="actions"><button className="btn" disabled=${busy} onClick=${() => toggle(r, !r.enabled)}>${r.enabled ? "Disable" : "Enable"}</button><button className="btn danger" disabled=${busy} onClick=${() => del(r)}>Delete</button></div>
         </div>
         <div className="meta">
-          ${r.patterns?.length ? `patterns: ${r.patterns.join(", ")}` : ""}
-          ${r.allow?.length ? ` | allow: ${r.allow.join(", ")}` : ""}
-          ${r.deny?.length ? ` | deny: ${r.deny.join(", ")}` : ""}
-          ${r.maxRequests ? ` | ${r.maxRequests} req/${r.windowSeconds}s` : ""}
-          ${r.replacement ? ` | replace: ${r.replacement}` : ""}
-          ${r.message ? ` | msg: ${r.message}` : ""}
+          ${r.patterns?.length ? `patterns: ${r.patterns.join(", ")}` : ""}${r.allow?.length ? ` | allow: ${r.allow.join(", ")}` : ""}${r.deny?.length ? ` | deny: ${r.deny.join(", ")}` : ""}${r.maxRequests ? ` | ${r.maxRequests} req/${r.windowSeconds}s` : ""}${r.replacement ? ` | replace: ${r.replacement}` : ""}${r.message ? ` | msg: ${r.message}` : ""}
         </div>
       </div>
     `)}
@@ -518,12 +566,7 @@ function AuditPanel({ entries, onRefresh }) {
       <div className="table-wrap"><table>
         <thead><tr><th>Time</th><th>Rule</th><th>Type</th><th>Action</th><th>Source</th><th>Matched</th><th>Before</th><th>After</th></tr></thead>
         <tbody>${filtered.map((e, i) => html`
-          <tr key=${i}>
-            <td>${ago(e.timestamp)}</td><td style=${{ fontWeight: 600 }}>${e.rule}</td><td><span className=${`badge ${e.type}`}>${e.type}</span></td><td>${e.action}</td><td>${e.source || "--"}</td>
-            <td style=${{ color: "#ef4444", fontFamily: "monospace", fontSize: "11px" }}>${e.matched_text || "--"}</td>
-            <td>${e.full_message ? html`<details><summary>view</summary><pre>${e.full_message}</pre></details>` : "--"}</td>
-            <td>${e.redacted_message ? html`<details><summary>view</summary><pre>${e.redacted_message}</pre></details>` : "--"}</td>
-          </tr>
+          <tr key=${i}><td>${ago(e.timestamp)}</td><td style=${{ fontWeight: 600 }}>${e.rule}</td><td><span className=${`badge ${e.type}`}>${e.type}</span></td><td>${e.action}</td><td>${e.source || "--"}</td><td style=${{ color: "#ef4444", fontFamily: "monospace", fontSize: "11px" }}>${e.matched_text || "--"}</td><td>${e.full_message ? html`<details><summary>view</summary><pre>${e.full_message}</pre></details>` : "--"}</td><td>${e.redacted_message ? html`<details><summary>view</summary><pre>${e.redacted_message}</pre></details>` : "--"}</td></tr>
         `)}</tbody>
       </table></div>
     `}

--- a/web/admin/app.js
+++ b/web/admin/app.js
@@ -1092,6 +1092,303 @@ function ModeEditor({ modes, rules, names, onSave, readOnly }) {
   </div>`;
 }
 
+// ── Simulator ──
+
+function SimulatePanel({ config }) {
+  const [target, setTarget] = useState("");
+  const [date, setDate] = useState(() => {
+    const d = new Date();
+    d.setMinutes(d.getMinutes() - d.getTimezoneOffset());
+    return d.toISOString().slice(0, 16);
+  });
+  const [prompt, setPrompt] = useState("");
+  const [trace, setTrace] = useState(null);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState("");
+
+  const targets = [
+    ...(config.presets || []).filter((p) => p.mode).map((p) => ({ value: p.id || p.name, label: `preset: ${p.id || p.name}` })),
+    ...(config.modes || []).map((m) => ({ value: m.id, label: `mode: ${m.id}` })),
+  ];
+
+  async function simulate() {
+    if (!target) { setErr("Pick a preset or mode first"); return; }
+    setBusy(true); setErr(""); setTrace(null);
+    try {
+      const t = await api("/v1/routing/simulate", jpost({
+        model: target,
+        now: new Date(date).toISOString(),
+        prompt: prompt || undefined,
+      }));
+      setTrace(t);
+    } catch (e) { setErr(e.message); }
+    setBusy(false);
+  }
+
+  function quickTime(spec) {
+    const d = new Date();
+    if (spec === "morning") { d.setHours(9, 0, 0, 0); }
+    else if (spec === "evening") { d.setHours(20, 0, 0, 0); }
+    else if (spec === "midnight") { d.setHours(0, 30, 0, 0); }
+    else if (spec === "weekend") {
+      const daysToSat = (6 - d.getDay() + 7) % 7 || 7;
+      d.setDate(d.getDate() + daysToSat);
+      d.setHours(14, 0, 0, 0);
+    }
+    d.setMinutes(d.getMinutes() - d.getTimezoneOffset());
+    setDate(d.toISOString().slice(0, 16));
+  }
+
+  return html`<div>
+    <h2>Simulator</h2>
+    <div style=${{ marginBottom: "10px", fontSize: "11px", color: "#52525b" }}>Dry-run the routing pipeline without calling the LLM. Pick a preset or mode, set the time, and see exactly which rules fire and which candidate wins.</div>
+
+    <div className="card" style=${{ marginBottom: "16px" }}>
+      <div className="form-grid">
+        <div className="full"><label>Target (preset or mode)</label>
+          <select value=${target} onChange=${(e) => setTarget(e.target.value)}>
+            <option value="">-- pick one --</option>
+            ${targets.map((t) => html`<option key=${t.value} value=${t.value}>${t.label}</option>`)}
+          </select>
+        </div>
+        <div className="full"><label>Simulated time</label>
+          <input type="datetime-local" value=${date} onInput=${(e) => setDate(e.target.value)} />
+          <div style=${{ display: "flex", gap: "4px", marginTop: "6px", flexWrap: "wrap" }}>
+            <button className="btn" onClick=${() => quickTime("now")} style=${{ fontSize: "10px", padding: "3px 8px" }}>now</button>
+            <button className="btn" onClick=${() => quickTime("morning")} style=${{ fontSize: "10px", padding: "3px 8px" }}>9am today</button>
+            <button className="btn" onClick=${() => quickTime("evening")} style=${{ fontSize: "10px", padding: "3px 8px" }}>8pm today</button>
+            <button className="btn" onClick=${() => quickTime("midnight")} style=${{ fontSize: "10px", padding: "3px 8px" }}>00:30 today</button>
+            <button className="btn" onClick=${() => quickTime("weekend")} style=${{ fontSize: "10px", padding: "3px 8px" }}>weekend 2pm</button>
+          </div>
+        </div>
+        <div className="full"><label>Sample prompt (optional)</label>
+          <textarea value=${prompt} onInput=${(e) => setPrompt(e.target.value)} placeholder="Some custom rules look at prompt content" rows="2" />
+        </div>
+      </div>
+      <div className="actions" style=${{ marginTop: "12px" }}><button className="btn primary" onClick=${simulate} disabled=${busy || !target}>${busy ? "Simulating..." : "Simulate"}</button></div>
+    </div>
+
+    ${err ? html`<div className="card" style=${{ color: "#ef4444", borderColor: "#7f1d1d" }}>${err}</div>` : null}
+    ${trace ? html`<${TraceView} trace=${trace} />` : null}
+  </div>`;
+}
+
+function TraceView({ trace }) {
+  return html`
+    <div className="card">
+      <h2 style=${{ marginBottom: "10px" }}>Pipeline trace</h2>
+
+      <div style=${{ marginBottom: "12px" }}>
+        <div className="meta" style=${{ marginBottom: "4px" }}>Input</div>
+        <div style=${{ fontFamily: "monospace", fontSize: "12px", color: "#a1a1aa", padding: "8px 12px", background: "#0d0d0f", borderRadius: "6px", border: "1px solid #27272a" }}>
+          model: ${trace.input.model} | now: ${trace.input.now}${trace.input.prompt ? " | prompt: " + trace.input.prompt.slice(0, 60) : ""}
+        </div>
+      </div>
+
+      ${trace.errors?.length ? html`
+        <div className="card" style=${{ color: "#ef4444", borderColor: "#7f1d1d", background: "#1c0a0a", marginBottom: "12px" }}>
+          ${trace.errors.map((e, i) => html`<div key=${i}>${e}</div>`)}
+        </div>
+      ` : null}
+
+      ${trace.resolution ? html`
+        <div style=${{ marginBottom: "16px" }}>
+          <div className="meta" style=${{ marginBottom: "4px" }}>1. Resolution</div>
+          <div className="card" style=${{ marginBottom: 0, padding: "10px 12px" }}>
+            ${trace.resolution.preset ? html`<span className="badge info">preset: ${trace.resolution.preset}</span>` : null}
+            <span className="badge neutral">mode: ${trace.resolution.mode}</span>
+            ${trace.resolution.modeDescription ? html`<div className="meta">${trace.resolution.modeDescription}</div>` : null}
+          </div>
+        </div>
+      ` : null}
+
+      ${trace.expansion ? html`
+        <div style=${{ marginBottom: "16px" }}>
+          <div className="meta" style=${{ marginBottom: "4px" }}>2. Candidate expansion (${trace.expansion.total})</div>
+          <div className="card" style=${{ marginBottom: 0, padding: "10px 12px" }}>
+            ${trace.expansion.candidates.map((c) => html`
+              <span key=${c.id} className="badge neutral" style=${{ marginRight: "4px", marginBottom: "4px", display: "inline-block" }}>
+                ${c.id}${c.kind ? " (" + c.kind + ")" : ""}${c.poolId ? " from " + c.poolId : ""}
+              </span>
+            `)}
+          </div>
+        </div>
+      ` : null}
+
+      ${trace.filtered ? html`
+        <div style=${{ marginBottom: "16px" }}>
+          <div className="meta" style=${{ marginBottom: "4px" }}>3. Cooldown filter (${trace.filtered.before} -> ${trace.filtered.after})</div>
+          ${trace.filtered.exhausted.length > 0 ? html`
+            <div className="card" style=${{ marginBottom: 0, padding: "10px 12px" }}>
+              <span style=${{ fontSize: "12px", color: "#52525b", marginRight: "6px" }}>removed:</span>
+              ${trace.filtered.exhausted.map((id) => html`<span key=${id} className="badge off" style=${{ marginRight: "4px" }}>${id}</span>`)}
+            </div>
+          ` : html`<div style=${{ fontSize: "11px", color: "#52525b", padding: "4px 0" }}>nothing filtered</div>`}
+        </div>
+      ` : null}
+
+      ${trace.ruleSteps?.length ? html`
+        <div style=${{ marginBottom: "16px" }}>
+          <div className="meta" style=${{ marginBottom: "4px" }}>4. Rule pipeline (${trace.ruleSteps.length} rules)</div>
+          ${trace.ruleSteps.map((step, i) => html`
+            <div key=${i} className="card" style=${{ marginBottom: "6px", padding: "10px 12px" }}>
+              <div>
+                <span className="name">${step.rule}</span>
+                <span className="badge neutral">${step.type}</span>
+                ${step.error ? html`<span className="badge off">${step.error}</span>` : null}
+              </div>
+              ${step.description ? html`<div className="meta">${step.description}</div>` : null}
+              ${step.removed?.length ? html`<div className="meta">removed: ${step.removed.map((id) => html`<span className="badge off" style=${{ marginRight: "3px" }}>${id}</span>`)}</div>` : null}
+              ${Object.keys(step.scoresAdded || {}).length > 0 ? html`
+                <div className="meta">scores: ${Object.entries(step.scoresAdded).map(([id, s]) => html`<span style=${{ marginRight: "8px" }}><code style=${{ color: s > 0 ? "#22c55e" : "#ef4444" }}>${id}: ${s > 0 ? "+" : ""}${s}</code></span>`)}</div>
+              ` : null}
+            </div>
+          `)}
+        </div>
+      ` : null}
+
+      ${trace.finalOrder?.length ? html`
+        <div style=${{ marginBottom: "16px" }}>
+          <div className="meta" style=${{ marginBottom: "4px" }}>5. Final order (sorted by score)</div>
+          <div className="table-wrap"><table>
+            <thead><tr><th>#</th><th>Candidate</th><th>Kind</th><th>Pool</th><th>Score</th></tr></thead>
+            <tbody>
+              ${trace.finalOrder.map((c, i) => html`
+                <tr key=${c.id} style=${i === 0 ? { background: "#052e16" } : {}}>
+                  <td>${i + 1}${i === 0 ? " WINNER" : ""}</td>
+                  <td style=${{ fontWeight: i === 0 ? 700 : 400, color: i === 0 ? "#22c55e" : "#a1a1aa" }}>${c.id}</td>
+                  <td>${c.kind || "--"}</td>
+                  <td>${c.poolId || "--"}</td>
+                  <td><strong>${c.score}</strong></td>
+                </tr>
+              `)}
+            </tbody>
+          </table></div>
+        </div>
+      ` : null}
+
+      ${trace.modelChoice ? html`
+        <div style=${{ marginBottom: "8px" }}>
+          <div className="meta" style=${{ marginBottom: "4px" }}>6. Model selection</div>
+          <div className="card" style=${{ marginBottom: 0, padding: "10px 12px" }}>
+            <div>
+              <span className="name">${trace.picked.provider}</span>
+              ${trace.modelChoice.picked ? html`<span className="badge on">picked: ${trace.modelChoice.picked}</span>` : html`<span className="badge off">no model picked</span>`}
+            </div>
+            ${trace.modelChoice.tries.length > 0 ? html`
+              <div className="meta">tries: ${trace.modelChoice.tries.map((t) => html`<span className=${`badge ${t.ok ? "on" : "off"}`} style=${{ marginRight: "4px" }}>${t.model}${t.ok ? " ok" : " skip"}</span>`)}</div>
+            ` : null}
+          </div>
+        </div>
+      ` : null}
+    </div>
+  `;
+}
+
+// ── AI config editor ──
+
+function AiEditPanel({ config, onApplied }) {
+  const [open, setOpen] = useState(false);
+  const [instruction, setInstruction] = useState("");
+  const [model, setModel] = useState("coding-premium");
+  const [busy, setBusy] = useState(false);
+  const [result, setResult] = useState(null);
+  const [err, setErr] = useState("");
+
+  const targets = [
+    ...(config.presets || []).map((p) => p.id || p.name),
+    ...(config.modes || []).map((m) => m.id),
+  ];
+
+  async function generate() {
+    if (!instruction.trim()) return;
+    setBusy(true); setErr(""); setResult(null);
+    try {
+      const r = await api("/v1/config/ai-edit", jpost({ instruction, model }));
+      setResult(r);
+    } catch (e) { setErr(e.message); }
+    setBusy(false);
+  }
+
+  async function apply() {
+    if (!result?.proposed) return;
+    if (!confirm("Apply the proposed config? A backup of the current config will be created.")) return;
+    setBusy(true);
+    try {
+      await api("/v1/config/ai-apply", jpost({ config: result.proposed }));
+      setResult(null);
+      setInstruction("");
+      setOpen(false);
+      if (onApplied) onApplied();
+    } catch (e) { setErr(e.message); }
+    setBusy(false);
+  }
+
+  if (!open) {
+    return html`
+      <div style=${{ marginBottom: "16px" }}>
+        <button className="btn primary" onClick=${() => setOpen(true)} style=${{ fontSize: "13px" }}>
+          Ask AI to edit config
+        </button>
+      </div>
+    `;
+  }
+
+  return html`
+    <div className="card" style=${{ marginBottom: "16px", borderColor: "#3b1f6e" }}>
+      <div className="card-row" style=${{ marginBottom: "10px" }}>
+        <h2 style=${{ margin: 0, color: "#a78bfa" }}>Ask AI to edit config</h2>
+        <button className="btn" onClick=${() => { setOpen(false); setResult(null); setErr(""); }}>Close</button>
+      </div>
+      <div style=${{ marginBottom: "10px", fontSize: "11px", color: "#52525b" }}>Describe what you want to change. The AI sees your current config (with secrets redacted) and proposes a complete updated config plus an explanation. You review and apply.</div>
+
+      <div className="form-grid">
+        <div className="full">
+          <label>Your request</label>
+          <textarea value=${instruction} onInput=${(e) => setInstruction(e.target.value)} placeholder="e.g. Add a routing rule that prefers Anthropic on Friday evenings, and add it to coding-premium mode" rows="4" />
+        </div>
+        <div>
+          <label>Use this preset/model to think</label>
+          <select value=${model} onChange=${(e) => setModel(e.target.value)}>
+            ${targets.map((t) => html`<option key=${t} value=${t}>${t}</option>`)}
+          </select>
+        </div>
+      </div>
+      <div className="actions" style=${{ marginTop: "12px" }}>
+        <button className="btn primary" onClick=${generate} disabled=${busy || !instruction.trim()}>${busy ? "Thinking..." : "Generate"}</button>
+      </div>
+
+      ${err ? html`<div className="card" style=${{ color: "#ef4444", borderColor: "#7f1d1d", marginTop: "12px" }}>${err}</div>` : null}
+
+      ${result ? html`
+        <div style=${{ marginTop: "16px" }}>
+          <div className="meta" style=${{ marginBottom: "6px" }}>
+            generated by ${result.provider_used || "?"} / ${result.model_used || "?"}
+            ${result.usage ? html` | ${result.usage.prompt_tokens} in / ${result.usage.completion_tokens} out` : null}
+          </div>
+
+          ${result.explanation ? html`
+            <div className="card" style=${{ background: "#0d0d0f", marginBottom: "10px" }}>
+              <div className="meta" style=${{ marginBottom: "6px" }}>Explanation</div>
+              <pre style=${{ fontFamily: "inherit", whiteSpace: "pre-wrap", color: "#d4d4d8", background: "transparent", border: "none", padding: 0, fontSize: "13px", lineHeight: "1.5" }}>${result.explanation}</pre>
+            </div>
+          ` : null}
+
+          <details>
+            <summary style=${{ cursor: "pointer", color: "#a1a1aa", fontSize: "12px", marginBottom: "8px" }}>View proposed config (JSON)</summary>
+            <pre>${JSON.stringify(result.proposed, null, 2)}</pre>
+          </details>
+
+          <div className="actions" style=${{ marginTop: "12px" }}>
+            <button className="btn primary" onClick=${apply} disabled=${busy}>Apply to config</button>
+            <button className="btn" onClick=${() => setResult(null)}>Discard</button>
+          </div>
+        </div>
+      ` : null}
+    </div>
+  `;
+}
+
 // ── Routing tab combines rules + modes ──
 
 function RoutingPanel({ onRefresh }) {
@@ -1111,11 +1408,14 @@ function RoutingPanel({ onRefresh }) {
   return html`<div>
     ${err ? html`<div className="card" style=${{ color: "#ef4444", borderColor: "#7f1d1d" }}>Error: ${err}</div>` : null}
     ${readOnly ? html`<div className="card" style=${{ borderColor: "#92400e", background: "#1c1508", marginBottom: "16px" }}><span style=${{ color: "#f59e0b", fontWeight: 600 }}>Read-only:</span> config managed by ${config._source}. Edit the file directly to make changes.</div>` : null}
+    ${!readOnly ? html`<${AiEditPanel} config=${config} onApplied=${refresh} />` : null}
     <${RoutingRuleEditor} rules=${config.routingRules || []} names=${names} onSave=${refresh} readOnly=${readOnly} />
     <div style=${{ marginTop: "24px" }} />
     <${ModeEditor} modes=${config.modes || []} rules=${config.routingRules || []} names=${names} onSave=${refresh} readOnly=${readOnly} />
     <div style=${{ marginTop: "24px" }} />
     <${PresetEditor} presets=${config.presets || []} modes=${config.modes || []} names=${names} onSave=${refresh} readOnly=${readOnly} />
+    <div style=${{ marginTop: "24px" }} />
+    <${SimulatePanel} config=${config} />
   </div>`;
 }
 

--- a/web/admin/app.js
+++ b/web/admin/app.js
@@ -162,12 +162,12 @@ function AuthPanel({ onRefresh, reloadNames }) {
   }
 
   async function addAccount() {
-    const name = newName.trim() || `${newBase}-2`;
-    const subId = `${newBase}-${name}`;
+    const label = newName.trim();
     setBusy((b) => ({ ...b, __new__: "creating..." }));
     try {
-      // 1. Create subscription entry
-      await api("/v1/config/subscriptions", jpost({ name, provider: newBase, enabled: true, alias: name }));
+      // 1. Create subscription entry (backend auto-assigns index)
+      const res = await api("/v1/config/subscriptions", jpost({ provider: newBase, label }));
+      const subId = res.subId; // e.g. "openai-codex-2"
       setShowAdd(false);
       setNewName("");
       if (onRefresh) onRefresh();
@@ -192,7 +192,7 @@ function AuthPanel({ onRefresh, reloadNames }) {
       <div className="card" style=${{ marginBottom: "12px" }}>
         <div className="form-grid">
           <div><label>Base provider</label><select value=${newBase} onChange=${(e) => setNewBase(e.target.value)}>${BASE_PROVIDERS.map((p) => html`<option key=${p} value=${p}>${p}</option>`)}</select></div>
-          <div><label>Account name</label><input value=${newName} onInput=${(e) => setNewName(e.target.value)} placeholder=${`e.g. ${newBase}-2`} /></div>
+          <div><label>Label (optional)</label><input value=${newName} onInput=${(e) => setNewName(e.target.value)} placeholder="e.g. work account, helmut@..." /></div>
         </div>
         <div className="actions" style=${{ marginTop: "10px" }}>
           <button className="btn primary" onClick=${addAccount} disabled=${!!busy.__new__}>${busy.__new__ || "Create & Login"}</button>

--- a/web/admin/app.js
+++ b/web/admin/app.js
@@ -1422,7 +1422,6 @@ function RoutingPanel({ onRefresh }) {
   return html`<div>
     ${err ? html`<div className="card" style=${{ color: "#ef4444", borderColor: "#7f1d1d" }}>Error: ${err}</div>` : null}
     ${readOnly ? html`<div className="card" style=${{ borderColor: "#92400e", background: "#1c1508", marginBottom: "16px" }}><span style=${{ color: "#f59e0b", fontWeight: 600 }}>Read-only:</span> config managed by ${config._source}. Edit the file directly to make changes.</div>` : null}
-    ${!readOnly ? html`<${AiEditPanel} config=${config} onApplied=${refresh} />` : null}
     <${RoutingRuleEditor} rules=${config.routingRules || []} names=${names} onSave=${refresh} readOnly=${readOnly} />
     <div style=${{ marginTop: "24px" }} />
     <${ModeEditor} modes=${config.modes || []} rules=${config.routingRules || []} names=${names} onSave=${refresh} readOnly=${readOnly} />
@@ -1452,6 +1451,7 @@ function ConfigPanel({ onRefresh }) {
   return html`<div>
     ${err ? html`<div className="card" style=${{ color: "#ef4444", borderColor: "#7f1d1d" }}>Error: ${err}</div>` : null}
     ${readOnly ? html`<div className="card" style=${{ borderColor: "#92400e", background: "#1c1508", marginBottom: "16px" }}><span style=${{ color: "#f59e0b", fontWeight: 600 }}>Read-only:</span> config managed by ${config._source}. Edit the JS file directly to make changes.</div>` : null}
+    ${!readOnly ? html`<${AiEditPanel} config=${config} onApplied=${refresh} />` : null}
     <${AuthPanel} onRefresh=${refresh} reloadNames=${reloadNames} />
     <div style=${{ marginTop: "24px" }} />
     <${ApiKeyEditor} apiKeys=${config.apiKeys || []} onSave=${refresh} />

--- a/web/admin/app.js
+++ b/web/admin/app.js
@@ -310,6 +310,111 @@ function AuthPanel({ onRefresh, reloadNames }) {
 const ALL_DAYS = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"];
 const ROLES = [{ value: "", label: "default (always available)" }, { value: "preferred", label: "preferred (active in windows only)" }, { value: "overflow", label: "overflow (last resort)" }];
 
+/**
+ * Global reusable chip picker.
+ * Props:
+ *   items: string[] -- current selection
+ *   onChange(newItems): callback
+ *   available?: string[] -- if provided, dropdown picker; else free-form text input
+ *   placeholder?: string
+ *   emptyText?: string
+ *   chipClass?: string -- "on" (green) | "neutral" (gray)
+ */
+function ChipPicker({ items, onChange, available, placeholder, emptyText, chipClass }) {
+  const [draft, setDraft] = useState("");
+  const remaining = available ? available.filter((a) => !items.includes(a)) : null;
+
+  function add(val) {
+    const v = (val ?? draft).trim();
+    if (v && !items.includes(v)) onChange([...items, v]);
+    setDraft("");
+  }
+  function remove(i) { onChange(items.filter((_, idx) => idx !== i)); }
+
+  return html`
+    <div>
+      <div style=${{ display: "flex", flexWrap: "wrap", gap: "4px", marginBottom: "6px", minHeight: "24px", alignItems: "center" }}>
+        ${items.length === 0 ? html`<span style=${{ color: "#52525b", fontSize: "12px" }}>${emptyText || "None"}</span>` : null}
+        ${items.map((item, i) => html`
+          <span key=${item + i} className=${`badge ${chipClass || "on"}`} style=${{ cursor: "pointer", fontSize: "12px", padding: "3px 8px" }} onClick=${() => remove(i)} title="Click to remove">
+            ${item} ${"x"}
+          </span>
+        `)}
+      </div>
+      ${available ? (
+        remaining.length > 0 ? html`
+          <select onChange=${(e) => { add(e.target.value); e.target.value = ""; }} style=${{ width: "100%" }}>
+            <option value="">${placeholder || "+ Add..."}</option>
+            ${remaining.map((a) => html`<option key=${a} value=${a}>${a}</option>`)}
+          </select>
+        ` : null
+      ) : html`
+        <div style=${{ display: "flex", gap: "6px" }}>
+          <input value=${draft} onInput=${(e) => setDraft(e.target.value)} onKeyDown=${(e) => { if (e.key === "Enter") { e.preventDefault(); add(); } }} placeholder=${placeholder || "Type and press Enter"} style=${{ flex: 1 }} />
+          <button className="btn" onClick=${() => add()}>+</button>
+        </div>
+      `}
+    </div>
+  `;
+}
+
+/** Visual editor for an array of time windows: [{ hours: [start,end], days: [...], tz?: string }] */
+function WindowListEditor({ windows, onChange }) {
+  const list = windows || [];
+
+  function addWindow() { onChange([...list, { hours: [9, 17], days: [...ALL_DAYS] }]); }
+  function removeWindow(i) { onChange(list.filter((_, idx) => idx !== i)); }
+  function updateWindow(i, patch) {
+    const next = [...list];
+    next[i] = { ...next[i], ...patch };
+    onChange(next);
+  }
+  function toggleDay(i, day) {
+    const w = list[i];
+    const days = w.days && w.days.length ? w.days : [...ALL_DAYS];
+    const newDays = days.includes(day) ? days.filter((d) => d !== day) : [...days, day];
+    updateWindow(i, { days: newDays });
+  }
+  function setAllDays(i) { updateWindow(i, { days: [...ALL_DAYS] }); }
+  function setWeekdays(i) { updateWindow(i, { days: ["mon", "tue", "wed", "thu", "fri"] }); }
+  function setWeekends(i) { updateWindow(i, { days: ["sat", "sun"] }); }
+
+  return html`
+    <div>
+      ${list.length === 0 ? html`<div style=${{ color: "#52525b", fontSize: "12px", padding: "6px 0" }}>No windows -- rule is always inactive. Click Add window.</div>` : null}
+      ${list.map((w, i) => {
+        const days = w.days && w.days.length ? w.days : [...ALL_DAYS];
+        return html`
+          <div key=${i} style=${{ background: "#0d0d0f", border: "1px solid #27272a", borderRadius: "8px", padding: "10px 12px", marginBottom: "8px" }}>
+            <div style=${{ display: "flex", gap: "8px", alignItems: "center", marginBottom: "8px", flexWrap: "wrap" }}>
+              <span style=${{ color: "#71717a", fontSize: "10px", fontWeight: 700, letterSpacing: "0.5px" }}>HOURS</span>
+              <input type="number" min="0" max="23" value=${w.hours?.[0] ?? 0} onInput=${(e) => updateWindow(i, { hours: [parseInt(e.target.value) || 0, w.hours?.[1] ?? 24] })} style=${{ width: "60px" }} />
+              <span style=${{ color: "#52525b" }}>to</span>
+              <input type="number" min="0" max="24" value=${w.hours?.[1] ?? 24} onInput=${(e) => updateWindow(i, { hours: [w.hours?.[0] ?? 0, parseInt(e.target.value) || 24] })} style=${{ width: "60px" }} />
+              <span style=${{ color: "#3f3f46", fontSize: "10px" }}>(24h, wraps midnight)</span>
+              <div style=${{ flex: 1 }} />
+              <input value=${w.tz || ""} onInput=${(e) => updateWindow(i, { tz: e.target.value || undefined })} placeholder="tz (optional)" style=${{ width: "150px", fontSize: "11px" }} />
+              <button className="btn danger" onClick=${() => removeWindow(i)} style=${{ padding: "3px 8px", fontSize: "11px" }}>x</button>
+            </div>
+            <div style=${{ display: "flex", gap: "4px", flexWrap: "wrap", alignItems: "center" }}>
+              <span style=${{ color: "#71717a", fontSize: "10px", fontWeight: 700, letterSpacing: "0.5px", marginRight: "4px" }}>DAYS</span>
+              ${ALL_DAYS.map((day) => {
+                const active = days.includes(day);
+                return html`<button key=${day} className=${`btn ${active ? "primary" : ""}`} onClick=${() => toggleDay(i, day)} style=${{ padding: "3px 9px", fontSize: "11px", minWidth: "38px" }}>${day}</button>`;
+              })}
+              <div style=${{ flex: 1 }} />
+              <button className="btn" onClick=${() => setAllDays(i)} style=${{ padding: "3px 8px", fontSize: "10px" }}>all</button>
+              <button className="btn" onClick=${() => setWeekdays(i)} style=${{ padding: "3px 8px", fontSize: "10px" }}>weekdays</button>
+              <button className="btn" onClick=${() => setWeekends(i)} style=${{ padding: "3px 8px", fontSize: "10px" }}>weekends</button>
+            </div>
+          </div>
+        `;
+      })}
+      <button className="btn" onClick=${addWindow} style=${{ fontSize: "11px" }}>+ Add window</button>
+    </div>
+  `;
+}
+
 function ScheduleEditor({ members, schedule, onChange }) {
   // schedule = { memberName: { role, windows: [{ hours, days, dateRange }] } }
   const sched = schedule || {};
@@ -397,7 +502,6 @@ function ScheduleEditor({ members, schedule, onChange }) {
 function ApiKeyEditor({ apiKeys, onSave }) {
   const [editing, setEditing] = useState(null);
   const [draft, setDraft] = useState({});
-  const [modelDraft, setModelDraft] = useState("");
 
   function startNew() { setEditing("__new__"); setDraft({ name: "", key: "", models: [], enabled: true, label: "" }); }
   function startEdit(k) { setEditing(k.name); setDraft({ ...k, models: [...(k.models || [])] }); }
@@ -410,9 +514,6 @@ function ApiKeyEditor({ apiKeys, onSave }) {
   }
   async function del(name) { if (confirm(`Delete API key "${name}"?`)) { await api(`/v1/config/apikeys/${encodeURIComponent(name)}`, { method: "DELETE" }); onSave(); } }
 
-  function addModel() { if (modelDraft.trim() && !draft.models.includes(modelDraft.trim())) { setDraft({ ...draft, models: [...draft.models, modelDraft.trim()] }); setModelDraft(""); } }
-  function removeModel(i) { setDraft({ ...draft, models: draft.models.filter((_, idx) => idx !== i) }); }
-
   function renderForm(isNew) {
     return html`
       <div className="card" style=${{ marginBottom: "10px" }}>
@@ -422,14 +523,7 @@ function ApiKeyEditor({ apiKeys, onSave }) {
           <div className="full"><label>API Key</label><input type="password" value=${draft.key || ""} onInput=${(e) => setDraft({ ...draft, key: e.target.value })} placeholder="sk-..." /></div>
           <div className="full">
             <label>Models (empty = any model)</label>
-            <div style=${{ display: "flex", flexWrap: "wrap", gap: "4px", marginBottom: "6px" }}>
-              ${(draft.models || []).map((m, i) => html`<span key=${m} className="badge on" style=${{ cursor: "pointer", fontSize: "12px", padding: "3px 8px" }} onClick=${() => removeModel(i)}>${m} x</span>`)}
-              ${!draft.models?.length ? html`<span style=${{ color: "#52525b", fontSize: "12px" }}>Any model</span>` : null}
-            </div>
-            <div style=${{ display: "flex", gap: "6px" }}>
-              <input value=${modelDraft} onInput=${(e) => setModelDraft(e.target.value)} onKeyDown=${(e) => { if (e.key === "Enter") { e.preventDefault(); addModel(); } }} placeholder="e.g. gpt-4o, claude-sonnet-4-20250514" style=${{ flex: 1 }} />
-              <button className="btn" onClick=${addModel}>+</button>
-            </div>
+            <${ChipPicker} items=${draft.models || []} onChange=${(v) => setDraft({ ...draft, models: v })} placeholder="e.g. gpt-4o, claude-sonnet-4-20250514" emptyText="Any model" />
           </div>
         </div>
         <div className="actions" style=${{ marginTop: "10px" }}><button className="btn primary" onClick=${save}>${isNew ? "Create" : "Save"}</button><button className="btn" onClick=${cancel}>Cancel</button></div>
@@ -823,6 +917,12 @@ function RoutingRuleEditor({ rules, names, onSave, readOnly }) {
 
   function updateParam(field, value) { setDraft({ ...draft, params: { ...draft.params, [field]: value } }); }
 
+  // Build the list of available targets (providers + pools + accounts)
+  const availableTargets = [
+    ...((names?.providers || []).map((p) => p.id)),
+    ...((names?.pools || []).map((p) => p.id || p.label)),
+  ];
+
   function renderForm(isNew) {
     const t = draft.type;
     return html`
@@ -834,11 +934,23 @@ function RoutingRuleEditor({ rules, names, onSave, readOnly }) {
 
           ${(t === "time-window" || t === "cost-tier") ? html`
             <div><label>Boost score</label><input type="number" value=${draft.params?.boost ?? 50} onInput=${(e) => updateParam("boost", parseInt(e.target.value) || 0)} /></div>
-            <div className="full"><label>Targets (comma-separated provider/pool/account IDs)</label><input value=${(draft.params?.targets || []).join(", ")} onInput=${(e) => updateParam("targets", e.target.value.split(",").map((s) => s.trim()).filter(Boolean))} placeholder="anthropic, codex-pool" /></div>
+            <div className="full">
+              <label>Targets (providers, pools, accounts)</label>
+              <${ChipPicker}
+                items=${draft.params?.targets || []}
+                onChange=${(v) => updateParam("targets", v)}
+                available=${availableTargets}
+                emptyText="No targets -- rule applies to all candidates"
+                placeholder="+ Add target..."
+              />
+            </div>
           ` : null}
 
           ${t === "time-window" ? html`
-            <div className="full"><label>Windows (JSON: [{ days: ["mon-fri"], hours: [9, 17], tz: "Europe/Vienna" }])</label><textarea rows="4" value=${JSON.stringify(draft.params?.windows || [], null, 2)} onInput=${(e) => { try { updateParam("windows", JSON.parse(e.target.value)); } catch {} }} /></div>
+            <div className="full">
+              <label>Time windows</label>
+              <${WindowListEditor} windows=${draft.params?.windows || []} onChange=${(v) => updateParam("windows", v)} />
+            </div>
           ` : null}
 
           ${t === "error-blacklist" ? html`
@@ -846,7 +958,7 @@ function RoutingRuleEditor({ rules, names, onSave, readOnly }) {
           ` : null}
 
           ${t === "model-fit" ? [
-            html`<div key="ctx"><label>Min context</label><input type="number" value=${draft.params?.minContext || 0} onInput=${(e) => updateParam("minContext", parseInt(e.target.value) || 0)} /></div>`,
+            html`<div key="ctx"><label>Min context tokens</label><input type="number" value=${draft.params?.minContext || 0} onInput=${(e) => updateParam("minContext", parseInt(e.target.value) || 0)} /></div>`,
             html`<div key="tools"><label>Require tools</label><select value=${String(!!draft.params?.requireTools)} onChange=${(e) => updateParam("requireTools", e.target.value === "true")}><option value="false">No</option><option value="true">Yes</option></select></div>`,
             html`<div key="vis"><label>Require vision</label><select value=${String(!!draft.params?.requireVision)} onChange=${(e) => updateParam("requireVision", e.target.value === "true")}><option value="false">No</option><option value="true">Yes</option></select></div>`,
           ] : null}
@@ -1049,17 +1161,17 @@ function RuleForm({ onCreate, onCancel }) {
   const [name, setName] = useState("");
   const [type, setType] = useState("block");
   const [scope, setScope] = useState("request");
-  const [patterns, setPatterns] = useState("");
+  const [patterns, setPatterns] = useState([]);
   const [replacement, setReplacement] = useState("[REDACTED]");
   const [message, setMessage] = useState("");
-  const [allow, setAllow] = useState("");
-  const [deny, setDeny] = useState("");
+  const [allow, setAllow] = useState([]);
+  const [deny, setDeny] = useState([]);
   const [maxReq, setMaxReq] = useState("60");
   const [winSec, setWinSec] = useState("60");
 
   function submit() {
-    const rule = { name: name || `rule-${Date.now()}`, type, scope, enabled: true, patterns: patterns.split("\n").map((x) => x.trim()).filter(Boolean), replacement: replacement || undefined, message: message || undefined };
-    if (type === "model") { rule.allow = allow.split(",").map((x) => x.trim()).filter(Boolean); rule.deny = deny.split(",").map((x) => x.trim()).filter(Boolean); }
+    const rule = { name: name || `rule-${Date.now()}`, type, scope, enabled: true, patterns, replacement: replacement || undefined, message: message || undefined };
+    if (type === "model") { rule.allow = allow; rule.deny = deny; }
     if (type === "limit") { rule.maxRequests = parseInt(maxReq) || 60; rule.windowSeconds = parseInt(winSec) || 60; }
     onCreate(rule);
   }
@@ -1070,11 +1182,28 @@ function RuleForm({ onCreate, onCancel }) {
         <div><label>Name</label><input value=${name} onInput=${(e) => setName(e.target.value)} placeholder="e.g. block-secrets" /></div>
         <div><label>Type</label><select value=${type} onChange=${(e) => setType(e.target.value)}><option value="block">block</option><option value="redact">redact</option><option value="warn">warn</option><option value="model">model</option><option value="limit">limit</option></select></div>
         <div><label>Scope</label><select value=${scope} onChange=${(e) => setScope(e.target.value)}><option value="request">request</option><option value="response">response</option><option value="both">both</option></select></div>
-        ${(type === "block" || type === "redact" || type === "warn") && html`<div className="full"><label>Patterns (regex, one per line)</label><textarea value=${patterns} onInput=${(e) => setPatterns(e.target.value)} placeholder="AKIA[0-9A-Z]{16}" /></div>`}
-        ${type === "redact" && html`<div><label>Replacement</label><input value=${replacement} onInput=${(e) => setReplacement(e.target.value)} /></div>`}
-        ${(type === "block" || type === "model") && html`<div><label>Block message</label><input value=${message} onInput=${(e) => setMessage(e.target.value)} placeholder="Blocked by policy" /></div>`}
-        ${type === "model" && [html`<div key="a"><label>Allow (globs)</label><input value=${allow} onInput=${(e) => setAllow(e.target.value)} placeholder="claude-*, gpt-5*" /></div>`, html`<div key="d"><label>Deny (globs)</label><input value=${deny} onInput=${(e) => setDeny(e.target.value)} placeholder="gpt-4o*" /></div>`]}
-        ${type === "limit" && [html`<div key="mr"><label>Max requests</label><input value=${maxReq} onInput=${(e) => setMaxReq(e.target.value)} type="number" /></div>`, html`<div key="ws"><label>Window (seconds)</label><input value=${winSec} onInput=${(e) => setWinSec(e.target.value)} type="number" /></div>`]}
+        ${(type === "block" || type === "redact" || type === "warn") ? html`
+          <div className="full">
+            <label>Patterns (regex, one per chip)</label>
+            <${ChipPicker} items=${patterns} onChange=${setPatterns} placeholder="AKIA[0-9A-Z]{16}" emptyText="No patterns" />
+          </div>
+        ` : null}
+        ${type === "redact" ? html`<div><label>Replacement</label><input value=${replacement} onInput=${(e) => setReplacement(e.target.value)} /></div>` : null}
+        ${(type === "block" || type === "model") ? html`<div><label>Block message</label><input value=${message} onInput=${(e) => setMessage(e.target.value)} placeholder="Blocked by policy" /></div>` : null}
+        ${type === "model" ? [
+          html`<div key="a" className="full">
+            <label>Allow (model globs)</label>
+            <${ChipPicker} items=${allow} onChange=${setAllow} placeholder="claude-*, gpt-5*" emptyText="No allow list" />
+          </div>`,
+          html`<div key="d" className="full">
+            <label>Deny (model globs)</label>
+            <${ChipPicker} items=${deny} onChange=${setDeny} placeholder="gpt-4o*" emptyText="No deny list" chipClass="off" />
+          </div>`,
+        ] : null}
+        ${type === "limit" ? [
+          html`<div key="mr"><label>Max requests</label><input value=${maxReq} onInput=${(e) => setMaxReq(e.target.value)} type="number" /></div>`,
+          html`<div key="ws"><label>Window (seconds)</label><input value=${winSec} onInput=${(e) => setWinSec(e.target.value)} type="number" /></div>`,
+        ] : null}
       </div>
       <div className="actions" style=${{ marginTop: "12px" }}><button className="btn primary" onClick=${submit}>Create</button><button className="btn" onClick=${onCancel}>Cancel</button></div>
     </div>
@@ -1244,32 +1373,6 @@ function UsersPanel() {
 
   function getUserStats(username) { return stats.find((s) => s.username === username); }
 
-  // Available presets/pools for dropdowns
-  const configPresets = (names?.pools || []).map((p) => p.label).concat(
-    // We need preset names too - fetch from config
-  );
-
-  function ChipPicker({ label, items, available, onChange, emptyText }) {
-    function add(val) { if (val && !items.includes(val)) onChange([...items, val]); }
-    function remove(i) { onChange(items.filter((_, idx) => idx !== i)); }
-    const remaining = available.filter((a) => !items.includes(a));
-    return html`
-      <div className="full">
-        <label>${label}</label>
-        <div style=${{ display: "flex", flexWrap: "wrap", gap: "4px", marginBottom: "6px", minHeight: "24px" }}>
-          ${items.length === 0 ? html`<span style=${{ color: "#52525b", fontSize: "12px" }}>${emptyText || "None (all access)"}</span>` : null}
-          ${items.map((item, i) => html`<span key=${item} className="badge on" style=${{ cursor: "pointer", fontSize: "12px", padding: "3px 8px" }} onClick=${() => remove(i)}>${item} ${"x"}</span>`)}
-        </div>
-        ${remaining.length > 0 ? html`
-          <select onChange=${(e) => { add(e.target.value); e.target.value = ""; }} style=${{ width: "100%" }}>
-            <option value="">+ Add...</option>
-            ${remaining.map((a) => html`<option key=${a} value=${a}>${a}</option>`)}
-          </select>
-        ` : null}
-      </div>
-    `;
-  }
-
   const availablePresetNames = (names?.presets || []).map((p) => p.label);
   const availablePoolNames = (names?.pools || []).map((p) => p.label);
 
@@ -1279,20 +1382,24 @@ function UsersPanel() {
       <div className="card" style=${{ marginBottom: "12px" }}>
         <div className="form-grid">
           ${isNew ? html`<div className="full"><label>Username</label><input value=${draft.username} onInput=${(e) => setDraft({ ...draft, username: e.target.value })} placeholder="e.g. alice" /></div>` : html`<div className="full"><label>Username</label><input value=${draft.username} disabled style=${{ opacity: 0.6 }} /></div>`}
-          <${ChipPicker}
-            label="Allowed presets (empty = all access)"
-            items=${draft.allowedPresets}
-            available=${availablePresetNames}
-            onChange=${(v) => setDraft({ ...draft, allowedPresets: v })}
-            emptyText="No restrictions -- all presets allowed"
-          />
-          <${ChipPicker}
-            label="Allowed pools (empty = all access)"
-            items=${draft.allowedPools}
-            available=${availablePoolNames}
-            onChange=${(v) => setDraft({ ...draft, allowedPools: v })}
-            emptyText="No restrictions -- all pools allowed"
-          />
+          <div className="full">
+            <label>Allowed presets (empty = all access)</label>
+            <${ChipPicker}
+              items=${draft.allowedPresets}
+              available=${availablePresetNames}
+              onChange=${(v) => setDraft({ ...draft, allowedPresets: v })}
+              emptyText="No restrictions -- all presets allowed"
+            />
+          </div>
+          <div className="full">
+            <label>Allowed pools (empty = all access)</label>
+            <${ChipPicker}
+              items=${draft.allowedPools}
+              available=${availablePoolNames}
+              onChange=${(v) => setDraft({ ...draft, allowedPools: v })}
+              emptyText="No restrictions -- all pools allowed"
+            />
+          </div>
           <div>
             <label>Daily token budget (0 = unlimited)</label>
             <input type="number" value=${draft.budgets?.daily_tokens || ""} onInput=${(e) => setDraft({ ...draft, budgets: { ...draft.budgets, daily_tokens: e.target.value } })} placeholder="e.g. 500000" />

--- a/web/admin/app.js
+++ b/web/admin/app.js
@@ -385,14 +385,12 @@ function ScheduleEditor({ members, schedule, onChange }) {
 
 // ── API Keys ──
 
-const API_KEY_TYPES = ["openai", "anthropic", "azure", "custom"];
-
 function ApiKeyEditor({ apiKeys, onSave }) {
   const [editing, setEditing] = useState(null);
   const [draft, setDraft] = useState({});
   const [modelDraft, setModelDraft] = useState("");
 
-  function startNew() { setEditing("__new__"); setDraft({ name: "", type: "openai", key: "", baseUrl: "https://api.openai.com/v1", models: [], enabled: true, label: "" }); }
+  function startNew() { setEditing("__new__"); setDraft({ name: "", key: "", models: [], enabled: true, label: "" }); }
   function startEdit(k) { setEditing(k.name); setDraft({ ...k, models: [...(k.models || [])] }); }
   function cancel() { setEditing(null); }
 
@@ -411,19 +409,16 @@ function ApiKeyEditor({ apiKeys, onSave }) {
       <div className="card" style=${{ marginBottom: "10px" }}>
         <div className="form-grid">
           <div><label>Name (unique ID)</label><input value=${draft.name} onInput=${(e) => setDraft({ ...draft, name: e.target.value })} placeholder="e.g. oai-team-1" disabled=${!isNew} style=${!isNew ? { opacity: 0.6 } : {}} /></div>
-          <div><label>Label</label><input value=${draft.label || ""} onInput=${(e) => setDraft({ ...draft, label: e.target.value })} placeholder="e.g. Team key" /></div>
-          <div><label>Type</label><select value=${draft.type} onChange=${(e) => setDraft({ ...draft, type: e.target.value })}>${API_KEY_TYPES.map((t) => html`<option key=${t} value=${t}>${t}</option>`)}</select></div>
-          <div><label>Enabled</label><select value=${String(draft.enabled)} onChange=${(e) => setDraft({ ...draft, enabled: e.target.value === "true" })}><option value="true">Yes</option><option value="false">No</option></select></div>
+          <div><label>Label</label><input value=${draft.label || ""} onInput=${(e) => setDraft({ ...draft, label: e.target.value })} placeholder="e.g. Team account" /></div>
           <div className="full"><label>API Key</label><input type="password" value=${draft.key || ""} onInput=${(e) => setDraft({ ...draft, key: e.target.value })} placeholder="sk-..." /></div>
-          <div className="full"><label>Base URL</label><input value=${draft.baseUrl || ""} onInput=${(e) => setDraft({ ...draft, baseUrl: e.target.value })} placeholder="https://api.openai.com/v1" /></div>
           <div className="full">
-            <label>Models (empty = any model accepted)</label>
+            <label>Models (empty = any model)</label>
             <div style=${{ display: "flex", flexWrap: "wrap", gap: "4px", marginBottom: "6px" }}>
-              ${draft.models.map((m, i) => html`<span key=${m} className="badge on" style=${{ cursor: "pointer", fontSize: "12px", padding: "3px 8px" }} onClick=${() => removeModel(i)}>${m} x</span>`)}
-              ${draft.models.length === 0 ? html`<span style=${{ color: "#52525b", fontSize: "12px" }}>Any model (no restriction)</span>` : null}
+              ${(draft.models || []).map((m, i) => html`<span key=${m} className="badge on" style=${{ cursor: "pointer", fontSize: "12px", padding: "3px 8px" }} onClick=${() => removeModel(i)}>${m} x</span>`)}
+              ${!draft.models?.length ? html`<span style=${{ color: "#52525b", fontSize: "12px" }}>Any model</span>` : null}
             </div>
             <div style=${{ display: "flex", gap: "6px" }}>
-              <input value=${modelDraft} onInput=${(e) => setModelDraft(e.target.value)} onKeyDown=${(e) => { if (e.key === "Enter") { e.preventDefault(); addModel(); } }} placeholder="e.g. gpt-4o" style=${{ flex: 1 }} />
+              <input value=${modelDraft} onInput=${(e) => setModelDraft(e.target.value)} onKeyDown=${(e) => { if (e.key === "Enter") { e.preventDefault(); addModel(); } }} placeholder="e.g. gpt-4o, claude-sonnet-4-20250514" style=${{ flex: 1 }} />
               <button className="btn" onClick=${addModel}>+</button>
             </div>
           </div>
@@ -435,7 +430,7 @@ function ApiKeyEditor({ apiKeys, onSave }) {
 
   return html`<div>
     <div className="card-row" style=${{ marginBottom: "10px" }}><h2 style=${{ margin: 0 }}>API keys</h2><button className="btn primary" onClick=${startNew}>+ Add key</button></div>
-    <div style=${{ marginBottom: "10px", fontSize: "11px", color: "#52525b" }}>Add raw API keys for OpenAI, Anthropic, Azure, or any OpenAI-compatible endpoint. Pool and route them just like OAuth accounts.</div>
+    <div style=${{ marginBottom: "10px", fontSize: "11px", color: "#52525b" }}>Add raw API keys for any OpenAI-compatible endpoint. Pool and route them just like OAuth accounts.</div>
     ${editing === "__new__" ? renderForm(true) : null}
     ${apiKeys.map((k) => editing === k.name ? renderForm(false) : html`
       <div className="card" key=${k.name}>
@@ -443,7 +438,6 @@ function ApiKeyEditor({ apiKeys, onSave }) {
           <div>
             <span className="name">${k.label || k.name}</span>
             <span className="badge neutral" style=${{ fontFamily: "monospace" }}>${k.name}</span>
-            <span className="badge neutral">${k.type}</span>
             <span className=${`badge ${k.enabled !== false ? "on" : "off"}`}>${k.enabled !== false ? "active" : "disabled"}</span>
             ${k.models?.length ? html`<span className="badge neutral">${k.models.join(", ")}</span>` : html`<span className="badge neutral">any model</span>`}
           </div>
@@ -452,10 +446,10 @@ function ApiKeyEditor({ apiKeys, onSave }) {
             <button className="btn danger" onClick=${() => del(k.name)}>Del</button>
           </div>
         </div>
-        <div className="meta">${k.baseUrl || "https://api.openai.com/v1"} | key: ${k.key ? k.key.slice(0, 8) + "..." : "not set"}</div>
+        <div className="meta">key: ${k.key ? k.key.slice(0, 12) + "..." : "not set"}</div>
       </div>
     `)}
-    ${apiKeys.length === 0 && editing !== "__new__" ? html`<div className="empty">No API keys configured. Use "+ Add key" to add OpenAI, Anthropic, or custom API keys.</div>` : null}
+    ${apiKeys.length === 0 && editing !== "__new__" ? html`<div className="empty">No API keys. Add OpenAI or any OpenAI-compatible API keys to pool and route them.</div>` : null}
   </div>`;
 }
 

--- a/web/admin/app.js
+++ b/web/admin/app.js
@@ -314,6 +314,88 @@ function PresetEditor({ presets, onSave }) {
   </div>`;
 }
 
+// ── Auth / OAuth ──
+
+function AuthPanel({ onRefresh }) {
+  const [providers, setProviders] = useState([]);
+  const [busy, setBusy] = useState({});
+  const [polling, setPolling] = useState({});
+
+  async function loadProviders() {
+    try { const d = await api("/v1/auth/providers"); setProviders(d.providers || []); } catch {}
+  }
+  useEffect(() => { loadProviders(); }, []);
+
+  async function startLogin(providerId) {
+    setBusy((b) => ({ ...b, [providerId]: "connecting..." }));
+    try {
+      const res = await api(`/v1/auth/login/${encodeURIComponent(providerId)}`, { method: "POST" });
+      if (res.authUrl) {
+        window.open(res.authUrl, "_blank");
+        setBusy((b) => ({ ...b, [providerId]: "waiting for browser..." }));
+        // Poll for completion
+        setPolling((p) => ({ ...p, [providerId]: true }));
+        pollLogin(providerId);
+      }
+    } catch (e) {
+      setBusy((b) => ({ ...b, [providerId]: `error: ${e.message}` }));
+      setTimeout(() => setBusy((b) => { const n = { ...b }; delete n[providerId]; return n; }), 3000);
+    }
+  }
+
+  async function pollLogin(providerId) {
+    for (let i = 0; i < 120; i++) {
+      await new Promise((r) => setTimeout(r, 2000));
+      try {
+        const s = await api(`/v1/auth/login/${encodeURIComponent(providerId)}`);
+        if (s.status === "authenticated" || s.hasAuth) {
+          setBusy((b) => { const n = { ...b }; delete n[providerId]; return n; });
+          setPolling((p) => { const n = { ...p }; delete n[providerId]; return n; });
+          await loadProviders();
+          if (onRefresh) onRefresh();
+          return;
+        }
+      } catch {}
+    }
+    setBusy((b) => ({ ...b, [providerId]: "timed out" }));
+    setPolling((p) => { const n = { ...p }; delete n[providerId]; return n; });
+  }
+
+  async function logout(providerId) {
+    if (!confirm(`Logout from ${providerId}?`)) return;
+    try {
+      await api(`/v1/auth/logout/${encodeURIComponent(providerId)}`, { method: "POST" });
+      await loadProviders();
+      if (onRefresh) onRefresh();
+    } catch {}
+  }
+
+  return html`<div>
+    <h2>OAuth accounts</h2>
+    <div style=${{ marginBottom: "10px", fontSize: "11px", color: "#52525b" }}>Login to providers to enable routing. OAuth tokens stored in ~/.pi/agent/auth.json</div>
+    ${providers.map((p) => html`
+      <div className="card" key=${p.id}>
+        <div className="card-row">
+          <div>
+            <span className="name">${p.name}</span>
+            <span className="badge neutral" style=${{ fontFamily: "monospace" }}>${p.id}</span>
+            <span className=${`badge ${p.authenticated ? "on" : "off"}`}>${p.authenticated ? "logged in" : "not logged in"}</span>
+          </div>
+          <div className="actions">
+            ${busy[p.id]
+              ? html`<span style=${{ fontSize: "12px", color: "#f59e0b" }}>${busy[p.id]}</span>`
+              : html`
+                ${!p.authenticated ? html`<button className="btn primary" onClick=${() => startLogin(p.id)}>Login</button>` : null}
+                ${p.authenticated ? html`<button className="btn danger" onClick=${() => logout(p.id)}>Logout</button>` : null}
+              `}
+          </div>
+        </div>
+      </div>
+    `)}
+    ${providers.length === 0 ? html`<div className="empty">Loading providers...</div>` : null}
+  </div>`;
+}
+
 function ConfigPanel({ onRefresh }) {
   const [config, setConfig] = useState(null);
   const [err, setErr] = useState("");
@@ -327,6 +409,8 @@ function ConfigPanel({ onRefresh }) {
 
   return html`<div>
     ${err ? html`<div className="card" style=${{ color: "#ef4444", borderColor: "#7f1d1d" }}>Error: ${err}</div>` : null}
+    <${AuthPanel} onRefresh=${refresh} />
+    <div style=${{ marginTop: "24px" }} />
     <div style=${{ marginBottom: "6px", fontSize: "11px", color: "#52525b" }}>Editing: ~/.pi/agent/multi-pass.json</div>
     <${SubEditor} subs=${config.subscriptions || []} onSave=${refresh} />
     <div style=${{ marginTop: "20px" }} />

--- a/web/admin/app.js
+++ b/web/admin/app.js
@@ -98,7 +98,7 @@ function SortableList({ items, onReorder, renderItem }) {
           transition: "background .1s, border .1s",
         }}
       >
-        <span style=${{ color: "#3f3f46", fontSize: "14px", cursor: "grab", userSelect: "none" }}>&#x2630;</span>
+        <span style=${{ color: "#3f3f46", fontSize: "14px", cursor: "grab", userSelect: "none" }}>${"\u2630"}</span>
         ${renderItem(item, i)}
       </div>
     `)}

--- a/web/admin/index.html
+++ b/web/admin/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Leeloo Admin</title>
+  <link rel="stylesheet" href="/web/admin/styles.css" />
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="/web/admin/app.js"></script>
+</body>
+</html>

--- a/web/admin/styles.css
+++ b/web/admin/styles.css
@@ -1,143 +1,91 @@
-* { box-sizing: border-box; }
-html, body, #app { height: 100%; margin: 0; }
-body {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  background: #0a0a0a;
-  color: #e0e0e0;
-}
-.app {
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-}
-.header {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 10px 14px;
-  border-bottom: 1px solid #222;
-  background: #111;
-}
-.title { font-weight: 700; color: #f90; }
-.link {
-  color: #888;
-  text-decoration: none;
-  border: 1px solid #333;
-  border-radius: 6px;
-  padding: 4px 10px;
-  font-size: 12px;
-}
-.link:hover { color: #ddd; border-color: #666; }
-.tabs {
-  display: flex;
-  border-bottom: 1px solid #222;
-  background: #111;
-}
-.tab {
-  padding: 10px 16px;
-  color: #888;
-  border: none;
-  background: transparent;
-  border-bottom: 2px solid transparent;
-  cursor: pointer;
-}
-.tab.active { color: #f90; border-color: #f90; }
-.tab:hover { color: #ddd; }
-.panel {
-  flex: 1;
-  overflow: auto;
-  padding: 16px;
-}
-h2 {
-  margin: 0 0 10px;
-  font-size: 13px;
-  color: #aaa;
-  text-transform: uppercase;
-  letter-spacing: 0.8px;
-}
-.card {
-  background: #111;
-  border: 1px solid #222;
-  border-radius: 8px;
-  padding: 12px;
-  margin-bottom: 10px;
-}
-.name { font-weight: 600; color: #eee; }
-.meta { color: #777; font-size: 12px; margin-top: 4px; }
-.badge {
-  display: inline-block;
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-size: 10px;
-  border: 1px solid #333;
-  margin-left: 6px;
-}
-.badge.on { color: #65d665; border-color: #2c4e2c; }
-.badge.off { color: #f16b6b; border-color: #5a2424; }
-.badge.block { color: #f16b6b; }
-.badge.redact { color: #f2c14e; }
-.badge.warn { color: #7fb5ff; }
-.badge.model { color: #c599ff; }
-.badge.limit { color: #8ea2ff; }
-.actions { display: flex; gap: 8px; }
-.btn {
-  background: #1a1a1a;
-  color: #ddd;
-  border: 1px solid #333;
-  border-radius: 6px;
-  padding: 6px 10px;
-  cursor: pointer;
-  font-size: 12px;
-}
-.btn:hover { border-color: #666; }
-.btn.primary { background: #f90; color: #000; border-color: #f90; font-weight: 600; }
-.btn.danger { color: #f16b6b; border-color: #5a2424; }
-.btn.danger:hover { background: #2a1010; }
-.stat-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-  gap: 10px;
-  margin-bottom: 14px;
-}
-.stat {
-  background: #111;
-  border: 1px solid #222;
-  border-radius: 8px;
-  padding: 12px;
-  text-align: center;
-}
-.stat-num { font-size: 24px; color: #f90; font-weight: 700; }
-.stat-label { color: #777; font-size: 12px; }
-.table-wrap { overflow: auto; border: 1px solid #222; border-radius: 8px; }
-table { width: 100%; border-collapse: collapse; font-size: 12px; }
-th, td { text-align: left; padding: 8px; border-bottom: 1px solid #1b1b1b; vertical-align: top; }
-th { color: #8b8b8b; font-size: 11px; text-transform: uppercase; }
-pre {
-  margin: 6px 0 0;
-  max-height: 260px;
-  overflow: auto;
-  white-space: pre-wrap;
-  word-break: break-word;
-  border: 1px solid #222;
-  border-radius: 6px;
-  background: #0d0d0d;
-  padding: 8px;
-}
-.form-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 10px;
-}
-.form-grid .full { grid-column: 1 / -1; }
-label { display: block; font-size: 12px; color: #888; margin-bottom: 4px; }
-input, select, textarea {
-  width: 100%;
-  border: 1px solid #333;
-  background: #1a1a1a;
-  color: #eee;
-  border-radius: 6px;
-  padding: 7px 9px;
-  font-family: inherit;
-}
-input:focus, select:focus, textarea:focus { outline: none; border-color: #f90; }
-.empty { color: #666; font-style: italic; padding: 16px; }
+*{box-sizing:border-box;margin:0;padding:0}
+html,body,#app{height:100%}
+body{font-family:Inter,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:#09090b;color:#e4e4e7;font-size:14px;-webkit-font-smoothing:antialiased}
+.app{height:100%;display:flex;flex-direction:column}
+
+/* header */
+.header{display:flex;align-items:center;gap:12px;padding:10px 16px;background:#18181b;border-bottom:1px solid #27272a}
+.logo{font-weight:700;color:#f59e0b;font-size:15px}
+.nav-link{color:#71717a;text-decoration:none;font-size:12px;padding:4px 10px;border:1px solid #27272a;border-radius:6px;transition:all .15s}
+.nav-link:hover{color:#d4d4d8;border-color:#52525b}
+
+/* tabs */
+.tabs{display:flex;background:#18181b;border-bottom:1px solid #27272a;gap:0}
+.tab{padding:10px 18px;font-size:13px;color:#71717a;cursor:pointer;border:none;background:transparent;border-bottom:2px solid transparent;transition:all .15s;text-transform:capitalize}
+.tab:hover{color:#a1a1aa}
+.tab.active{color:#f59e0b;border-color:#f59e0b}
+
+/* panel */
+.panel{flex:1;overflow-y:auto;padding:20px 16px}
+.panel-inner{max-width:1100px;margin:0 auto}
+
+/* section headers */
+h2{font-size:12px;font-weight:600;color:#71717a;text-transform:uppercase;letter-spacing:.8px;margin:0 0 10px}
+h2.mt{margin-top:20px}
+
+/* stat cards */
+.stat-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:10px;margin-bottom:16px}
+.stat{background:#18181b;border:1px solid #27272a;border-radius:10px;padding:14px 16px;text-align:center}
+.stat-num{font-size:26px;font-weight:700;color:#f59e0b;line-height:1}
+.stat-label{font-size:11px;color:#52525b;margin-top:6px;text-transform:uppercase;letter-spacing:.5px}
+
+/* cards */
+.card{background:#18181b;border:1px solid #27272a;border-radius:10px;padding:14px 16px;margin-bottom:10px}
+.card-row{display:flex;justify-content:space-between;align-items:center}
+.name{font-weight:600;color:#fafafa;font-size:14px}
+.meta{font-size:12px;color:#52525b;margin-top:4px}
+.actions{display:flex;gap:6px}
+
+/* badges */
+.badge{display:inline-block;padding:2px 7px;border-radius:5px;font-size:10px;font-weight:600;border:1px solid #27272a;margin-left:6px}
+.badge.on{color:#22c55e;border-color:#166534;background:#052e16}
+.badge.off{color:#ef4444;border-color:#7f1d1d;background:#1c0a0a}
+.badge.block{color:#ef4444;border-color:#7f1d1d}
+.badge.redact{color:#eab308;border-color:#713f12}
+.badge.warn{color:#3b82f6;border-color:#1e40af}
+.badge.model{color:#a78bfa;border-color:#5b21b6}
+.badge.limit{color:#06b6d4;border-color:#155e75}
+.badge.neutral{color:#71717a;border-color:#3f3f46}
+
+/* buttons */
+.btn{background:#27272a;color:#d4d4d8;border:1px solid #3f3f46;border-radius:8px;padding:6px 12px;font-size:12px;cursor:pointer;transition:all .15s}
+.btn:hover{background:#3f3f46;color:#fff}
+.btn:disabled{opacity:.5;cursor:not-allowed}
+.btn.primary{background:#f59e0b;color:#000;border-color:#f59e0b;font-weight:600}
+.btn.primary:hover{background:#fbbf24}
+.btn.danger{color:#ef4444;border-color:#7f1d1d}
+.btn.danger:hover{background:#1c0a0a}
+
+/* tables */
+.table-wrap{border:1px solid #27272a;border-radius:10px;overflow:hidden;margin-bottom:16px}
+table{width:100%;border-collapse:collapse;font-size:12px}
+th,td{text-align:left;padding:8px 12px;border-bottom:1px solid #18181b}
+th{font-size:10px;text-transform:uppercase;letter-spacing:.5px;color:#52525b;background:#111113;font-weight:600}
+td{color:#a1a1aa;vertical-align:top}
+tr:last-child td{border-bottom:none}
+tr:hover td{background:#111113}
+
+/* quota bar in table */
+.q-bar{display:inline-block;width:50px;height:6px;border-radius:3px;background:#27272a;overflow:hidden;vertical-align:middle;margin-right:6px}
+.q-fill{height:100%;border-radius:3px}
+
+/* forms */
+.form-grid{display:grid;grid-template-columns:1fr 1fr;gap:10px}
+.form-grid .full{grid-column:1/-1}
+label{display:block;font-size:11px;color:#71717a;margin-bottom:4px;font-weight:500;text-transform:uppercase;letter-spacing:.3px}
+input,select,textarea{width:100%;background:#27272a;border:1px solid #3f3f46;color:#e4e4e7;border-radius:8px;padding:8px 10px;font-size:13px;font-family:inherit;transition:border-color .15s}
+input:focus,select:focus,textarea:focus{outline:none;border-color:#f59e0b}
+textarea{resize:vertical;min-height:80px}
+
+/* details/pre */
+details>summary{cursor:pointer;color:#71717a;font-size:11px}
+details>summary:hover{color:#a1a1aa}
+pre{margin:6px 0 0;max-height:240px;overflow:auto;white-space:pre-wrap;word-break:break-word;background:#0d0d0f;border:1px solid #27272a;border-radius:8px;padding:10px;font-size:12px;font-family:"JetBrains Mono",Menlo,monospace;color:#a1a1aa}
+
+.empty{color:#3f3f46;font-style:italic;padding:20px;text-align:center}
+
+/* scrollbar */
+::-webkit-scrollbar{width:6px;height:6px}
+::-webkit-scrollbar-track{background:transparent}
+::-webkit-scrollbar-thumb{background:#27272a;border-radius:3px}
+::-webkit-scrollbar-thumb:hover{background:#3f3f46}

--- a/web/admin/styles.css
+++ b/web/admin/styles.css
@@ -4,95 +4,102 @@ body{font-family:Inter,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-s
 .app{height:100%;display:flex;flex-direction:column}
 
 /* header */
-.header{display:flex;align-items:center;gap:12px;padding:10px 16px;background:#18181b;border-bottom:1px solid #27272a}
-.logo{font-weight:700;color:#f59e0b;font-size:15px}
-.nav-link{color:#71717a;text-decoration:none;font-size:12px;padding:4px 10px;border:1px solid #27272a;border-radius:6px;transition:all .15s}
-.nav-link:hover{color:#d4d4d8;border-color:#52525b}
+.header{display:flex;align-items:center;gap:12px;padding:10px 16px;background:linear-gradient(180deg,#18181b,#131316);border-bottom:1px solid #27272a}
+.logo{font-weight:800;color:#f59e0b;font-size:16px;letter-spacing:-0.3px}
+.nav-link{color:#52525b;text-decoration:none;font-size:12px;padding:5px 12px;border:1px solid #27272a;border-radius:8px;transition:all .15s;font-weight:500}
+.nav-link:hover{color:#d4d4d8;border-color:#3f3f46;background:#1a1a1e}
 
 /* tabs */
-.tabs{display:flex;background:#18181b;border-bottom:1px solid #27272a;gap:0}
-.tab{padding:10px 18px;font-size:13px;color:#71717a;cursor:pointer;border:none;background:transparent;border-bottom:2px solid transparent;transition:all .15s;text-transform:capitalize}
-.tab:hover{color:#a1a1aa}
+.tabs{display:flex;background:linear-gradient(180deg,#141418,#111114);border-bottom:1px solid #27272a;gap:0}
+.tab{padding:11px 20px;font-size:13px;color:#52525b;cursor:pointer;border:none;background:transparent;border-bottom:2px solid transparent;transition:all .15s;text-transform:capitalize;font-weight:600;letter-spacing:.3px}
+.tab:hover{color:#a1a1aa;background:rgba(255,255,255,0.02)}
 .tab.active{color:#f59e0b;border-color:#f59e0b}
 
 /* panel */
-.panel{flex:1;overflow-y:auto;padding:20px 16px}
+.panel{flex:1;overflow-y:auto;padding:24px 16px}
 .panel-inner{max-width:1100px;margin:0 auto}
 
-/* section headers */
-h2{font-size:12px;font-weight:600;color:#71717a;text-transform:uppercase;letter-spacing:.8px;margin:0 0 10px}
-h2.mt{margin-top:20px}
+/* headings */
+h2{font-size:11px;font-weight:700;color:#52525b;text-transform:uppercase;letter-spacing:1px;margin:0 0 12px}
+h2.mt{margin-top:24px}
 
 /* stat cards */
-.stat-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:10px;margin-bottom:16px}
-.stat{background:#18181b;border:1px solid #27272a;border-radius:10px;padding:14px 16px;text-align:center}
-.stat-num{font-size:26px;font-weight:700;color:#f59e0b;line-height:1}
-.stat-label{font-size:11px;color:#52525b;margin-top:6px;text-transform:uppercase;letter-spacing:.5px}
+.stat-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:10px;margin-bottom:20px}
+.stat{background:linear-gradient(135deg,#18181b,#1a1a20);border:1px solid #27272a;border-radius:12px;padding:16px 18px;text-align:center;transition:border-color .2s}
+.stat:hover{border-color:#3f3f46}
+.stat-num{font-size:28px;font-weight:800;color:#f59e0b;line-height:1;letter-spacing:-1px}
+.stat-label{font-size:10px;color:#3f3f46;margin-top:6px;text-transform:uppercase;letter-spacing:.8px;font-weight:600}
 
 /* cards */
-.card{background:#18181b;border:1px solid #27272a;border-radius:10px;padding:14px 16px;margin-bottom:10px}
-.card-row{display:flex;justify-content:space-between;align-items:center}
+.card{background:#14141a;border:1px solid #27272a;border-radius:12px;padding:14px 18px;margin-bottom:10px;transition:border-color .15s}
+.card:hover{border-color:#3f3f46}
+.card-row{display:flex;justify-content:space-between;align-items:center;gap:10px}
 .name{font-weight:600;color:#fafafa;font-size:14px}
-.meta{font-size:12px;color:#52525b;margin-top:4px}
-.actions{display:flex;gap:6px}
+.meta{font-size:12px;color:#3f3f46;margin-top:4px}
+.actions{display:flex;gap:6px;flex-wrap:wrap}
 
 /* badges */
-.badge{display:inline-block;padding:2px 7px;border-radius:5px;font-size:10px;font-weight:600;border:1px solid #27272a;margin-left:6px}
+.badge{display:inline-block;padding:2px 8px;border-radius:6px;font-size:10px;font-weight:600;border:1px solid #27272a;margin-left:6px}
 .badge.on{color:#22c55e;border-color:#166534;background:#052e16}
 .badge.off{color:#ef4444;border-color:#7f1d1d;background:#1c0a0a}
-.badge.block{color:#ef4444;border-color:#7f1d1d}
-.badge.redact{color:#eab308;border-color:#713f12}
 .badge.warn{color:#f59e0b;border-color:#92400e;background:#1c1508}
 .badge.info{color:#3b82f6;border-color:#1e40af}
+.badge.block{color:#ef4444;border-color:#7f1d1d}
+.badge.redact{color:#eab308;border-color:#713f12}
 .badge.model{color:#a78bfa;border-color:#5b21b6}
 .badge.limit{color:#06b6d4;border-color:#155e75}
-.badge.neutral{color:#71717a;border-color:#3f3f46}
+.badge.neutral{color:#71717a;border-color:#27272a;background:#18181b}
 
 /* buttons */
-.btn{background:#27272a;color:#d4d4d8;border:1px solid #3f3f46;border-radius:8px;padding:6px 12px;font-size:12px;cursor:pointer;transition:all .15s}
+.btn{background:#27272a;color:#d4d4d8;border:1px solid #3f3f46;border-radius:8px;padding:6px 14px;font-size:12px;cursor:pointer;transition:all .15s;font-weight:500}
 .btn:hover{background:#3f3f46;color:#fff}
 .btn:disabled{opacity:.5;cursor:not-allowed}
-.btn.primary{background:#f59e0b;color:#000;border-color:#f59e0b;font-weight:600}
-.btn.primary:hover{background:#fbbf24}
+.btn.primary{background:linear-gradient(135deg,#f59e0b,#d97706);color:#000;border:none;font-weight:600;box-shadow:0 1px 4px rgba(245,158,11,0.2)}
+.btn.primary:hover{background:linear-gradient(135deg,#fbbf24,#f59e0b)}
 .btn.danger{color:#ef4444;border-color:#7f1d1d}
-.btn.danger:hover{background:#1c0a0a}
+.btn.danger:hover{background:#1c0a0a;color:#fca5a5}
 
 /* tables */
-.table-wrap{border:1px solid #27272a;border-radius:10px;overflow:hidden;margin-bottom:16px}
+.table-wrap{border:1px solid #27272a;border-radius:12px;overflow:hidden;margin-bottom:20px}
 table{width:100%;border-collapse:collapse;font-size:12px}
-th,td{text-align:left;padding:8px 12px;border-bottom:1px solid #18181b}
-th{font-size:10px;text-transform:uppercase;letter-spacing:.5px;color:#52525b;background:#111113;font-weight:600}
+th,td{text-align:left;padding:10px 14px;border-bottom:1px solid #1a1a1e}
+th{font-size:10px;text-transform:uppercase;letter-spacing:.6px;color:#3f3f46;background:#111114;font-weight:700}
 td{color:#a1a1aa;vertical-align:top}
 tr:last-child td{border-bottom:none}
-tr:hover td{background:#111113}
+tr:hover td{background:rgba(255,255,255,0.015)}
 
-/* quota bar in table */
-.q-bar{display:inline-block;width:50px;height:6px;border-radius:3px;background:#27272a;overflow:hidden;vertical-align:middle;margin-right:6px}
-.q-fill{height:100%;border-radius:3px}
+/* quota bars */
+.q-bar{display:inline-block;width:50px;height:6px;border-radius:3px;background:#1e1e24;overflow:hidden;vertical-align:middle;margin-right:6px}
+.q-fill{height:100%;border-radius:3px;transition:width .6s ease}
 
 /* forms */
-.form-grid{display:grid;grid-template-columns:1fr 1fr;gap:10px}
+.form-grid{display:grid;grid-template-columns:1fr 1fr;gap:12px}
 .form-grid .full{grid-column:1/-1}
-label{display:block;font-size:11px;color:#71717a;margin-bottom:4px;font-weight:500;text-transform:uppercase;letter-spacing:.3px}
-input,select,textarea{width:100%;background:#27272a;border:1px solid #3f3f46;color:#e4e4e7;border-radius:8px;padding:8px 10px;font-size:13px;font-family:inherit;transition:border-color .15s}
-input:focus,select:focus,textarea:focus{outline:none;border-color:#f59e0b}
+label{display:block;font-size:10px;color:#52525b;margin-bottom:4px;font-weight:700;text-transform:uppercase;letter-spacing:.4px}
+input,select,textarea{width:100%;background:#1e1e24;border:1px solid #3f3f46;color:#e4e4e7;border-radius:8px;padding:9px 12px;font-size:13px;font-family:inherit;transition:border-color .15s,box-shadow .15s}
+input:focus,select:focus,textarea:focus{outline:none;border-color:#f59e0b;box-shadow:0 0 0 2px rgba(245,158,11,0.1)}
 textarea{resize:vertical;min-height:80px}
 
 /* details/pre */
-details>summary{cursor:pointer;color:#71717a;font-size:11px}
+details>summary{cursor:pointer;color:#52525b;font-size:11px;font-weight:500;transition:color .15s}
 details>summary:hover{color:#a1a1aa}
-pre{margin:6px 0 0;max-height:240px;overflow:auto;white-space:pre-wrap;word-break:break-word;background:#0d0d0f;border:1px solid #27272a;border-radius:8px;padding:10px;font-size:12px;font-family:"JetBrains Mono",Menlo,monospace;color:#a1a1aa}
+pre{margin:6px 0 0;max-height:260px;overflow:auto;white-space:pre-wrap;word-break:break-word;background:#0d0d0f;border:1px solid #27272a;border-radius:8px;padding:12px;font-size:12px;font-family:"JetBrains Mono","Fira Code",Menlo,monospace;color:#a1a1aa;line-height:1.5}
 
-/* diff view */
-.diff-view{margin:6px 0 0;max-height:300px;overflow:auto;white-space:pre-wrap;word-break:break-word;background:#0d0d0f;border:1px solid #27272a;border-radius:8px;padding:10px;font-size:12px;font-family:"JetBrains Mono",Menlo,monospace;color:#a1a1aa;line-height:1.6}
-.diff-del{background:#3b1219;color:#fca5a5;text-decoration:line-through;border-radius:2px;padding:0 1px}
-.diff-ins{background:#052e16;color:#86efac;border-radius:2px;padding:0 1px}
+/* diff */
+.diff-view{margin:6px 0 0;max-height:300px;overflow:auto;white-space:pre-wrap;word-break:break-word;background:#0d0d0f;border:1px solid #27272a;border-radius:8px;padding:12px;font-size:12px;font-family:"JetBrains Mono",Menlo,monospace;color:#a1a1aa;line-height:1.6}
+.diff-del{background:#3b1219;color:#fca5a5;text-decoration:line-through;border-radius:3px;padding:0 2px}
+.diff-ins{background:#052e16;color:#86efac;border-radius:3px;padding:0 2px}
 .diff-eq{color:#a1a1aa}
 
-.empty{color:#3f3f46;font-style:italic;padding:20px;text-align:center}
+.empty{color:#27272a;font-style:italic;padding:24px;text-align:center;font-size:13px}
 
 /* scrollbar */
 ::-webkit-scrollbar{width:6px;height:6px}
 ::-webkit-scrollbar-track{background:transparent}
 ::-webkit-scrollbar-thumb{background:#27272a;border-radius:3px}
 ::-webkit-scrollbar-thumb:hover{background:#3f3f46}
+
+/* login */
+.login-card{width:360px;padding:36px;background:linear-gradient(135deg,#18181b,#1a1a20);border:1px solid #27272a;border-radius:20px;box-shadow:0 8px 32px rgba(0,0,0,0.5)}
+.login-card h2{color:#f59e0b;font-size:22px;font-weight:800;margin-bottom:4px;letter-spacing:-0.5px}
+.login-card p{color:#52525b;font-size:13px;margin-bottom:24px}

--- a/web/admin/styles.css
+++ b/web/admin/styles.css
@@ -83,6 +83,12 @@ details>summary{cursor:pointer;color:#71717a;font-size:11px}
 details>summary:hover{color:#a1a1aa}
 pre{margin:6px 0 0;max-height:240px;overflow:auto;white-space:pre-wrap;word-break:break-word;background:#0d0d0f;border:1px solid #27272a;border-radius:8px;padding:10px;font-size:12px;font-family:"JetBrains Mono",Menlo,monospace;color:#a1a1aa}
 
+/* diff view */
+.diff-view{margin:6px 0 0;max-height:300px;overflow:auto;white-space:pre-wrap;word-break:break-word;background:#0d0d0f;border:1px solid #27272a;border-radius:8px;padding:10px;font-size:12px;font-family:"JetBrains Mono",Menlo,monospace;color:#a1a1aa;line-height:1.6}
+.diff-del{background:#3b1219;color:#fca5a5;text-decoration:line-through;border-radius:2px;padding:0 1px}
+.diff-ins{background:#052e16;color:#86efac;border-radius:2px;padding:0 1px}
+.diff-eq{color:#a1a1aa}
+
 .empty{color:#3f3f46;font-style:italic;padding:20px;text-align:center}
 
 /* scrollbar */

--- a/web/admin/styles.css
+++ b/web/admin/styles.css
@@ -1,0 +1,143 @@
+* { box-sizing: border-box; }
+html, body, #app { height: 100%; margin: 0; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0a0a0a;
+  color: #e0e0e0;
+}
+.app {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+.header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  border-bottom: 1px solid #222;
+  background: #111;
+}
+.title { font-weight: 700; color: #f90; }
+.link {
+  color: #888;
+  text-decoration: none;
+  border: 1px solid #333;
+  border-radius: 6px;
+  padding: 4px 10px;
+  font-size: 12px;
+}
+.link:hover { color: #ddd; border-color: #666; }
+.tabs {
+  display: flex;
+  border-bottom: 1px solid #222;
+  background: #111;
+}
+.tab {
+  padding: 10px 16px;
+  color: #888;
+  border: none;
+  background: transparent;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+}
+.tab.active { color: #f90; border-color: #f90; }
+.tab:hover { color: #ddd; }
+.panel {
+  flex: 1;
+  overflow: auto;
+  padding: 16px;
+}
+h2 {
+  margin: 0 0 10px;
+  font-size: 13px;
+  color: #aaa;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+}
+.card {
+  background: #111;
+  border: 1px solid #222;
+  border-radius: 8px;
+  padding: 12px;
+  margin-bottom: 10px;
+}
+.name { font-weight: 600; color: #eee; }
+.meta { color: #777; font-size: 12px; margin-top: 4px; }
+.badge {
+  display: inline-block;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 10px;
+  border: 1px solid #333;
+  margin-left: 6px;
+}
+.badge.on { color: #65d665; border-color: #2c4e2c; }
+.badge.off { color: #f16b6b; border-color: #5a2424; }
+.badge.block { color: #f16b6b; }
+.badge.redact { color: #f2c14e; }
+.badge.warn { color: #7fb5ff; }
+.badge.model { color: #c599ff; }
+.badge.limit { color: #8ea2ff; }
+.actions { display: flex; gap: 8px; }
+.btn {
+  background: #1a1a1a;
+  color: #ddd;
+  border: 1px solid #333;
+  border-radius: 6px;
+  padding: 6px 10px;
+  cursor: pointer;
+  font-size: 12px;
+}
+.btn:hover { border-color: #666; }
+.btn.primary { background: #f90; color: #000; border-color: #f90; font-weight: 600; }
+.btn.danger { color: #f16b6b; border-color: #5a2424; }
+.btn.danger:hover { background: #2a1010; }
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 10px;
+  margin-bottom: 14px;
+}
+.stat {
+  background: #111;
+  border: 1px solid #222;
+  border-radius: 8px;
+  padding: 12px;
+  text-align: center;
+}
+.stat-num { font-size: 24px; color: #f90; font-weight: 700; }
+.stat-label { color: #777; font-size: 12px; }
+.table-wrap { overflow: auto; border: 1px solid #222; border-radius: 8px; }
+table { width: 100%; border-collapse: collapse; font-size: 12px; }
+th, td { text-align: left; padding: 8px; border-bottom: 1px solid #1b1b1b; vertical-align: top; }
+th { color: #8b8b8b; font-size: 11px; text-transform: uppercase; }
+pre {
+  margin: 6px 0 0;
+  max-height: 260px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  border: 1px solid #222;
+  border-radius: 6px;
+  background: #0d0d0d;
+  padding: 8px;
+}
+.form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+.form-grid .full { grid-column: 1 / -1; }
+label { display: block; font-size: 12px; color: #888; margin-bottom: 4px; }
+input, select, textarea {
+  width: 100%;
+  border: 1px solid #333;
+  background: #1a1a1a;
+  color: #eee;
+  border-radius: 6px;
+  padding: 7px 9px;
+  font-family: inherit;
+}
+input:focus, select:focus, textarea:focus { outline: none; border-color: #f90; }
+.empty { color: #666; font-style: italic; padding: 16px; }

--- a/web/admin/styles.css
+++ b/web/admin/styles.css
@@ -42,7 +42,8 @@ h2.mt{margin-top:20px}
 .badge.off{color:#ef4444;border-color:#7f1d1d;background:#1c0a0a}
 .badge.block{color:#ef4444;border-color:#7f1d1d}
 .badge.redact{color:#eab308;border-color:#713f12}
-.badge.warn{color:#3b82f6;border-color:#1e40af}
+.badge.warn{color:#f59e0b;border-color:#92400e;background:#1c1508}
+.badge.info{color:#3b82f6;border-color:#1e40af}
 .badge.model{color:#a78bfa;border-color:#5b21b6}
 .badge.limit{color:#06b6d4;border-color:#155e75}
 .badge.neutral{color:#71717a;border-color:#3f3f46}

--- a/web/ui/app.js
+++ b/web/ui/app.js
@@ -1,9 +1,10 @@
-import React, { useEffect, useMemo, useRef, useState } from "https://esm.sh/react@18.3.1";
+import React, { useEffect, useRef, useState } from "https://esm.sh/react@18.3.1";
 import { createRoot } from "https://esm.sh/react-dom@18.3.1/client";
 import htm from "https://esm.sh/htm@3.1.1";
 
 const html = htm.bind(React.createElement);
 const BASE = location.origin;
+const ROUTE_STORAGE_KEY = "leeloo.selectedRoute";
 
 function routeLabel(id) {
   return id.replace("pool:", "").replace("provider:", "").replace("/", " / ");
@@ -93,7 +94,7 @@ function Composer({ input, setInput, onSend, disabled }) {
 
 function App() {
   const [groups, setGroups] = useState([]);
-  const [selectedRoute, setSelectedRoute] = useState("");
+  const [selectedRoute, setSelectedRoute] = useState(() => localStorage.getItem(ROUTE_STORAGE_KEY) || "");
   const [health, setHealth] = useState(null);
   const [quota, setQuota] = useState(null);
   const [messages, setMessages] = useState([]);
@@ -107,7 +108,13 @@ function App() {
   useEffect(() => {
     loadRouting();
     loadInfo();
+    const timer = setInterval(() => loadInfo(true), 15000);
+    return () => clearInterval(timer);
   }, []);
+
+  useEffect(() => {
+    if (selectedRoute) localStorage.setItem(ROUTE_STORAGE_KEY, selectedRoute);
+  }, [selectedRoute]);
 
   useEffect(() => {
     const el = chatRef.current;
@@ -119,24 +126,29 @@ function App() {
       const data = await fetch(`${BASE}/v1/routing`).then((r) => r.json());
       const gs = data?.groups || [];
       setGroups(gs);
-      const first = gs.flatMap((g) => g.items || [])[0]?.id || "";
-      setSelectedRoute((prev) => prev || first);
-      setStatus({ kind: "", text: `${gs.flatMap((g) => g.items || []).length} routes` });
+      const flat = gs.flatMap((g) => g.items || []);
+      const first = flat[0]?.id || "";
+      const available = new Set(flat.map((x) => x.id));
+      setSelectedRoute((prev) => (prev && available.has(prev) ? prev : first));
+      setStatus({ kind: "", text: `${flat.length} routes` });
     } catch (e) {
       setStatus({ kind: "error", text: `routing failed: ${e.message}` });
     }
   }
 
-  async function loadInfo() {
+  async function loadInfo(silent = false) {
     try {
-      const [h, q] = await Promise.all([
+      const [healthRes, quotaRes] = await Promise.allSettled([
         fetch(`${BASE}/health`).then((r) => r.json()),
         fetch(`${BASE}/v1/quota`).then((r) => r.json()),
       ]);
-      setHealth(h);
-      setQuota(q);
+      if (healthRes.status === "fulfilled") setHealth(healthRes.value);
+      if (quotaRes.status === "fulfilled") setQuota(quotaRes.value);
+      if (!silent && healthRes.status === "rejected" && quotaRes.status === "rejected") {
+        setStatus({ kind: "error", text: "health/quota unavailable" });
+      }
     } catch {
-      // best-effort
+      if (!silent) setStatus({ kind: "error", text: "health/quota unavailable" });
     }
   }
 
@@ -169,6 +181,18 @@ function App() {
     let xProvider = "";
     let xModel = "";
     let xLabel = "";
+    let flushScheduled = false;
+
+    const flushAssistant = () => {
+      if (flushScheduled) return;
+      flushScheduled = true;
+      requestAnimationFrame(() => {
+        flushScheduled = false;
+        setMessages((prev) => prev.map((m) =>
+          m.id === aid ? { ...m, content: full, thinking: false } : m
+        ));
+      });
+    };
 
     try {
       const resp = await fetch(`${BASE}/v1/chat/completions`, {
@@ -210,18 +234,14 @@ function App() {
           const d = j.choices?.[0]?.delta;
           if (d?.content) {
             full += d.content;
-            setMessages((prev) => prev.map((m) =>
-              m.id === aid ? { ...m, content: full, thinking: false } : m
-            ));
+            flushAssistant();
           }
 
           if (d?.tool_calls?.length) {
             const tc = d.tool_calls[0];
             const textPart = `\n[Tool call: ${tc?.function?.name || "?"}]\n`;
             full += textPart;
-            setMessages((prev) => prev.map((m) =>
-              m.id === aid ? { ...m, content: full, thinking: false } : m
-            ));
+            flushAssistant();
           }
 
           if (j.usage) usage = j.usage;

--- a/web/ui/app.js
+++ b/web/ui/app.js
@@ -1,40 +1,72 @@
-import React, { useEffect, useRef, useState } from "https://esm.sh/react@18.3.1";
+import React, { useCallback, useEffect, useRef, useState } from "https://esm.sh/react@18.3.1";
 import { createRoot } from "https://esm.sh/react-dom@18.3.1/client";
 import htm from "https://esm.sh/htm@3.1.1";
+import { marked } from "https://esm.sh/marked@12.0.2";
+import hljs from "https://esm.sh/highlight.js@11.9.0/lib/core";
+import javascript from "https://esm.sh/highlight.js@11.9.0/lib/languages/javascript";
+import python from "https://esm.sh/highlight.js@11.9.0/lib/languages/python";
+import bash from "https://esm.sh/highlight.js@11.9.0/lib/languages/bash";
+import typescript from "https://esm.sh/highlight.js@11.9.0/lib/languages/typescript";
+import json from "https://esm.sh/highlight.js@11.9.0/lib/languages/json";
+import css from "https://esm.sh/highlight.js@11.9.0/lib/languages/css";
+import xml from "https://esm.sh/highlight.js@11.9.0/lib/languages/xml";
+import rust from "https://esm.sh/highlight.js@11.9.0/lib/languages/rust";
+import cpp from "https://esm.sh/highlight.js@11.9.0/lib/languages/cpp";
+
+hljs.registerLanguage("javascript", javascript);
+hljs.registerLanguage("js", javascript);
+hljs.registerLanguage("python", python);
+hljs.registerLanguage("py", python);
+hljs.registerLanguage("bash", bash);
+hljs.registerLanguage("sh", bash);
+hljs.registerLanguage("typescript", typescript);
+hljs.registerLanguage("ts", typescript);
+hljs.registerLanguage("json", json);
+hljs.registerLanguage("css", css);
+hljs.registerLanguage("html", xml);
+hljs.registerLanguage("xml", xml);
+hljs.registerLanguage("rust", rust);
+hljs.registerLanguage("cpp", cpp);
+hljs.registerLanguage("c", cpp);
+
+marked.setOptions({
+  highlight(code, lang) {
+    if (lang && hljs.getLanguage(lang)) return hljs.highlight(code, { language: lang }).value;
+    return hljs.highlightAuto(code).value;
+  },
+  breaks: true,
+  gfm: true,
+});
 
 const html = htm.bind(React.createElement);
 const BASE = location.origin;
-const ROUTE_STORAGE_KEY = "leeloo.selectedRoute";
+const ROUTE_KEY = "leeloo.route";
 
-function routeLabel(id) {
-  return id.replace("pool:", "").replace("provider:", "").replace("/", " / ");
-}
+function esc(s) { const d = document.createElement("div"); d.textContent = s; return d.innerHTML; }
 
-function quotaClass(score) {
-  if (score == null) return "pill";
-  if (score > 50) return "pill ok";
-  if (score > 20) return "pill warn";
-  return "pill bad";
-}
+function routeLabel(id) { return id.replace("pool:", "").replace("provider:", "").replace("/", " / "); }
 
-function TopBar({ groups, selectedRoute, setSelectedRoute, onClear, status, loading }) {
+function qColor(s) { return s == null ? "#3f3f46" : s > 50 ? "#22c55e" : s > 20 ? "#eab308" : "#ef4444"; }
+
+// ── Components ──
+
+function TopBar({ groups, route, setRoute, onClear, status, busy }) {
   return html`
     <div className="topbar">
-      <div className="title">Leeloo</div>
-      <select
-        className="route-select"
-        value=${selectedRoute || ""}
-        onChange=${(e) => setSelectedRoute(e.target.value)}
-        disabled=${loading || groups.length === 0}
-      >
+      <div className="logo">
+        <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
+        Leeloo
+      </div>
+      <select className="route-select" value=${route} onChange=${(e) => setRoute(e.target.value)} disabled=${busy || !groups.length}>
         ${groups.map((g) => html`
           <optgroup key=${g.label} label=${g.label}>
-            ${g.items.map((it) => html`<option key=${it.id} value=${it.id}>${it.name}</option>`) }
+            ${g.items.map((it) => html`<option key=${it.id} value=${it.id}>${it.name}</option>`)}
           </optgroup>
         `)}
       </select>
-      <button className="btn" onClick=${onClear} disabled=${loading}>Clear</button>
+      <button className="btn" onClick=${onClear} disabled=${busy}>Clear</button>
       <a className="btn" href="/admin">Admin</a>
+      <div className="spacer" />
       <div className=${`status ${status.kind}`}>${status.text}</div>
     </div>
   `;
@@ -45,205 +77,184 @@ function InfoStrip({ health, quota }) {
   const exhausted = new Set(health?.exhausted || []);
   return html`
     <div className="info-strip">
-      <span>Pools: ${health?.pools?.length || 0}</span>
-      <span>Presets: ${health?.presets?.length || 0}</span>
-      <span>Providers: ${health?.providers?.length || 0}</span>
-      ${providers.map((p) => html`
-        <span key=${p.provider} className=${quotaClass(p.score)}>
-          ${p.label || p.provider}: ${p.score == null ? "?" : `${p.score}%`}
-          ${exhausted.has(p.provider) ? " (exhausted)" : ""}
-        </span>
-      `)}
+      <span>${health?.pools?.length || 0} pools</span>
+      <span>${health?.presets?.length || 0} presets</span>
+      <span>${health?.providers?.length || 0} providers</span>
+      ${providers.map((p) => {
+        const pct = p.score ?? 0;
+        const exh = exhausted.has(p.provider);
+        return html`
+          <span key=${p.provider} className="quota-chip">
+            ${p.label || p.provider}
+            <span className="quota-bar"><span className="quota-fill" style=${{ width: `${pct}%`, background: qColor(p.score) }} /></span>
+            <span style=${{ color: qColor(p.score) }}>${p.score == null ? "?" : `${p.score}%`}</span>
+            ${exh ? html`<span style=${{ color: "#ef4444" }}> exh</span>` : null}
+          </span>
+        `;
+      })}
     </div>
   `;
 }
 
+function Markdown({ content }) {
+  const ref = useRef(null);
+  useEffect(() => {
+    if (!ref.current) return;
+    ref.current.innerHTML = marked.parse(content || "");
+    ref.current.querySelectorAll("pre").forEach((pre) => {
+      if (pre.querySelector(".copy-btn")) return;
+      const btn = document.createElement("button");
+      btn.className = "copy-btn";
+      btn.textContent = "Copy";
+      btn.onclick = () => {
+        const code = pre.querySelector("code")?.textContent || pre.textContent;
+        navigator.clipboard.writeText(code);
+        btn.textContent = "Copied!";
+        btn.classList.add("copied");
+        setTimeout(() => { btn.textContent = "Copy"; btn.classList.remove("copied"); }, 1500);
+      };
+      pre.style.position = "relative";
+      pre.appendChild(btn);
+    });
+  }, [content]);
+  return html`<div ref=${ref} />`;
+}
+
 function MessageCard({ m }) {
+  const isUser = m.role === "user";
   return html`
     <div className=${`msg ${m.role}`}>
-      <div className=${`body ${m.error ? "error" : ""}`}>
-        ${m.thinking ? html`<span className="thinking"><span className="dots"><span>.</span><span>.</span><span>.</span></span> Thinking...</span>` : m.content}
+      <div className=${`msg-header ${m.role}`}>${isUser ? "You" : "Assistant"}</div>
+      <div className=${`msg-body ${m.error ? "error" : ""}`}>
+        ${m.thinking
+          ? html`<div className="thinking"><div className="thinking-dots"><span /><span /><span /></div> Thinking...</div>`
+          : isUser
+            ? html`<div style=${{ whiteSpace: "pre-wrap" }}>${m.content}</div>`
+            : html`<${Markdown} content=${m.content} />`
+        }
       </div>
-      ${m.meta ? html`<div className="meta">${m.meta}</div>` : null}
+      ${m.meta ? html`
+        <div className="msg-meta">
+          ${m.metaParts?.map((p, i) => html`<span key=${i} className=${`meta-tag ${p.type}`}>${p.text}</span>`)}
+        </div>
+      ` : null}
     </div>
   `;
 }
 
 function Composer({ input, setInput, onSend, disabled }) {
+  const ref = useRef(null);
+
+  const autoResize = useCallback(() => {
+    const el = ref.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = Math.min(el.scrollHeight, 200) + "px";
+  }, []);
+
+  useEffect(() => { autoResize(); }, [input]);
+
   return html`
     <div className="composer">
-      <div style=${{ flex: 1 }}>
-        <textarea
-          value=${input}
-          onInput=${(e) => setInput(e.target.value)}
-          placeholder="Ask something..."
-          disabled=${disabled}
-          onKeyDown=${(e) => {
-            if (e.key === "Enter" && !e.shiftKey) {
-              e.preventDefault();
-              onSend();
-            }
-          }}
-        />
-        <div className="footer-note">Enter to send, Shift+Enter for newline.</div>
+      <div className="composer-inner">
+        <div className="composer-wrap">
+          <textarea
+            ref=${ref}
+            value=${input}
+            onInput=${(e) => setInput(e.target.value)}
+            placeholder="Message Leeloo..."
+            disabled=${disabled}
+            rows="1"
+            onKeyDown=${(e) => {
+              if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); onSend(); }
+            }}
+          />
+        </div>
+        <button className="btn send" onClick=${onSend} disabled=${disabled || !input.trim()}>
+          Send
+        </button>
       </div>
-      <button className="btn" onClick=${onSend} disabled=${disabled || !input.trim()}>Send</button>
     </div>
   `;
 }
 
+// ── App ──
+
 function App() {
   const [groups, setGroups] = useState([]);
-  const [selectedRoute, setSelectedRoute] = useState(() => localStorage.getItem(ROUTE_STORAGE_KEY) || "");
+  const [route, setRoute] = useState(() => localStorage.getItem(ROUTE_KEY) || "");
   const [health, setHealth] = useState(null);
   const [quota, setQuota] = useState(null);
   const [messages, setMessages] = useState([]);
   const [input, setInput] = useState("");
   const [streaming, setStreaming] = useState(false);
   const [status, setStatus] = useState({ kind: "", text: "loading..." });
-
   const chatRef = useRef(null);
   const convoRef = useRef([]);
+  const bottomRef = useRef(null);
 
-  useEffect(() => {
-    loadRouting();
-    loadInfo();
-    const timer = setInterval(() => loadInfo(true), 15000);
-    return () => clearInterval(timer);
-  }, []);
-
-  useEffect(() => {
-    if (selectedRoute) localStorage.setItem(ROUTE_STORAGE_KEY, selectedRoute);
-  }, [selectedRoute]);
-
-  useEffect(() => {
-    const el = chatRef.current;
-    if (el) el.scrollTop = el.scrollHeight;
-  }, [messages]);
+  useEffect(() => { loadRouting(); loadInfo(); const t = setInterval(() => loadInfo(true), 12000); return () => clearInterval(t); }, []);
+  useEffect(() => { if (route) localStorage.setItem(ROUTE_KEY, route); }, [route]);
+  useEffect(() => { bottomRef.current?.scrollIntoView({ behavior: "smooth" }); }, [messages]);
 
   async function loadRouting() {
     try {
-      const data = await fetch(`${BASE}/v1/routing`).then((r) => r.json());
-      const gs = data?.groups || [];
+      const { groups: gs = [] } = await fetch(`${BASE}/v1/routing`).then((r) => r.json());
       setGroups(gs);
       const flat = gs.flatMap((g) => g.items || []);
-      const first = flat[0]?.id || "";
-      const available = new Set(flat.map((x) => x.id));
-      setSelectedRoute((prev) => (prev && available.has(prev) ? prev : first));
+      const ids = new Set(flat.map((x) => x.id));
+      setRoute((prev) => (prev && ids.has(prev) ? prev : flat[0]?.id || ""));
       setStatus({ kind: "", text: `${flat.length} routes` });
-    } catch (e) {
-      setStatus({ kind: "error", text: `routing failed: ${e.message}` });
-    }
+    } catch (e) { setStatus({ kind: "error", text: e.message }); }
   }
 
-  async function loadInfo(silent = false) {
-    try {
-      const [healthRes, quotaRes] = await Promise.allSettled([
-        fetch(`${BASE}/health`).then((r) => r.json()),
-        fetch(`${BASE}/v1/quota`).then((r) => r.json()),
-      ]);
-      if (healthRes.status === "fulfilled") setHealth(healthRes.value);
-      if (quotaRes.status === "fulfilled") setQuota(quotaRes.value);
-      if (!silent && healthRes.status === "rejected" && quotaRes.status === "rejected") {
-        setStatus({ kind: "error", text: "health/quota unavailable" });
-      }
-    } catch {
-      if (!silent) setStatus({ kind: "error", text: "health/quota unavailable" });
-    }
+  async function loadInfo(silent) {
+    const [h, q] = await Promise.allSettled([
+      fetch(`${BASE}/health`).then((r) => r.json()),
+      fetch(`${BASE}/v1/quota`).then((r) => r.json()),
+    ]);
+    if (h.status === "fulfilled") setHealth(h.value);
+    if (q.status === "fulfilled") setQuota(q.value);
   }
 
-  function clearChat() {
-    convoRef.current = [];
-    setMessages([]);
-  }
+  function clearChat() { convoRef.current = []; setMessages([]); }
 
   async function sendMessage() {
     const text = input.trim();
-    if (!text || streaming || !selectedRoute) return;
-
-    const userTurn = { role: "user", content: text };
-    convoRef.current.push(userTurn);
+    if (!text || streaming || !route) return;
+    convoRef.current.push({ role: "user", content: text });
 
     const aid = `a-${Date.now()}-${Math.random().toString(16).slice(2)}`;
-    setMessages((prev) => [
-      ...prev,
-      { id: `u-${Date.now()}`, role: "user", content: text },
-      { id: aid, role: "assistant", content: "", thinking: true },
-    ]);
-
+    setMessages((prev) => [...prev, { id: `u-${Date.now()}`, role: "user", content: text }, { id: aid, role: "assistant", content: "", thinking: true }]);
     setInput("");
     setStreaming(true);
-    setStatus({ kind: "busy", text: "connecting..." });
+    setStatus({ kind: "busy", text: "streaming..." });
 
     const t0 = Date.now();
-    let full = "";
-    let usage = null;
-    let xProvider = "";
-    let xModel = "";
-    let xLabel = "";
-    let flushScheduled = false;
-
-    const flushAssistant = () => {
-      if (flushScheduled) return;
-      flushScheduled = true;
-      requestAnimationFrame(() => {
-        flushScheduled = false;
-        setMessages((prev) => prev.map((m) =>
-          m.id === aid ? { ...m, content: full, thinking: false } : m
-        ));
-      });
-    };
+    let full = "", usage = null, xProvider = "", xModel = "", xLabel = "";
+    let raf = false;
+    const flush = () => { if (raf) return; raf = true; requestAnimationFrame(() => { raf = false; setMessages((p) => p.map((m) => m.id === aid ? { ...m, content: full, thinking: false } : m)); }); };
 
     try {
-      const resp = await fetch(`${BASE}/v1/chat/completions`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          model: selectedRoute,
-          messages: convoRef.current,
-          stream: true,
-        }),
-      });
-
-      if (!resp.ok) {
-        const err = await resp.json().catch(() => ({}));
-        throw new Error(err?.error?.message || `HTTP ${resp.status}`);
-      }
+      const resp = await fetch(`${BASE}/v1/chat/completions`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ model: route, messages: convoRef.current, stream: true }) });
+      if (!resp.ok) { const e = await resp.json().catch(() => ({})); throw new Error(e?.error?.message || `HTTP ${resp.status}`); }
 
       const reader = resp.body.getReader();
       const dec = new TextDecoder();
       let buf = "";
-
       while (true) {
         const { done, value } = await reader.read();
         if (done) break;
-
         buf += dec.decode(value, { stream: true });
-        const lines = buf.split("\n");
-        buf = lines.pop() || "";
-
+        const lines = buf.split("\n"); buf = lines.pop() || "";
         for (const line of lines) {
           if (!line.startsWith("data: ")) continue;
-          const payload = line.slice(6).trim();
-          if (payload === "[DONE]") continue;
-
-          let j;
-          try { j = JSON.parse(payload); }
-          catch { continue; }
-
+          const p = line.slice(6).trim();
+          if (p === "[DONE]") continue;
+          let j; try { j = JSON.parse(p); } catch { continue; }
           const d = j.choices?.[0]?.delta;
-          if (d?.content) {
-            full += d.content;
-            flushAssistant();
-          }
-
-          if (d?.tool_calls?.length) {
-            const tc = d.tool_calls[0];
-            const textPart = `\n[Tool call: ${tc?.function?.name || "?"}]\n`;
-            full += textPart;
-            flushAssistant();
-          }
-
+          if (d?.content) { full += d.content; flush(); }
+          if (d?.tool_calls?.length) { full += `\n**Tool:** \`${d.tool_calls[0]?.function?.name || "?"}\`\n`; flush(); }
           if (j.usage) usage = j.usage;
           if (j.x_provider) xProvider = j.x_provider;
           if (j.x_model) xModel = j.x_model;
@@ -252,58 +263,36 @@ function App() {
       }
 
       convoRef.current.push({ role: "assistant", content: full });
-      const duration = ((Date.now() - t0) / 1000).toFixed(1) + "s";
-      const parts = [];
-      parts.push(routeLabel(selectedRoute));
-      if (xLabel || xProvider) parts.push(`${xLabel || xProvider} / ${xModel}`);
-      if (usage) parts.push(`${usage.prompt_tokens} in / ${usage.completion_tokens} out`);
-      parts.push(duration);
-
-      setMessages((prev) => prev.map((m) =>
-        m.id === aid
-          ? { ...m, content: full || "(empty)", thinking: false, meta: parts.join(" | ") }
-          : m
-      ));
-
+      const dur = ((Date.now() - t0) / 1000).toFixed(1) + "s";
+      const metaParts = [
+        { type: "route", text: routeLabel(route) },
+        ...(xLabel || xProvider ? [{ type: "provider", text: `${xLabel || xProvider} / ${xModel}` }] : []),
+        ...(usage ? [{ type: "tokens", text: `${usage.prompt_tokens} in / ${usage.completion_tokens} out` }] : []),
+        { type: "time", text: dur },
+      ];
+      setMessages((p) => p.map((m) => m.id === aid ? { ...m, content: full || "(empty)", thinking: false, meta: true, metaParts } : m));
       setStatus({ kind: "", text: "done" });
-      loadInfo();
+      loadInfo(true);
     } catch (e) {
       const last = convoRef.current[convoRef.current.length - 1];
-      if (last && last.role === "user" && last.content === text) convoRef.current.pop();
-      setMessages((prev) => prev.map((m) =>
-        m.id === aid
-          ? { ...m, content: `[Error: ${e.message}]`, thinking: false, error: true }
-          : m
-      ));
+      if (last?.role === "user" && last.content === text) convoRef.current.pop();
+      setMessages((p) => p.map((m) => m.id === aid ? { ...m, content: `Error: ${e.message}`, thinking: false, error: true } : m));
       setStatus({ kind: "error", text: e.message });
-    } finally {
-      setStreaming(false);
-    }
+    } finally { setStreaming(false); }
   }
-
-  const hasMessages = messages.length > 0;
 
   return html`
     <div className="app">
-      <${TopBar}
-        groups=${groups}
-        selectedRoute=${selectedRoute}
-        setSelectedRoute=${setSelectedRoute}
-        onClear=${clearChat}
-        status=${status}
-        loading=${streaming}
-      />
+      <${TopBar} groups=${groups} route=${route} setRoute=${setRoute} onClear=${clearChat} status=${status} busy=${streaming} />
       <${InfoStrip} health=${health} quota=${quota} />
       <div className="chat" ref=${chatRef}>
-        ${!hasMessages ? html`<div className="welcome"><h2>Leeloo on multi-pass</h2><p>Start chatting to test routes, pools and rules.</p></div>` : null}
-        ${messages.map((m) => html`<${MessageCard} key=${m.id} m=${m} />`)}
+        <div className="chat-inner">
+          ${!messages.length ? html`<div className="welcome"><h2>Leeloo on multi-pass</h2><p>Send a message to test routing, pools, presets, and rules.</p></div>` : null}
+          ${messages.map((m) => html`<${MessageCard} key=${m.id} m=${m} />`)}
+          <div ref=${bottomRef} />
+        </div>
       </div>
-      <${Composer}
-        input=${input}
-        setInput=${setInput}
-        onSend=${sendMessage}
-        disabled=${streaming}
-      />
+      <${Composer} input=${input} setInput=${setInput} onSend=${sendMessage} disabled=${streaming} />
     </div>
   `;
 }

--- a/web/ui/app.js
+++ b/web/ui/app.js
@@ -1,0 +1,291 @@
+import React, { useEffect, useMemo, useRef, useState } from "https://esm.sh/react@18.3.1";
+import { createRoot } from "https://esm.sh/react-dom@18.3.1/client";
+import htm from "https://esm.sh/htm@3.1.1";
+
+const html = htm.bind(React.createElement);
+const BASE = location.origin;
+
+function routeLabel(id) {
+  return id.replace("pool:", "").replace("provider:", "").replace("/", " / ");
+}
+
+function quotaClass(score) {
+  if (score == null) return "pill";
+  if (score > 50) return "pill ok";
+  if (score > 20) return "pill warn";
+  return "pill bad";
+}
+
+function TopBar({ groups, selectedRoute, setSelectedRoute, onClear, status, loading }) {
+  return html`
+    <div className="topbar">
+      <div className="title">Leeloo</div>
+      <select
+        className="route-select"
+        value=${selectedRoute || ""}
+        onChange=${(e) => setSelectedRoute(e.target.value)}
+        disabled=${loading || groups.length === 0}
+      >
+        ${groups.map((g) => html`
+          <optgroup key=${g.label} label=${g.label}>
+            ${g.items.map((it) => html`<option key=${it.id} value=${it.id}>${it.name}</option>`) }
+          </optgroup>
+        `)}
+      </select>
+      <button className="btn" onClick=${onClear} disabled=${loading}>Clear</button>
+      <a className="btn" href="/admin">Admin</a>
+      <div className=${`status ${status.kind}`}>${status.text}</div>
+    </div>
+  `;
+}
+
+function InfoStrip({ health, quota }) {
+  const providers = quota?.providers || [];
+  const exhausted = new Set(health?.exhausted || []);
+  return html`
+    <div className="info-strip">
+      <span>Pools: ${health?.pools?.length || 0}</span>
+      <span>Presets: ${health?.presets?.length || 0}</span>
+      <span>Providers: ${health?.providers?.length || 0}</span>
+      ${providers.map((p) => html`
+        <span key=${p.provider} className=${quotaClass(p.score)}>
+          ${p.label || p.provider}: ${p.score == null ? "?" : `${p.score}%`}
+          ${exhausted.has(p.provider) ? " (exhausted)" : ""}
+        </span>
+      `)}
+    </div>
+  `;
+}
+
+function MessageCard({ m }) {
+  return html`
+    <div className=${`msg ${m.role}`}>
+      <div className=${`body ${m.error ? "error" : ""}`}>
+        ${m.thinking ? html`<span className="thinking"><span className="dots"><span>.</span><span>.</span><span>.</span></span> Thinking...</span>` : m.content}
+      </div>
+      ${m.meta ? html`<div className="meta">${m.meta}</div>` : null}
+    </div>
+  `;
+}
+
+function Composer({ input, setInput, onSend, disabled }) {
+  return html`
+    <div className="composer">
+      <div style=${{ flex: 1 }}>
+        <textarea
+          value=${input}
+          onInput=${(e) => setInput(e.target.value)}
+          placeholder="Ask something..."
+          disabled=${disabled}
+          onKeyDown=${(e) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault();
+              onSend();
+            }
+          }}
+        />
+        <div className="footer-note">Enter to send, Shift+Enter for newline.</div>
+      </div>
+      <button className="btn" onClick=${onSend} disabled=${disabled || !input.trim()}>Send</button>
+    </div>
+  `;
+}
+
+function App() {
+  const [groups, setGroups] = useState([]);
+  const [selectedRoute, setSelectedRoute] = useState("");
+  const [health, setHealth] = useState(null);
+  const [quota, setQuota] = useState(null);
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState("");
+  const [streaming, setStreaming] = useState(false);
+  const [status, setStatus] = useState({ kind: "", text: "loading..." });
+
+  const chatRef = useRef(null);
+  const convoRef = useRef([]);
+
+  useEffect(() => {
+    loadRouting();
+    loadInfo();
+  }, []);
+
+  useEffect(() => {
+    const el = chatRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [messages]);
+
+  async function loadRouting() {
+    try {
+      const data = await fetch(`${BASE}/v1/routing`).then((r) => r.json());
+      const gs = data?.groups || [];
+      setGroups(gs);
+      const first = gs.flatMap((g) => g.items || [])[0]?.id || "";
+      setSelectedRoute((prev) => prev || first);
+      setStatus({ kind: "", text: `${gs.flatMap((g) => g.items || []).length} routes` });
+    } catch (e) {
+      setStatus({ kind: "error", text: `routing failed: ${e.message}` });
+    }
+  }
+
+  async function loadInfo() {
+    try {
+      const [h, q] = await Promise.all([
+        fetch(`${BASE}/health`).then((r) => r.json()),
+        fetch(`${BASE}/v1/quota`).then((r) => r.json()),
+      ]);
+      setHealth(h);
+      setQuota(q);
+    } catch {
+      // best-effort
+    }
+  }
+
+  function clearChat() {
+    convoRef.current = [];
+    setMessages([]);
+  }
+
+  async function sendMessage() {
+    const text = input.trim();
+    if (!text || streaming || !selectedRoute) return;
+
+    const userTurn = { role: "user", content: text };
+    convoRef.current.push(userTurn);
+
+    const aid = `a-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    setMessages((prev) => [
+      ...prev,
+      { id: `u-${Date.now()}`, role: "user", content: text },
+      { id: aid, role: "assistant", content: "", thinking: true },
+    ]);
+
+    setInput("");
+    setStreaming(true);
+    setStatus({ kind: "busy", text: "connecting..." });
+
+    const t0 = Date.now();
+    let full = "";
+    let usage = null;
+    let xProvider = "";
+    let xModel = "";
+    let xLabel = "";
+
+    try {
+      const resp = await fetch(`${BASE}/v1/chat/completions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: selectedRoute,
+          messages: convoRef.current,
+          stream: true,
+        }),
+      });
+
+      if (!resp.ok) {
+        const err = await resp.json().catch(() => ({}));
+        throw new Error(err?.error?.message || `HTTP ${resp.status}`);
+      }
+
+      const reader = resp.body.getReader();
+      const dec = new TextDecoder();
+      let buf = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buf += dec.decode(value, { stream: true });
+        const lines = buf.split("\n");
+        buf = lines.pop() || "";
+
+        for (const line of lines) {
+          if (!line.startsWith("data: ")) continue;
+          const payload = line.slice(6).trim();
+          if (payload === "[DONE]") continue;
+
+          let j;
+          try { j = JSON.parse(payload); }
+          catch { continue; }
+
+          const d = j.choices?.[0]?.delta;
+          if (d?.content) {
+            full += d.content;
+            setMessages((prev) => prev.map((m) =>
+              m.id === aid ? { ...m, content: full, thinking: false } : m
+            ));
+          }
+
+          if (d?.tool_calls?.length) {
+            const tc = d.tool_calls[0];
+            const textPart = `\n[Tool call: ${tc?.function?.name || "?"}]\n`;
+            full += textPart;
+            setMessages((prev) => prev.map((m) =>
+              m.id === aid ? { ...m, content: full, thinking: false } : m
+            ));
+          }
+
+          if (j.usage) usage = j.usage;
+          if (j.x_provider) xProvider = j.x_provider;
+          if (j.x_model) xModel = j.x_model;
+          if (j.x_label) xLabel = j.x_label;
+        }
+      }
+
+      convoRef.current.push({ role: "assistant", content: full });
+      const duration = ((Date.now() - t0) / 1000).toFixed(1) + "s";
+      const parts = [];
+      parts.push(routeLabel(selectedRoute));
+      if (xLabel || xProvider) parts.push(`${xLabel || xProvider} / ${xModel}`);
+      if (usage) parts.push(`${usage.prompt_tokens} in / ${usage.completion_tokens} out`);
+      parts.push(duration);
+
+      setMessages((prev) => prev.map((m) =>
+        m.id === aid
+          ? { ...m, content: full || "(empty)", thinking: false, meta: parts.join(" | ") }
+          : m
+      ));
+
+      setStatus({ kind: "", text: "done" });
+      loadInfo();
+    } catch (e) {
+      const last = convoRef.current[convoRef.current.length - 1];
+      if (last && last.role === "user" && last.content === text) convoRef.current.pop();
+      setMessages((prev) => prev.map((m) =>
+        m.id === aid
+          ? { ...m, content: `[Error: ${e.message}]`, thinking: false, error: true }
+          : m
+      ));
+      setStatus({ kind: "error", text: e.message });
+    } finally {
+      setStreaming(false);
+    }
+  }
+
+  const hasMessages = messages.length > 0;
+
+  return html`
+    <div className="app">
+      <${TopBar}
+        groups=${groups}
+        selectedRoute=${selectedRoute}
+        setSelectedRoute=${setSelectedRoute}
+        onClear=${clearChat}
+        status=${status}
+        loading=${streaming}
+      />
+      <${InfoStrip} health=${health} quota=${quota} />
+      <div className="chat" ref=${chatRef}>
+        ${!hasMessages ? html`<div className="welcome"><h2>Leeloo on multi-pass</h2><p>Start chatting to test routes, pools and rules.</p></div>` : null}
+        ${messages.map((m) => html`<${MessageCard} key=${m.id} m=${m} />`)}
+      </div>
+      <${Composer}
+        input=${input}
+        setInput=${setInput}
+        onSend=${sendMessage}
+        disabled=${streaming}
+      />
+    </div>
+  `;
+}
+
+createRoot(document.getElementById("app")).render(html`<${App} />`);

--- a/web/ui/app.js
+++ b/web/ui/app.js
@@ -41,6 +41,13 @@ marked.setOptions({
 const html = htm.bind(React.createElement);
 const BASE = location.origin;
 const ROUTE_KEY = "leeloo.route";
+const TOKEN_KEY = "leeloo.token";
+
+function getToken() { return localStorage.getItem(TOKEN_KEY) || ""; }
+function authHeaders() { return { "Content-Type": "application/json", Authorization: `Bearer ${getToken()}` }; }
+function authFetch(url, opts = {}) {
+  return fetch(url, { ...opts, headers: { ...opts.headers, Authorization: `Bearer ${getToken()}` } });
+}
 
 function esc(s) { const d = document.createElement("div"); d.textContent = s; return d.innerHTML; }
 
@@ -199,7 +206,7 @@ function App() {
 
   async function loadRouting() {
     try {
-      const { groups: gs = [] } = await fetch(`${BASE}/v1/routing`).then((r) => r.json());
+      const { groups: gs = [] } = await authFetch(`${BASE}/v1/routing`).then((r) => r.json());
       setGroups(gs);
       const flat = gs.flatMap((g) => g.items || []);
       const ids = new Set(flat.map((x) => x.id));
@@ -211,7 +218,7 @@ function App() {
   async function loadInfo(silent) {
     const [h, q] = await Promise.allSettled([
       fetch(`${BASE}/health`).then((r) => r.json()),
-      fetch(`${BASE}/v1/quota`).then((r) => r.json()),
+      authFetch(`${BASE}/v1/quota`).then((r) => r.json()),
     ]);
     if (h.status === "fulfilled") setHealth(h.value);
     if (q.status === "fulfilled") setQuota(q.value);
@@ -236,7 +243,7 @@ function App() {
     const flush = () => { if (raf) return; raf = true; requestAnimationFrame(() => { raf = false; setMessages((p) => p.map((m) => m.id === aid ? { ...m, content: full, thinking: false } : m)); }); };
 
     try {
-      const resp = await fetch(`${BASE}/v1/chat/completions`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ model: route, messages: convoRef.current, stream: true }) });
+      const resp = await authFetch(`${BASE}/v1/chat/completions`, { method: "POST", headers: authHeaders(), body: JSON.stringify({ model: route, messages: convoRef.current, stream: true }) });
       if (!resp.ok) { const e = await resp.json().catch(() => ({})); throw new Error(e?.error?.message || `HTTP ${resp.status}`); }
 
       const reader = resp.body.getReader();
@@ -297,4 +304,61 @@ function App() {
   `;
 }
 
-createRoot(document.getElementById("app")).render(html`<${App} />`);
+function LoginScreen({ onLogin }) {
+  const [token, setToken] = useState("");
+  const [error, setError] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  async function submit() {
+    if (!token.trim()) return;
+    setBusy(true); setError("");
+    try {
+      const r = await fetch(`${BASE}/v1/auth/verify`, { method: "POST", headers: { Authorization: `Bearer ${token.trim()}` } });
+      const d = await r.json();
+      if (d.valid) { localStorage.setItem(TOKEN_KEY, token.trim()); onLogin(d); }
+      else setError("Invalid token");
+    } catch (e) { setError(e.message); }
+    setBusy(false);
+  }
+
+  return html`
+    <div style=${{ display: "flex", alignItems: "center", justifyContent: "center", height: "100vh", background: "#09090b" }}>
+      <div style=${{ width: "340px", padding: "32px", background: "#18181b", border: "1px solid #27272a", borderRadius: "16px" }}>
+        <h2 style=${{ color: "#f59e0b", fontSize: "18px", fontWeight: 700, marginBottom: "4px" }}>Leeloo</h2>
+        <p style=${{ color: "#52525b", fontSize: "13px", marginBottom: "20px" }}>Enter your API token to continue.</p>
+        <input
+          type="password"
+          value=${token}
+          onInput=${(e) => setToken(e.target.value)}
+          onKeyDown=${(e) => { if (e.key === "Enter") submit(); }}
+          placeholder="Token..."
+          style=${{ width: "100%", marginBottom: "10px" }}
+          autoFocus
+        />
+        ${error ? html`<div style=${{ color: "#ef4444", fontSize: "12px", marginBottom: "8px" }}>${error}</div>` : null}
+        <button className="btn send" onClick=${submit} disabled=${busy} style=${{ width: "100%" }}>${busy ? "Verifying..." : "Login"}</button>
+      </div>
+    </div>
+  `;
+}
+
+function AuthGate() {
+  const [authed, setAuthed] = useState(false);
+  const [checking, setChecking] = useState(true);
+
+  useEffect(() => {
+    const t = getToken();
+    if (!t) { setChecking(false); return; }
+    fetch(`${BASE}/v1/auth/verify`, { method: "POST", headers: { Authorization: `Bearer ${t}` } })
+      .then((r) => r.json())
+      .then((d) => { if (d.valid) setAuthed(true); })
+      .catch(() => {})
+      .finally(() => setChecking(false));
+  }, []);
+
+  if (checking) return html`<div style=${{ display: "flex", alignItems: "center", justifyContent: "center", height: "100vh", background: "#09090b", color: "#52525b" }}>Loading...</div>`;
+  if (!authed) return html`<${LoginScreen} onLogin=${() => setAuthed(true)} />`;
+  return html`<${App} />`;
+}
+
+createRoot(document.getElementById("app")).render(html`<${AuthGate} />`);

--- a/web/ui/app.js
+++ b/web/ui/app.js
@@ -323,16 +323,16 @@ function LoginScreen({ onLogin }) {
 
   return html`
     <div style=${{ display: "flex", alignItems: "center", justifyContent: "center", height: "100vh", background: "#09090b" }}>
-      <div style=${{ width: "340px", padding: "32px", background: "#18181b", border: "1px solid #27272a", borderRadius: "16px" }}>
-        <h2 style=${{ color: "#f59e0b", fontSize: "18px", fontWeight: 700, marginBottom: "4px" }}>Leeloo</h2>
-        <p style=${{ color: "#52525b", fontSize: "13px", marginBottom: "20px" }}>Enter your API token to continue.</p>
+      <div className="login-card">
+        <h2>Leeloo</h2>
+        <p>Enter your API token to continue.</p>
         <input
           type="password"
           value=${token}
           onInput=${(e) => setToken(e.target.value)}
           onKeyDown=${(e) => { if (e.key === "Enter") submit(); }}
           placeholder="Token..."
-          style=${{ width: "100%", marginBottom: "10px" }}
+          style=${{ width: "100%", marginBottom: "12px" }}
           autoFocus
         />
         ${error ? html`<div style=${{ color: "#ef4444", fontSize: "12px", marginBottom: "8px" }}>${error}</div>` : null}

--- a/web/ui/index.html
+++ b/web/ui/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Leeloo UI</title>
+  <link rel="stylesheet" href="/web/ui/styles.css" />
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="/web/ui/app.js"></script>
+</body>
+</html>

--- a/web/ui/index.html
+++ b/web/ui/index.html
@@ -3,8 +3,9 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Leeloo UI</title>
+  <title>Leeloo</title>
   <link rel="stylesheet" href="/web/ui/styles.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css" />
 </head>
 <body>
   <div id="app"></div>

--- a/web/ui/styles.css
+++ b/web/ui/styles.css
@@ -1,0 +1,158 @@
+* { box-sizing: border-box; }
+html, body, #app { height: 100%; margin: 0; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0a0a0a;
+  color: #e0e0e0;
+}
+.app {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border-bottom: 1px solid #222;
+  background: #111;
+}
+.title {
+  font-weight: 700;
+  color: #f90;
+  margin-right: 6px;
+}
+.route-select {
+  min-width: 260px;
+  max-width: 420px;
+  background: #1a1a1a;
+  border: 1px solid #333;
+  color: #ddd;
+  border-radius: 6px;
+  padding: 6px 8px;
+}
+.btn {
+  background: #1a1a1a;
+  color: #ddd;
+  border: 1px solid #333;
+  border-radius: 6px;
+  padding: 6px 10px;
+  cursor: pointer;
+}
+.btn:hover { border-color: #666; }
+.btn:disabled { opacity: 0.6; cursor: not-allowed; }
+.status {
+  margin-left: auto;
+  font-size: 12px;
+  color: #999;
+}
+.status.busy { color: #f9a825; }
+.status.error { color: #ff6b6b; }
+.info-strip {
+  border-bottom: 1px solid #1a1a1a;
+  background: #101010;
+  font-size: 11px;
+  color: #aaa;
+  padding: 8px 14px;
+  display: flex;
+  gap: 18px;
+  align-items: center;
+  overflow-x: auto;
+  white-space: nowrap;
+}
+.pill {
+  display: inline-block;
+  padding: 2px 6px;
+  border-radius: 4px;
+  border: 1px solid #333;
+  background: #151515;
+  color: #bbb;
+}
+.pill.ok { color: #65d665; border-color: #2c4e2c; }
+.pill.warn { color: #f2c14e; border-color: #5a4d24; }
+.pill.bad { color: #f16b6b; border-color: #5a2424; }
+.chat {
+  flex: 1;
+  overflow-y: auto;
+  padding: 18px;
+}
+.welcome {
+  max-width: 900px;
+  margin: 30px auto;
+  color: #888;
+  text-align: center;
+}
+.msg {
+  max-width: 900px;
+  margin: 10px auto;
+  border: 1px solid #222;
+  border-radius: 10px;
+  background: #101010;
+  overflow: hidden;
+}
+.msg.user {
+  border-color: #2e2e2e;
+  background: #151515;
+}
+.msg .body {
+  padding: 12px 14px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.45;
+}
+.msg .meta {
+  padding: 8px 14px;
+  border-top: 1px solid #1d1d1d;
+  color: #888;
+  font-size: 12px;
+}
+.provider-tag {
+  color: #8ecaff;
+  border: 1px solid #244;
+  border-radius: 999px;
+  padding: 1px 8px;
+}
+.error { color: #ff7e7e; }
+.thinking {
+  color: #888;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.dots span {
+  animation: blink 1.2s infinite;
+  opacity: 0.2;
+}
+.dots span:nth-child(2) { animation-delay: 0.15s; }
+.dots span:nth-child(3) { animation-delay: 0.3s; }
+@keyframes blink {
+  0%, 80%, 100% { opacity: 0.2; }
+  40% { opacity: 1; }
+}
+.composer {
+  border-top: 1px solid #222;
+  padding: 12px 14px;
+  background: #111;
+  display: flex;
+  gap: 10px;
+  align-items: flex-end;
+}
+textarea {
+  flex: 1;
+  min-height: 48px;
+  max-height: 200px;
+  resize: vertical;
+  background: #1a1a1a;
+  border: 1px solid #333;
+  color: #eee;
+  border-radius: 8px;
+  padding: 10px 12px;
+  font-family: inherit;
+}
+textarea:focus, .route-select:focus { outline: none; border-color: #f90; }
+.footer-note {
+  font-size: 11px;
+  color: #666;
+  margin-top: 4px;
+}

--- a/web/ui/styles.css
+++ b/web/ui/styles.css
@@ -1,158 +1,98 @@
-* { box-sizing: border-box; }
-html, body, #app { height: 100%; margin: 0; }
-body {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  background: #0a0a0a;
-  color: #e0e0e0;
-}
-.app {
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-}
-.topbar {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 10px 14px;
-  border-bottom: 1px solid #222;
-  background: #111;
-}
-.title {
-  font-weight: 700;
-  color: #f90;
-  margin-right: 6px;
-}
-.route-select {
-  min-width: 260px;
-  max-width: 420px;
-  background: #1a1a1a;
-  border: 1px solid #333;
-  color: #ddd;
-  border-radius: 6px;
-  padding: 6px 8px;
-}
-.btn {
-  background: #1a1a1a;
-  color: #ddd;
-  border: 1px solid #333;
-  border-radius: 6px;
-  padding: 6px 10px;
-  cursor: pointer;
-}
-.btn:hover { border-color: #666; }
-.btn:disabled { opacity: 0.6; cursor: not-allowed; }
-.status {
-  margin-left: auto;
-  font-size: 12px;
-  color: #999;
-}
-.status.busy { color: #f9a825; }
-.status.error { color: #ff6b6b; }
-.info-strip {
-  border-bottom: 1px solid #1a1a1a;
-  background: #101010;
-  font-size: 11px;
-  color: #aaa;
-  padding: 8px 14px;
-  display: flex;
-  gap: 18px;
-  align-items: center;
-  overflow-x: auto;
-  white-space: nowrap;
-}
-.pill {
-  display: inline-block;
-  padding: 2px 6px;
-  border-radius: 4px;
-  border: 1px solid #333;
-  background: #151515;
-  color: #bbb;
-}
-.pill.ok { color: #65d665; border-color: #2c4e2c; }
-.pill.warn { color: #f2c14e; border-color: #5a4d24; }
-.pill.bad { color: #f16b6b; border-color: #5a2424; }
-.chat {
-  flex: 1;
-  overflow-y: auto;
-  padding: 18px;
-}
-.welcome {
-  max-width: 900px;
-  margin: 30px auto;
-  color: #888;
-  text-align: center;
-}
-.msg {
-  max-width: 900px;
-  margin: 10px auto;
-  border: 1px solid #222;
-  border-radius: 10px;
-  background: #101010;
-  overflow: hidden;
-}
-.msg.user {
-  border-color: #2e2e2e;
-  background: #151515;
-}
-.msg .body {
-  padding: 12px 14px;
-  white-space: pre-wrap;
-  word-break: break-word;
-  line-height: 1.45;
-}
-.msg .meta {
-  padding: 8px 14px;
-  border-top: 1px solid #1d1d1d;
-  color: #888;
-  font-size: 12px;
-}
-.provider-tag {
-  color: #8ecaff;
-  border: 1px solid #244;
-  border-radius: 999px;
-  padding: 1px 8px;
-}
-.error { color: #ff7e7e; }
-.thinking {
-  color: #888;
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-}
-.dots span {
-  animation: blink 1.2s infinite;
-  opacity: 0.2;
-}
-.dots span:nth-child(2) { animation-delay: 0.15s; }
-.dots span:nth-child(3) { animation-delay: 0.3s; }
-@keyframes blink {
-  0%, 80%, 100% { opacity: 0.2; }
-  40% { opacity: 1; }
-}
-.composer {
-  border-top: 1px solid #222;
-  padding: 12px 14px;
-  background: #111;
-  display: flex;
-  gap: 10px;
-  align-items: flex-end;
-}
-textarea {
-  flex: 1;
-  min-height: 48px;
-  max-height: 200px;
-  resize: vertical;
-  background: #1a1a1a;
-  border: 1px solid #333;
-  color: #eee;
-  border-radius: 8px;
-  padding: 10px 12px;
-  font-family: inherit;
-}
-textarea:focus, .route-select:focus { outline: none; border-color: #f90; }
-.footer-note {
-  font-size: 11px;
-  color: #666;
-  margin-top: 4px;
-}
+*{box-sizing:border-box;margin:0;padding:0}
+html,body,#app{height:100%}
+body{font-family:Inter,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:#09090b;color:#e4e4e7;font-size:14px;-webkit-font-smoothing:antialiased}
+
+/* layout */
+.app{height:100%;display:flex;flex-direction:column}
+
+/* ── topbar ── */
+.topbar{display:flex;align-items:center;gap:10px;padding:8px 16px;background:#18181b;border-bottom:1px solid #27272a}
+.logo{display:flex;align-items:center;gap:6px;font-weight:700;color:#f59e0b;font-size:15px;white-space:nowrap}
+.logo svg{width:18px;height:18px}
+.route-select{min-width:220px;max-width:360px;background:#27272a;border:1px solid #3f3f46;color:#d4d4d8;border-radius:8px;padding:6px 10px;font-size:13px;appearance:none;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='%2371717a' viewBox='0 0 16 16'%3E%3Cpath d='M8 11L3 6h10z'/%3E%3C/svg%3E");background-repeat:no-repeat;background-position:right 8px center}
+.route-select:focus{outline:none;border-color:#f59e0b}
+.btn{background:#27272a;color:#d4d4d8;border:1px solid #3f3f46;border-radius:8px;padding:6px 12px;font-size:13px;cursor:pointer;text-decoration:none;transition:all .15s}
+.btn:hover{background:#3f3f46;border-color:#52525b;color:#fff}
+.btn:disabled{opacity:.5;cursor:not-allowed}
+.btn.send{background:#f59e0b;color:#000;border-color:#f59e0b;font-weight:600;padding:10px 20px;border-radius:10px}
+.btn.send:hover{background:#fbbf24}
+.btn.send:disabled{background:#78350f;border-color:#78350f;color:#451a03}
+.spacer{flex:1}
+.status{font-size:12px;color:#71717a}
+.status.busy{color:#f59e0b}
+.status.error{color:#ef4444}
+
+/* ── info strip ── */
+.info-strip{display:flex;align-items:center;gap:12px;padding:6px 16px;background:#111113;border-bottom:1px solid #1e1e22;font-size:11px;color:#71717a;overflow-x:auto;white-space:nowrap}
+.quota-chip{display:inline-flex;align-items:center;gap:5px;padding:2px 8px;border-radius:6px;border:1px solid #27272a;background:#18181b}
+.quota-bar{width:40px;height:5px;border-radius:3px;background:#27272a;overflow:hidden;display:inline-block;vertical-align:middle}
+.quota-fill{height:100%;border-radius:3px;transition:width .5s}
+
+/* ── chat area ── */
+.chat{flex:1;overflow-y:auto;scroll-behavior:smooth}
+.chat-inner{max-width:820px;margin:0 auto;padding:20px 16px 40px}
+.welcome{text-align:center;padding:60px 20px;color:#52525b}
+.welcome h2{font-size:22px;font-weight:700;color:#a1a1aa;margin-bottom:8px}
+.welcome p{font-size:14px}
+
+/* ── messages ── */
+.msg{margin-bottom:20px;animation:fadeIn .2s ease}
+@keyframes fadeIn{from{opacity:0;transform:translateY(6px)}to{opacity:1;transform:translateY(0)}}
+.msg-header{display:flex;align-items:center;gap:6px;margin-bottom:6px;font-size:12px;font-weight:600;text-transform:uppercase;letter-spacing:.5px}
+.msg-header.user{color:#60a5fa}
+.msg-header.assistant{color:#a78bfa}
+.msg-body{padding:14px 16px;border-radius:12px;line-height:1.6;word-break:break-word}
+.msg.user .msg-body{background:#1e293b;border:1px solid #1e3a5f;color:#e2e8f0}
+.msg.assistant .msg-body{background:#18181b;border:1px solid #27272a;color:#d4d4d8}
+.msg.assistant .msg-body.error{background:#1c1017;border-color:#7f1d1d;color:#fca5a5}
+
+/* markdown inside assistant */
+.msg-body h1,.msg-body h2,.msg-body h3{margin:12px 0 6px;font-weight:700;color:#fafafa}
+.msg-body h1{font-size:18px}.msg-body h2{font-size:16px}.msg-body h3{font-size:14px}
+.msg-body p{margin:6px 0}
+.msg-body ul,.msg-body ol{margin:6px 0;padding-left:20px}
+.msg-body li{margin:2px 0}
+.msg-body a{color:#60a5fa;text-decoration:underline}
+.msg-body blockquote{border-left:3px solid #3f3f46;padding-left:12px;margin:8px 0;color:#a1a1aa}
+.msg-body strong{color:#fafafa}
+.msg-body em{color:#a1a1aa}
+
+/* code */
+.msg-body code{background:#27272a;padding:1px 5px;border-radius:4px;font-size:13px;font-family:"JetBrains Mono","Fira Code",Menlo,monospace}
+.msg-body pre{position:relative;margin:10px 0;border-radius:8px;overflow:hidden;background:#0d0d0f !important;border:1px solid #27272a}
+.msg-body pre code{display:block;padding:14px 16px;background:transparent !important;white-space:pre;overflow-x:auto;font-size:13px;line-height:1.5}
+.copy-btn{position:absolute;top:6px;right:6px;background:#27272a;color:#a1a1aa;border:1px solid #3f3f46;border-radius:6px;padding:3px 8px;font-size:11px;cursor:pointer;opacity:0;transition:opacity .15s}
+.msg-body pre:hover .copy-btn{opacity:1}
+.copy-btn:hover{color:#fff;background:#3f3f46}
+.copy-btn.copied{color:#22c55e;border-color:#22c55e}
+
+/* meta footer */
+.msg-meta{display:flex;flex-wrap:wrap;gap:8px;margin-top:8px;font-size:11px;color:#52525b}
+.meta-tag{padding:2px 8px;border-radius:999px;border:1px solid #27272a;background:#18181b}
+.meta-tag.route{color:#60a5fa;border-color:#1e3a5f}
+.meta-tag.provider{color:#a78bfa;border-color:#3b1f6e}
+.meta-tag.tokens{color:#71717a}
+.meta-tag.time{color:#71717a}
+
+/* thinking */
+.thinking{display:inline-flex;align-items:center;gap:8px;color:#71717a;padding:4px 0}
+.thinking-dots{display:flex;gap:3px}
+.thinking-dots span{width:6px;height:6px;border-radius:50%;background:#52525b;animation:pulse 1.2s ease infinite}
+.thinking-dots span:nth-child(2){animation-delay:.15s}
+.thinking-dots span:nth-child(3){animation-delay:.3s}
+@keyframes pulse{0%,80%,100%{opacity:.3;transform:scale(.8)}40%{opacity:1;transform:scale(1)}}
+
+/* ── composer ── */
+.composer{padding:12px 16px;background:#18181b;border-top:1px solid #27272a}
+.composer-inner{max-width:820px;margin:0 auto;display:flex;gap:10px;align-items:flex-end}
+.composer-wrap{flex:1;position:relative}
+textarea{width:100%;min-height:48px;max-height:200px;resize:none;background:#27272a;border:1px solid #3f3f46;color:#e4e4e7;border-radius:10px;padding:12px 14px;font-family:inherit;font-size:14px;line-height:1.4;transition:border-color .15s}
+textarea:focus{outline:none;border-color:#f59e0b}
+textarea::placeholder{color:#52525b}
+.hint{font-size:11px;color:#3f3f46;margin-top:4px;text-align:right}
+
+/* scrollbar */
+::-webkit-scrollbar{width:6px;height:6px}
+::-webkit-scrollbar-track{background:transparent}
+::-webkit-scrollbar-thumb{background:#27272a;border-radius:3px}
+::-webkit-scrollbar-thumb:hover{background:#3f3f46}

--- a/web/ui/styles.css
+++ b/web/ui/styles.css
@@ -2,97 +2,104 @@
 html,body,#app{height:100%}
 body{font-family:Inter,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:#09090b;color:#e4e4e7;font-size:14px;-webkit-font-smoothing:antialiased}
 
-/* layout */
 .app{height:100%;display:flex;flex-direction:column}
 
 /* ── topbar ── */
-.topbar{display:flex;align-items:center;gap:10px;padding:8px 16px;background:#18181b;border-bottom:1px solid #27272a}
-.logo{display:flex;align-items:center;gap:6px;font-weight:700;color:#f59e0b;font-size:15px;white-space:nowrap}
-.logo svg{width:18px;height:18px}
-.route-select{min-width:220px;max-width:360px;background:#27272a;border:1px solid #3f3f46;color:#d4d4d8;border-radius:8px;padding:6px 10px;font-size:13px;appearance:none;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='%2371717a' viewBox='0 0 16 16'%3E%3Cpath d='M8 11L3 6h10z'/%3E%3C/svg%3E");background-repeat:no-repeat;background-position:right 8px center}
-.route-select:focus{outline:none;border-color:#f59e0b}
-.btn{background:#27272a;color:#d4d4d8;border:1px solid #3f3f46;border-radius:8px;padding:6px 12px;font-size:13px;cursor:pointer;text-decoration:none;transition:all .15s}
+.topbar{display:flex;align-items:center;gap:10px;padding:10px 16px;background:linear-gradient(180deg,#18181b 0%,#131316 100%);border-bottom:1px solid #27272a}
+.logo{display:flex;align-items:center;gap:8px;font-weight:700;color:#f59e0b;font-size:16px;white-space:nowrap;letter-spacing:-0.3px}
+.logo svg{width:20px;height:20px}
+.route-select{min-width:220px;max-width:360px;background:#27272a;border:1px solid #3f3f46;color:#d4d4d8;border-radius:8px;padding:7px 10px;font-size:13px;appearance:none;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='%2371717a' viewBox='0 0 16 16'%3E%3Cpath d='M8 11L3 6h10z'/%3E%3C/svg%3E");background-repeat:no-repeat;background-position:right 10px center;transition:border-color .15s}
+.route-select:focus{outline:none;border-color:#f59e0b;box-shadow:0 0 0 2px rgba(245,158,11,0.15)}
+.btn{background:#27272a;color:#d4d4d8;border:1px solid #3f3f46;border-radius:8px;padding:7px 14px;font-size:13px;cursor:pointer;text-decoration:none;transition:all .15s;font-weight:500}
 .btn:hover{background:#3f3f46;border-color:#52525b;color:#fff}
 .btn:disabled{opacity:.5;cursor:not-allowed}
-.btn.send{background:#f59e0b;color:#000;border-color:#f59e0b;font-weight:600;padding:10px 20px;border-radius:10px}
-.btn.send:hover{background:#fbbf24}
-.btn.send:disabled{background:#78350f;border-color:#78350f;color:#451a03}
+.btn.send{background:linear-gradient(135deg,#f59e0b,#d97706);color:#000;border:none;font-weight:600;padding:11px 22px;border-radius:12px;box-shadow:0 2px 8px rgba(245,158,11,0.25)}
+.btn.send:hover{background:linear-gradient(135deg,#fbbf24,#f59e0b);box-shadow:0 4px 12px rgba(245,158,11,0.35)}
+.btn.send:disabled{background:#78350f;color:#451a03;box-shadow:none}
 .spacer{flex:1}
-.status{font-size:12px;color:#71717a}
-.status.busy{color:#f59e0b}
+.status{font-size:12px;color:#71717a;font-weight:500}
+.status.busy{color:#f59e0b;animation:pulse-text 1.5s ease infinite}
 .status.error{color:#ef4444}
+@keyframes pulse-text{0%,100%{opacity:1}50%{opacity:.5}}
 
 /* ── info strip ── */
-.info-strip{display:flex;align-items:center;gap:12px;padding:6px 16px;background:#111113;border-bottom:1px solid #1e1e22;font-size:11px;color:#71717a;overflow-x:auto;white-space:nowrap}
-.quota-chip{display:inline-flex;align-items:center;gap:5px;padding:2px 8px;border-radius:6px;border:1px solid #27272a;background:#18181b}
-.quota-bar{width:40px;height:5px;border-radius:3px;background:#27272a;overflow:hidden;display:inline-block;vertical-align:middle}
-.quota-fill{height:100%;border-radius:3px;transition:width .5s}
+.info-strip{display:flex;align-items:center;gap:12px;padding:6px 16px;background:#0c0c0e;border-bottom:1px solid #1a1a1e;font-size:11px;color:#52525b;overflow-x:auto;white-space:nowrap}
+.quota-chip{display:inline-flex;align-items:center;gap:5px;padding:3px 10px;border-radius:8px;border:1px solid #27272a;background:#14141a;transition:border-color .2s}
+.quota-chip:hover{border-color:#3f3f46}
+.quota-bar{width:40px;height:5px;border-radius:3px;background:#1e1e24;overflow:hidden;display:inline-block;vertical-align:middle}
+.quota-fill{height:100%;border-radius:3px;transition:width .6s ease}
 
 /* ── chat area ── */
 .chat{flex:1;overflow-y:auto;scroll-behavior:smooth}
-.chat-inner{max-width:820px;margin:0 auto;padding:20px 16px 40px}
-.welcome{text-align:center;padding:60px 20px;color:#52525b}
-.welcome h2{font-size:22px;font-weight:700;color:#a1a1aa;margin-bottom:8px}
-.welcome p{font-size:14px}
+.chat-inner{max-width:820px;margin:0 auto;padding:24px 16px 60px}
+.welcome{text-align:center;padding:80px 20px}
+.welcome h2{font-size:28px;font-weight:800;background:linear-gradient(135deg,#f59e0b,#f97316);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;margin-bottom:8px}
+.welcome p{font-size:15px;color:#52525b}
 
 /* ── messages ── */
-.msg{margin-bottom:20px;animation:fadeIn .2s ease}
-@keyframes fadeIn{from{opacity:0;transform:translateY(6px)}to{opacity:1;transform:translateY(0)}}
-.msg-header{display:flex;align-items:center;gap:6px;margin-bottom:6px;font-size:12px;font-weight:600;text-transform:uppercase;letter-spacing:.5px}
+.msg{margin-bottom:24px;animation:fadeIn .25s ease}
+@keyframes fadeIn{from{opacity:0;transform:translateY(8px)}to{opacity:1;transform:translateY(0)}}
+.msg-header{display:flex;align-items:center;gap:6px;margin-bottom:6px;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.7px}
 .msg-header.user{color:#60a5fa}
 .msg-header.assistant{color:#a78bfa}
-.msg-body{padding:14px 16px;border-radius:12px;line-height:1.6;word-break:break-word}
-.msg.user .msg-body{background:#1e293b;border:1px solid #1e3a5f;color:#e2e8f0}
-.msg.assistant .msg-body{background:#18181b;border:1px solid #27272a;color:#d4d4d8}
+.msg-body{padding:16px 18px;border-radius:14px;line-height:1.65;word-break:break-word}
+.msg.user .msg-body{background:linear-gradient(135deg,#1e293b,#172033);border:1px solid #1e3a5f;color:#e2e8f0}
+.msg.assistant .msg-body{background:#14141a;border:1px solid #27272a;color:#d4d4d8}
 .msg.assistant .msg-body.error{background:#1c1017;border-color:#7f1d1d;color:#fca5a5}
 
-/* markdown inside assistant */
-.msg-body h1,.msg-body h2,.msg-body h3{margin:12px 0 6px;font-weight:700;color:#fafafa}
+/* markdown */
+.msg-body h1,.msg-body h2,.msg-body h3{margin:14px 0 8px;font-weight:700;color:#fafafa}
 .msg-body h1{font-size:18px}.msg-body h2{font-size:16px}.msg-body h3{font-size:14px}
-.msg-body p{margin:6px 0}
-.msg-body ul,.msg-body ol{margin:6px 0;padding-left:20px}
-.msg-body li{margin:2px 0}
+.msg-body p{margin:8px 0}
+.msg-body ul,.msg-body ol{margin:8px 0;padding-left:22px}
+.msg-body li{margin:3px 0}
 .msg-body a{color:#60a5fa;text-decoration:underline}
-.msg-body blockquote{border-left:3px solid #3f3f46;padding-left:12px;margin:8px 0;color:#a1a1aa}
+.msg-body blockquote{border-left:3px solid #3f3f46;padding-left:14px;margin:10px 0;color:#a1a1aa;font-style:italic}
 .msg-body strong{color:#fafafa}
 .msg-body em{color:#a1a1aa}
+.msg-body hr{border:none;border-top:1px solid #27272a;margin:16px 0}
 
 /* code */
-.msg-body code{background:#27272a;padding:1px 5px;border-radius:4px;font-size:13px;font-family:"JetBrains Mono","Fira Code",Menlo,monospace}
-.msg-body pre{position:relative;margin:10px 0;border-radius:8px;overflow:hidden;background:#0d0d0f !important;border:1px solid #27272a}
-.msg-body pre code{display:block;padding:14px 16px;background:transparent !important;white-space:pre;overflow-x:auto;font-size:13px;line-height:1.5}
-.copy-btn{position:absolute;top:6px;right:6px;background:#27272a;color:#a1a1aa;border:1px solid #3f3f46;border-radius:6px;padding:3px 8px;font-size:11px;cursor:pointer;opacity:0;transition:opacity .15s}
+.msg-body code{background:#1e1e24;padding:2px 6px;border-radius:5px;font-size:13px;font-family:"JetBrains Mono","Fira Code","Cascadia Code",Menlo,monospace;color:#e2e8f0}
+.msg-body pre{position:relative;margin:12px 0;border-radius:10px;overflow:hidden;background:#0d0d0f !important;border:1px solid #27272a}
+.msg-body pre code{display:block;padding:16px 18px;background:transparent !important;white-space:pre;overflow-x:auto;font-size:13px;line-height:1.55;color:#d4d4d8}
+.copy-btn{position:absolute;top:8px;right:8px;background:#27272a;color:#a1a1aa;border:1px solid #3f3f46;border-radius:6px;padding:4px 10px;font-size:11px;cursor:pointer;opacity:0;transition:all .15s;font-weight:500}
 .msg-body pre:hover .copy-btn{opacity:1}
 .copy-btn:hover{color:#fff;background:#3f3f46}
 .copy-btn.copied{color:#22c55e;border-color:#22c55e}
 
 /* meta footer */
-.msg-meta{display:flex;flex-wrap:wrap;gap:8px;margin-top:8px;font-size:11px;color:#52525b}
-.meta-tag{padding:2px 8px;border-radius:999px;border:1px solid #27272a;background:#18181b}
+.msg-meta{display:flex;flex-wrap:wrap;gap:6px;margin-top:10px;font-size:11px;color:#52525b}
+.meta-tag{padding:3px 10px;border-radius:999px;border:1px solid #27272a;background:#14141a;transition:border-color .15s}
+.meta-tag:hover{border-color:#3f3f46}
 .meta-tag.route{color:#60a5fa;border-color:#1e3a5f}
 .meta-tag.provider{color:#a78bfa;border-color:#3b1f6e}
 .meta-tag.tokens{color:#71717a}
 .meta-tag.time{color:#71717a}
 
 /* thinking */
-.thinking{display:inline-flex;align-items:center;gap:8px;color:#71717a;padding:4px 0}
-.thinking-dots{display:flex;gap:3px}
-.thinking-dots span{width:6px;height:6px;border-radius:50%;background:#52525b;animation:pulse 1.2s ease infinite}
+.thinking{display:inline-flex;align-items:center;gap:10px;color:#71717a;padding:4px 0}
+.thinking-dots{display:flex;gap:4px}
+.thinking-dots span{width:7px;height:7px;border-radius:50%;background:#3f3f46;animation:pulse 1.2s ease infinite}
 .thinking-dots span:nth-child(2){animation-delay:.15s}
 .thinking-dots span:nth-child(3){animation-delay:.3s}
-@keyframes pulse{0%,80%,100%{opacity:.3;transform:scale(.8)}40%{opacity:1;transform:scale(1)}}
+@keyframes pulse{0%,80%,100%{opacity:.25;transform:scale(.8)}40%{opacity:1;transform:scale(1.1)}}
 
 /* ── composer ── */
-.composer{padding:12px 16px;background:#18181b;border-top:1px solid #27272a}
-.composer-inner{max-width:820px;margin:0 auto;display:flex;gap:10px;align-items:flex-end}
+.composer{padding:14px 16px;background:linear-gradient(0deg,#18181b 0%,#131316 100%);border-top:1px solid #27272a}
+.composer-inner{max-width:820px;margin:0 auto;display:flex;gap:12px;align-items:flex-end}
 .composer-wrap{flex:1;position:relative}
-textarea{width:100%;min-height:48px;max-height:200px;resize:none;background:#27272a;border:1px solid #3f3f46;color:#e4e4e7;border-radius:10px;padding:12px 14px;font-family:inherit;font-size:14px;line-height:1.4;transition:border-color .15s}
-textarea:focus{outline:none;border-color:#f59e0b}
-textarea::placeholder{color:#52525b}
-.hint{font-size:11px;color:#3f3f46;margin-top:4px;text-align:right}
+textarea{width:100%;min-height:48px;max-height:200px;resize:none;background:#27272a;border:1px solid #3f3f46;color:#e4e4e7;border-radius:12px;padding:12px 16px;font-family:inherit;font-size:14px;line-height:1.5;transition:border-color .15s,box-shadow .15s}
+textarea:focus{outline:none;border-color:#f59e0b;box-shadow:0 0 0 2px rgba(245,158,11,0.1)}
+textarea::placeholder{color:#3f3f46}
 
 /* scrollbar */
 ::-webkit-scrollbar{width:6px;height:6px}
 ::-webkit-scrollbar-track{background:transparent}
 ::-webkit-scrollbar-thumb{background:#27272a;border-radius:3px}
 ::-webkit-scrollbar-thumb:hover{background:#3f3f46}
+
+/* login */
+.login-card{width:360px;padding:36px;background:linear-gradient(135deg,#18181b,#1a1a20);border:1px solid #27272a;border-radius:20px;box-shadow:0 8px 32px rgba(0,0,0,0.5)}
+.login-card h2{color:#f59e0b;font-size:22px;font-weight:800;margin-bottom:4px;letter-spacing:-0.5px}
+.login-card p{color:#52525b;font-size:13px;margin-bottom:24px}


### PR DESCRIPTION
## Leeloo Dallas Multi Pass!

Phase 1 of #10: local proxy mode with OpenAI-compatible endpoint.

A standalone Node.js server that reads pi-multi-pass config and pi's auth storage, then exposes a local OpenAI-compatible API. Point any tool at `http://localhost:4000/v1` and let multi-pass handle the routing.

### Usage

```bash
./leeloo.js [--port 4000]

# Then in your tools:
OPENAI_BASE_URL=http://localhost:4000/v1
```

### Endpoints

| Endpoint | Description |
|---|---|
| `POST /v1/chat/completions` | Chat completions (streaming + non-streaming) |
| `GET /v1/models` | List all available models across providers |
| `GET /health` | Show providers, pools, presets status |

### How it works

1. Reads `~/.pi/agent/multi-pass.json` for subscriptions, pools, chains, presets
2. Uses pi's `AuthStorage` for OAuth token management (auto-refresh)
3. Routes requests through configured providers with pool ordering
4. On rate limits, automatically fails over to the next pool member (up to 5 attempts)
5. Returns everything in OpenAI format (works with any OpenAI-compatible client)

### Tested

- `/health` -- shows all authenticated providers
- `/v1/models` -- lists models from all providers
- `/v1/chat/completions` (non-streaming) -- routed through Anthropic, got response in OpenAI format with usage stats
- Streaming support included

### Prerequisites

Requires pi installed globally. Symlink SDK into node_modules:
```bash
mkdir -p node_modules/@mariozechner
ln -s $(npm root -g)/@mariozechner/pi-coding-agent node_modules/@mariozechner/pi-coding-agent
ln -s $(npm root -g)/@mariozechner/pi-coding-agent/node_modules/@mariozechner/pi-ai node_modules/@mariozechner/pi-ai
```

### What's next (future PRs)

- Phase 2: Usage/quota reading, tray UI
- Phase 3: UI-based rule editing, observability

Ref #10