### PR TITLE
add thinking level map to cloneModels

### DIFF
--- a/extensions/multi-sub.ts
+++ b/extensions/multi-sub.ts
@@ -1881,6 +1881,7 @@ function cloneModels(originalProvider: string, index: number) {
 		name: `${m.name} (#${index})`,
 		api: m.api,
 		reasoning: m.reasoning,
+		thinkingLevelMap: m.thinkingLevelMap ? { ...m.thinkingLevelMap } : undefined,
 		input: m.input as ("text" | "image")[],
 		cost: { ...m.cost },
 		contextWindow: m.contextWindow,


### PR DESCRIPTION
I noticed a little bug when using cloned models after /sub switch.
Some models (in my case openai-codex-2 gpt 5.4 and gpt 5.5) where not showing all thinking modes present in the parent model/provider (openai-codex).
So I checked the code and concluded the thinking map was not currently being passed to the clone.
This PR is a one liner that adds this thinking-map to the cloned models, and it allowed me to select xhigh after implemented.