### PR TITLE
feat: add subscription cycle shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ pi install git:github.com/hjanuschka/pi-multi-pass
 /subs add              Pick a provider, add a subscription
 /login                 Authenticate the new subscription
 /subs switch           Manually switch to another subscription/provider
+ctrl+s                 Cycle to the next authenticated subscription/provider
 /subs limits           Check built-in quota support (Codex + Google)
 /pool create           Group subs into a rotation pool (with strategy selection)
 /pool chain create     Build an ordered fallback chain across pools
@@ -43,6 +44,12 @@ pi install git:github.com/hjanuschka/pi-multi-pass
 When one account hits a rate limit during an assistant turn, multi-pass automatically switches to the next eligible target and retries.
 
 ## Commands
+
+### Keyboard shortcuts
+
+| Shortcut | Action |
+|---|---|
+| `ctrl+s` | Cycle to the next authenticated subscription/provider, preserving the current model ID when available |
 
 ### `/subs` -- Subscription management
 

--- a/extensions/multi-sub.ts
+++ b/extensions/multi-sub.ts
@@ -2838,6 +2838,41 @@ function resolveSwitchTargetModel(
 	return undefined;
 }
 
+async function handleSubsCycle(pi: ExtensionAPI, ctx: ExtensionContext): Promise<void> {
+	const options = getSwitchableProviderOptions(ctx);
+	if (options.length === 0) {
+		const allowedProviderNames = normalizeSwitchAllowedProviderNames(ctx.cwd);
+		const suffix = allowedProviderNames && allowedProviderNames.length > 0
+			? ` for this project restriction (${allowedProviderNames.join(", ")})`
+			: "";
+		ctx.ui.notify(`No authenticated subscriptions are available to cycle${suffix}.`, "info");
+		return;
+	}
+
+	const currentProvider = ctx.model?.provider;
+	const currentIndex = currentProvider
+		? options.findIndex((option) => option.providerName === currentProvider)
+		: -1;
+
+	for (let offset = 1; offset <= options.length; offset += 1) {
+		const selected = options[(Math.max(currentIndex, -1) + offset) % options.length];
+		if (!selected || selected.providerName === currentProvider) continue;
+
+		const nextModel = resolveSwitchTargetModel(ctx, selected.providerName, ctx.model?.id);
+		if (!nextModel) continue;
+
+		const success = await pi.setModel(nextModel);
+		if (!success) {
+			ctx.ui.notify(`Failed to switch to ${selected.label}.`, "error");
+			return;
+		}
+		ctx.ui.notify(`Switched to ${selected.label} (${nextModel.id}).`, "info");
+		return;
+	}
+
+	ctx.ui.notify("No other authenticated subscription with a selectable model is available.", "info");
+}
+
 async function handleSubsSwitch(
 	pi: ExtensionAPI,
 	ctx: ExtensionCommandContext,
@@ -5531,6 +5566,13 @@ export default function multiSub(pi: ExtensionAPI) {
 				}
 			}
 		}
+	});
+
+	pi.registerShortcut("ctrl+s", {
+		description: "Cycle to the next authenticated multi-pass subscription/provider",
+		handler: async (ctx: ExtensionContext) => {
+			await handleSubsCycle(pi, ctx);
+		},
 	});
 
 	// Register /subs command

--- a/tests/subs-switch-check.mjs
+++ b/tests/subs-switch-check.mjs
@@ -89,6 +89,18 @@ function resolveSwitchTargetModel({ providerName, preferredModelId, hasAuth, pro
   return undefined;
 }
 
+function computeNextCyclableProviderName({ providerNames, currentProvider, preferredModelId, canResolveModel }) {
+  const currentIndex = currentProvider ? providerNames.findIndex((providerName) => providerName === currentProvider) : -1;
+
+  for (let offset = 1; offset <= providerNames.length; offset += 1) {
+    const providerName = providerNames[(Math.max(currentIndex, -1) + offset) % providerNames.length];
+    if (!providerName || providerName === currentProvider) continue;
+    if (!canResolveModel(providerName, preferredModelId)) continue;
+    return providerName;
+  }
+  return undefined;
+}
+
 function runAllowedProviderFilteringCheck() {
   const providerNames = getSwitchableProviderNames({
     baseProviders: ["openai-codex"],
@@ -130,7 +142,31 @@ function runFallbackModelCheck() {
   assert.equal(model?.id, "gpt-5.3-codex");
 }
 
+function runCycleNextProviderCheck() {
+  const providerName = computeNextCyclableProviderName({
+    providerNames: ["openai-codex", "openai-codex-2", "openai-codex-3"],
+    currentProvider: "openai-codex-2",
+    preferredModelId: "gpt-5.4",
+    canResolveModel: (providerName) => providerName !== "openai-codex-3",
+  });
+
+  assert.equal(providerName, "openai-codex");
+}
+
+function runCycleFromUnknownProviderCheck() {
+  const providerName = computeNextCyclableProviderName({
+    providerNames: ["openai-codex", "openai-codex-2"],
+    currentProvider: "anthropic",
+    preferredModelId: "gpt-5.4",
+    canResolveModel: () => true,
+  });
+
+  assert.equal(providerName, "openai-codex");
+}
+
 runAllowedProviderFilteringCheck();
 runPreferredModelCheck();
 runFallbackModelCheck();
+runCycleNextProviderCheck();
+runCycleFromUnknownProviderCheck();
 console.log("subs switch checks passed");


### PR DESCRIPTION
## Summary

- add `ctrl+s` shortcut to cycle to the next authenticated multi-pass subscription/provider
- preserve the current model ID when the next provider supports it, otherwise fall back to the provider's first compatible model
- document the shortcut and cover the cycle selection behavior in the switch checks

## Validation

- `for test in tests/*.mjs; do node "$test"; done`
