### PR TITLE
fix(multi-sub): use onDeviceCode for GitHub Copilot login callback

### DIFF
--- a/extensions/multi-sub.ts
+++ b/extensions/multi-sub.ts
@@ -152,8 +152,7 @@ const PROVIDER_TEMPLATES: Record<string, ProviderTemplate> = {
 				name: `GitHub Copilot #${index}`,
 				async login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
 					return loginGitHubCopilot({
-						onAuth: (url: string, instructions?: string) =>
-							callbacks.onAuth({ url, instructions }),
+						onDeviceCode: callbacks.onDeviceCode,
 						onPrompt: callbacks.onPrompt,
 						onProgress: callbacks.onProgress,
 						signal: callbacks.signal,


### PR DESCRIPTION
pi v0.75.5+ changed Copilot OAuth login to require `onDeviceCode` instead of `onAuth`. The multi-sub extension still passed `onAuth`, causing runtime login failures for additional Copilot subscriptions:

Update the GitHub Copilot provider wiring in `extensions/multi-sub.ts` to pass `onDeviceCode: callbacks.onDeviceCode`, keeping existing prompt/progress/signal behaviour unchanged.

This restores compatibility with newer pi OAuth callback contracts.