### PR TITLE
fix: restore authStorage compatibility with pi v0.80.10+

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ pi install git:github.com/hjanuschka/pi-multi-pass
 
 When one account hits a rate limit during an assistant turn, multi-pass automatically switches to the next eligible target and retries.
 
+### OpenAI Codex login flow
+
+Logging in to a Codex subscription (base account or `openai-codex-2` / `openai-codex-3`, …) uses the same OAuth flow as pi itself: pi opens the OpenAI authorization page and captures the callback at `http://localhost:1455/auth/callback` with a local callback server, so the login completes automatically. You can choose between **Browser login** (default) and **Device code login (headless)** when pi prompts you. If port `1455` is already taken, pi falls back to asking you to paste the redirect URL manually.
+
 ## Commands
 
 ### `/subs` -- Subscription management

--- a/extensions/lib/oauth-compat.ts
+++ b/extensions/lib/oauth-compat.ts
@@ -1,0 +1,751 @@
+// ==========================================================================
+// OAuth compatibility shim for pi-multi-pass
+//
+// Provides standalone OAuth functions (loginAnthropic, refreshOpenAICodexToken,
+// etc.) that pi-multi-pass expects, without depending on
+// @earendil-works/pi-ai/oauth runtime exports.
+//
+// Token refresh uses simple fetch() calls. Login flows implement
+// PKCE + local callback server or device-code flows as appropriate.
+// ==========================================================================
+
+import type {
+	OAuthAuthInfo,
+	OAuthCredentials,
+	OAuthDeviceCodeInfo,
+	OAuthLoginCallbacks,
+	OAuthPrompt,
+	OAuthSelectOption,
+	OAuthSelectPrompt,
+	OAuthProviderInterface,
+} from "@earendil-works/pi-ai/oauth";
+
+export type {
+	OAuthAuthInfo,
+	OAuthCredentials,
+	OAuthDeviceCodeInfo,
+	OAuthLoginCallbacks,
+	OAuthPrompt,
+	OAuthSelectOption,
+	OAuthSelectPrompt,
+	OAuthProviderInterface,
+};
+
+// ==========================================================================
+// PKCE utilities (Web Crypto API)
+// ==========================================================================
+
+async function generatePKCE(): Promise<{ verifier: string; challenge: string }> {
+	const verifierBytes = new Uint8Array(32);
+	crypto.getRandomValues(verifierBytes);
+	const verifier = base64url(verifierBytes);
+	const hash = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(verifier));
+	const challenge = base64url(new Uint8Array(hash));
+	return { verifier, challenge };
+}
+
+function base64url(bytes: Uint8Array): string {
+	return btoa(String.fromCharCode(...bytes))
+		.replace(/\+/g, "-")
+		.replace(/\//g, "_")
+		.replace(/=+$/, "");
+}
+
+function createState(): string {
+	const bytes = new Uint8Array(16);
+	crypto.getRandomValues(bytes);
+	return Array.from(bytes)
+		.map((b) => b.toString(16).padStart(2, "0"))
+		.join("");
+}
+
+// ==========================================================================
+// Token refresh implementations (simple fetch calls)
+// ==========================================================================
+
+// --- Anthropic ---
+
+const ANTHROPIC_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+const ANTHROPIC_TOKEN_URL = "https://platform.claude.com/v1/oauth/token";
+const ANTHROPIC_AUTHORIZE_URL = "https://claude.ai/oauth/authorize";
+const ANTHROPIC_SCOPES = "org:create_api_key user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload";
+const ANTHROPIC_CALLBACK_PORT = 53692;
+const ANTHROPIC_REDIRECT_URI = `http://localhost:${ANTHROPIC_CALLBACK_PORT}/callback`;
+
+export async function refreshAnthropicToken(refreshToken: string): Promise<OAuthCredentials> {
+	const response = await fetch(ANTHROPIC_TOKEN_URL, {
+		method: "POST",
+		headers: { "Content-Type": "application/x-www-form-urlencoded" },
+		body: new URLSearchParams({
+			grant_type: "refresh_token",
+			refresh_token: refreshToken,
+			client_id: ANTHROPIC_CLIENT_ID,
+		}),
+	});
+	if (!response.ok) {
+		const text = await response.text().catch(() => "");
+		throw new Error(`Anthropic token refresh failed (${response.status}): ${text || response.statusText}`);
+	}
+	const data = await response.json() as { access_token?: string; refresh_token?: string; expires_in?: number };
+	if (!data.access_token || !data.refresh_token) {
+		throw new Error("Anthropic token refresh returned invalid response");
+	}
+	return {
+		type: "oauth",
+		access: data.access_token,
+		refresh: data.refresh_token,
+		expires: Date.now() + (data.expires_in || 3600) * 1000 - 300000,
+	};
+}
+
+export const anthropicOAuthProvider: OAuthProviderInterface = {
+	name: "Anthropic (Claude Pro/Max)",
+	async login(callbacks) { return loginAnthropic(callbacks); },
+	async refreshToken(credentials) { return refreshAnthropicToken(credentials.refresh); },
+	getApiKey(credentials) { return credentials.access; },
+};
+
+// --- OpenAI Codex ---
+
+const CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
+const CODEX_AUTH_BASE_URL = "https://auth.openai.com";
+const CODEX_TOKEN_URL = `${CODEX_AUTH_BASE_URL}/oauth/token`;
+const CODEX_REDIRECT_URI = "http://localhost:1455/auth/callback";
+const CODEX_DEVICE_USER_CODE_URL = `${CODEX_AUTH_BASE_URL}/api/accounts/deviceauth/usercode`;
+const CODEX_DEVICE_TOKEN_URL = `${CODEX_AUTH_BASE_URL}/api/accounts/deviceauth/token`;
+const CODEX_DEVICE_VERIFICATION_URI = `${CODEX_AUTH_BASE_URL}/codex/device`;
+
+export async function refreshOpenAICodexToken(refreshToken: string): Promise<OAuthCredentials> {
+	const response = await fetch(CODEX_TOKEN_URL, {
+		method: "POST",
+		headers: { "Content-Type": "application/x-www-form-urlencoded" },
+		body: new URLSearchParams({
+			grant_type: "refresh_token",
+			refresh_token: refreshToken,
+			client_id: CODEX_CLIENT_ID,
+		}),
+	});
+	if (!response.ok) {
+		const text = await response.text().catch(() => "");
+		throw new Error(`OpenAI Codex token refresh failed (${response.status}): ${text || response.statusText}`);
+	}
+	const data = await response.json() as { access_token?: string; refresh_token?: string; expires_in?: number };
+	if (!data.access_token || !data.refresh_token) {
+		throw new Error("OpenAI Codex token refresh returned invalid response");
+	}
+	return {
+		type: "oauth",
+		access: data.access_token,
+		refresh: data.refresh_token,
+		expires: Date.now() + (data.expires_in || 3600) * 1000 - 300000,
+	};
+}
+
+export const openaiCodexOAuthProvider: OAuthProviderInterface = {
+	name: "ChatGPT Plus/Pro (Codex)",
+	usesCallbackServer: true,
+	async login(callbacks) { return loginOpenAICodex(callbacks); },
+	async refreshToken(credentials) { return refreshOpenAICodexToken(credentials.refresh); },
+	getApiKey(credentials) { return credentials.access; },
+};
+
+// --- GitHub Copilot ---
+
+const COPILOT_CLIENT_ID = "Iv1.b507a08c87ecef98";
+const COPILOT_USER_AGENT = "GitHubCopilotChat/0.35.0";
+const COPILOT_API_VERSION = "2026-06-01";
+
+function normalizeDomain(input: string): string | null {
+	const trimmed = (input || "").trim();
+	if (!trimmed) return null;
+	try {
+		const url = trimmed.includes("://") ? new URL(trimmed) : new URL(`https://${trimmed}`);
+		return url.hostname;
+	} catch { return null; }
+}
+
+function getBaseUrlFromToken(token: string): string | null {
+	const match = token.match(/proxy-ep=([^;]+)/);
+	if (!match) return null;
+	return `https://${match[1].replace(/^proxy\./, "api.")}`;
+}
+
+function getGitHubCopilotBaseUrl(token: string, enterpriseDomain?: string): string {
+	if (token) {
+		const fromToken = getBaseUrlFromToken(token);
+		if (fromToken) return fromToken;
+	}
+	if (enterpriseDomain) return `https://copilot-api.${enterpriseDomain}`;
+	return "https://api.individual.githubcopilot.com";
+}
+
+export { normalizeDomain, getGitHubCopilotBaseUrl };
+
+export async function refreshGitHubCopilotToken(refreshToken: string, enterpriseDomain?: string): Promise<OAuthCredentials> {
+	const domain = enterpriseDomain || "github.com";
+	const response = await fetch(`https://${domain}/login/oauth/access_token`, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			"Accept": "application/json",
+			"User-Agent": COPILOT_USER_AGENT,
+			"Editor-Version": "vscode/1.107.0",
+			"Editor-Plugin-Version": "copilot-chat/0.35.0",
+			"Copilot-Integration-Id": "vscode-chat",
+			"X-GitHub-Api-Version": COPILOT_API_VERSION,
+		},
+		body: JSON.stringify({ client_id: COPILOT_CLIENT_ID, refresh_token: refreshToken, grant_type: "refresh_token" }),
+	});
+	if (!response.ok) {
+		const text = await response.text().catch(() => "");
+		throw new Error(`GitHub Copilot token refresh failed (${response.status}): ${text || response.statusText}`);
+	}
+	const data = await response.json() as { access_token?: string; refresh_token?: string; expires_in?: number; token_type?: string };
+	if (!data.access_token) {
+		throw new Error("GitHub Copilot token refresh returned invalid response");
+	}
+	return {
+		type: "oauth",
+		access: data.access_token,
+		refresh: data.refresh_token || refreshToken,
+		expires: Date.now() + (data.expires_in || 3600) * 1000 - 300000,
+		...(enterpriseDomain ? { enterpriseUrl: enterpriseDomain } : {}),
+	} as OAuthCredentials & { enterpriseUrl?: string };
+}
+
+export const githubCopilotOAuthProvider: OAuthProviderInterface = {
+	name: "GitHub Copilot",
+	async login(callbacks) { return loginGitHubCopilot(callbacks); },
+	async refreshToken(credentials) {
+		const creds = credentials as OAuthCredentials & { enterpriseUrl?: string };
+		return refreshGitHubCopilotToken(creds.refresh, creds.enterpriseUrl ?? undefined);
+	},
+	getApiKey(credentials) { return credentials.access; },
+};
+
+// ==========================================================================
+// Login flow implementations
+// ==========================================================================
+
+// --- Anthropic login (PKCE + callback server) ---
+
+export async function loginAnthropic(callbacks: Partial<OAuthLoginCallbacks>): Promise<OAuthCredentials> {
+	const { verifier, challenge } = await generatePKCE();
+
+	let server: import("node:http").Server | undefined;
+	let pendingCode: string | undefined;
+	let pendingState: string | undefined;
+
+	const { promise: serverReady, resolve: serverReadyResolve } = Promise.withResolvers<void>();
+
+	import("node:http").then((http) => {
+		server = http.createServer((req, res) => {
+			try {
+				const reqUrl = new URL(req.url || "", `http://127.0.0.1:${ANTHROPIC_CALLBACK_PORT}`);
+				if (reqUrl.pathname !== "/callback") {
+					res.statusCode = 404; res.end("Not found"); return;
+				}
+				if (reqUrl.searchParams.get("state") !== verifier) {
+					res.statusCode = 400; res.end("State mismatch"); return;
+				}
+				const code = reqUrl.searchParams.get("code");
+				if (!code) { res.statusCode = 400; res.end("Missing code"); return; }
+				res.statusCode = 200;
+				res.end("<h1>Anthropic auth complete!</h1><p>You can close this window.</p>");
+				pendingCode = code;
+				pendingState = verifier;
+				server?.close();
+				server = undefined;
+			} catch { res.statusCode = 500; res.end("Error"); }
+		});
+		server.listen(ANTHROPIC_CALLBACK_PORT, "127.0.0.1", () => serverReadyResolve());
+	}).catch((e) => {
+		throw new Error(`Failed to start callback server: ${e.message}`);
+	});
+
+	await serverReady;
+
+	const authUrl = new URL(ANTHROPIC_AUTHORIZE_URL);
+	authUrl.searchParams.set("code", "true");
+	authUrl.searchParams.set("client_id", ANTHROPIC_CLIENT_ID);
+	authUrl.searchParams.set("response_type", "code");
+	authUrl.searchParams.set("redirect_uri", ANTHROPIC_REDIRECT_URI);
+	authUrl.searchParams.set("scope", ANTHROPIC_SCOPES);
+	authUrl.searchParams.set("code_challenge", challenge);
+	authUrl.searchParams.set("code_challenge_method", "S256");
+	authUrl.searchParams.set("state", verifier);
+
+	if (callbacks.onAuth) {
+		callbacks.onAuth({
+			url: authUrl.toString(),
+			instructions: "Complete login in your browser. If on another machine, paste the redirect URL here.",
+		});
+	}
+
+	const timeout = 5 * 60 * 1000;
+	const start = Date.now();
+
+	while (Date.now() - start < timeout) {
+		if (pendingCode) {
+			if (callbacks.onProgress) callbacks.onProgress("Exchanging authorization code for tokens...");
+
+			const exchangeResponse = await fetch(ANTHROPIC_TOKEN_URL, {
+				method: "POST",
+				headers: { "Content-Type": "application/x-www-form-urlencoded" },
+				body: new URLSearchParams({
+					grant_type: "authorization_code",
+					client_id: ANTHROPIC_CLIENT_ID,
+					code: pendingCode,
+					code_verifier: verifier,
+					redirect_uri: ANTHROPIC_REDIRECT_URI,
+				}),
+			});
+			if (!exchangeResponse.ok) {
+				const text = await exchangeResponse.text().catch(() => "");
+				throw new Error(`Token exchange failed (${exchangeResponse.status}): ${text}`);
+			}
+			const data = await exchangeResponse.json() as { access_token?: string; refresh_token?: string; expires_in?: number };
+			if (!data.access_token || !data.refresh_token) throw new Error("Invalid token response");
+			return {
+				type: "oauth",
+				access: data.access_token,
+				refresh: data.refresh_token,
+				expires: Date.now() + (data.expires_in || 3600) * 1000 - 300000,
+			};
+		}
+		await new Promise((r) => setTimeout(r, 500));
+	}
+
+	server?.close();
+	throw new Error("Anthropic login timed out");
+}
+
+// --- OpenAI Codex login ---
+
+const CODEX_JWT_CLAIM_PATH = "https://api.openai.com/auth";
+
+function decodeJwtPayload(token: string): Record<string, unknown> {
+	const parts = token.split(".");
+	if (parts.length !== 3) return {};
+	try {
+		return JSON.parse(Buffer.from(parts[1] ?? "", "base64url").toString("utf8")) as Record<string, unknown>;
+	} catch {
+		return {};
+	}
+}
+
+/** Extract the ChatGPT account id from the access token JWT (like pi's built-in flow). */
+function extractCodexAccountId(token: string): string | undefined {
+	const payload = decodeJwtPayload(token);
+	const auth = payload[CODEX_JWT_CLAIM_PATH];
+	if (auth && typeof auth === "object") {
+		const accountId = (auth as Record<string, unknown>).chatgpt_account_id;
+		if (typeof accountId === "string" && accountId.length > 0) return accountId;
+	}
+	return undefined;
+}
+
+function getCodexCallbackHost(): string {
+	return process.env.PI_OAUTH_CALLBACK_HOST || "127.0.0.1";
+}
+
+/** Parse the code/state out of a pasted redirect URL, query string, or raw code. */
+function parseAuthorizationInput(input: string): { code?: string; state?: string } {
+	const value = (input || "").trim();
+	if (!value) return {};
+
+	try {
+		const url = new URL(value);
+		return {
+			code: url.searchParams.get("code") ?? undefined,
+			state: url.searchParams.get("state") ?? undefined,
+		};
+	} catch {
+		// not a URL
+	}
+
+	if (value.includes("#")) {
+		const [code, state] = value.split("#", 2);
+		return { code, state };
+	}
+
+	if (value.includes("code=")) {
+		const params = new URLSearchParams(value);
+		return {
+			code: params.get("code") ?? undefined,
+			state: params.get("state") ?? undefined,
+		};
+	}
+
+	return { code: value };
+}
+
+async function exchangeCodexAuthorizationCode(
+	code: string,
+	verifier: string,
+	redirectUri: string,
+	signal?: AbortSignal,
+): Promise<OAuthCredentials> {
+	const response = await fetch(CODEX_TOKEN_URL, {
+		method: "POST",
+		headers: { "Content-Type": "application/x-www-form-urlencoded" },
+		body: new URLSearchParams({
+			grant_type: "authorization_code",
+			client_id: CODEX_CLIENT_ID,
+			code,
+			code_verifier: verifier,
+			redirect_uri: redirectUri,
+		}),
+		signal,
+	});
+	if (!response.ok) {
+		const text = await response.text().catch(() => "");
+		throw new Error(`OpenAI Codex token exchange failed (${response.status}): ${text || response.statusText}`);
+	}
+	const data = await response.json() as { access_token?: string; refresh_token?: string; expires_in?: number };
+	if (!data.access_token || !data.refresh_token) {
+		throw new Error("OpenAI Codex token exchange returned an invalid response");
+	}
+	const access = data.access_token;
+	const accountId = extractCodexAccountId(access);
+	return {
+		type: "oauth",
+		access,
+		refresh: data.refresh_token,
+		expires: Date.now() + (data.expires_in || 3600) * 1000 - 300000,
+		...(accountId ? { accountId } : {}),
+	};
+}
+
+type CodexCallbackServerInfo = {
+	close: () => void;
+	cancelWait: () => void;
+	waitForCode: () => Promise<{ code: string } | null>;
+};
+
+/**
+ * Start a local HTTP callback server on port 1455 that captures the OAuth
+ * authorization code, mirroring pi's built-in Codex login. Returns null when
+ * the port is unavailable so the caller can fall back to manual input.
+ */
+function startCodexCallbackServer(state: string, signal?: AbortSignal): Promise<CodexCallbackServerInfo | null> {
+	let settleWait: ((value: { code: string } | null) => void) | undefined;
+	const waitForCodePromise = new Promise<{ code: string } | null>((resolve) => {
+		let settled = false;
+		settleWait = (value) => {
+			if (settled) return;
+			settled = true;
+			resolve(value);
+		};
+	});
+
+	return import("node:http").then((http) => {
+		const server = http.createServer((req, res) => {
+			try {
+				const url = new URL(req.url || "", "http://localhost");
+				if (url.pathname !== "/auth/callback") {
+					res.statusCode = 404;
+					res.setHeader("Content-Type", "text/html; charset=utf-8");
+					res.end("<h1>Callback route not found.</h1>");
+					return;
+				}
+				if (url.searchParams.get("state") !== state) {
+					res.statusCode = 400;
+					res.setHeader("Content-Type", "text/html; charset=utf-8");
+					res.end("<h1>State mismatch.</h1>");
+					return;
+				}
+				const code = url.searchParams.get("code");
+				if (!code) {
+					res.statusCode = 400;
+					res.setHeader("Content-Type", "text/html; charset=utf-8");
+					res.end("<h1>Missing authorization code.</h1>");
+					return;
+				}
+				res.statusCode = 200;
+				res.setHeader("Content-Type", "text/html; charset=utf-8");
+				res.end("<h1>OpenAI authentication completed.</h1><p>You can close this window.</p>");
+				settleWait?.({ code });
+			} catch {
+				res.statusCode = 500;
+				res.setHeader("Content-Type", "text/html; charset=utf-8");
+				res.end("<h1>Internal error while processing OAuth callback.</h1>");
+			}
+		});
+
+		return new Promise<CodexCallbackServerInfo | null>((resolve) => {
+			const onError = () => {
+				settleWait?.(null);
+				resolve(null);
+			};
+			server.once("error", onError);
+			server.listen(1455, getCodexCallbackHost(), () => {
+				server.removeListener("error", onError);
+				resolve({
+					close: () => {
+						try { server.close(); } catch { /* ignore */ }
+					},
+					cancelWait: () => settleWait?.(null),
+					waitForCode: () => waitForCodePromise,
+				});
+			});
+		});
+	}).catch(() => null);
+}
+
+/**
+ * OpenAI Codex login. Mirrors pi's built-in Codex OAuth flow:
+ *  - Asks the user to pick browser login (default) or device-code login.
+ *  - Browser login runs PKCE against the registered redirect URI
+ *    (http://localhost:1455/auth/callback) and captures the callback with a
+ *    local server on port 1455, exactly like pi's built-in flow. If the port
+ *    is unavailable (or the callback never arrives), it falls back to asking
+ *    the user to paste the redirect URL manually.
+ */
+export async function loginOpenAICodex(callbacks: Partial<OAuthLoginCallbacks>): Promise<OAuthCredentials> {
+	let method = "browser";
+	if (callbacks.onSelect) {
+		method = (await callbacks.onSelect({
+			message: "Select OpenAI Codex login method:",
+			options: [
+				{ id: "browser", label: "Browser login (default)" },
+				{ id: "device_code", label: "Device code login (headless)" },
+			],
+		})) ?? "browser";
+	}
+
+	if (method === "device_code") {
+		return loginOpenAICodexDeviceCode(callbacks);
+	}
+	if (method !== "browser") {
+		throw new Error(`Unknown OpenAI Codex login method: ${method}`);
+	}
+
+	const { verifier, challenge } = await generatePKCE();
+	const state = createState();
+
+	const authUrl = new URL("https://auth.openai.com/oauth/authorize");
+	authUrl.searchParams.set("response_type", "code");
+	authUrl.searchParams.set("client_id", CODEX_CLIENT_ID);
+	authUrl.searchParams.set("redirect_uri", CODEX_REDIRECT_URI);
+	authUrl.searchParams.set("scope", "openid profile email offline_access");
+	authUrl.searchParams.set("code_challenge", challenge);
+	authUrl.searchParams.set("code_challenge_method", "S256");
+	authUrl.searchParams.set("state", state);
+	authUrl.searchParams.set("id_token_add_organizations", "true");
+	authUrl.searchParams.set("codex_cli_simplified_flow", "true");
+	authUrl.searchParams.set("originator", "pi");
+
+	// Local callback server on port 1455 so the browser redirect is captured
+	// automatically (same as pi's built-in Codex login).
+	const server = await startCodexCallbackServer(state, callbacks.signal);
+
+	if (callbacks.onAuth) {
+		callbacks.onAuth({
+			url: authUrl.toString(),
+			instructions: server
+				? "A browser window should open. Complete login to finish."
+				: "Port 1455 is busy, so the callback cannot be captured automatically. After logging in, paste the full redirect URL (http://localhost:1455/auth/callback?code=...) back here.",
+		});
+	}
+
+	let code: string | undefined;
+	let aborted = false;
+	const onAbort = () => {
+		aborted = true;
+		server?.cancelWait();
+	};
+	callbacks.signal?.addEventListener("abort", onAbort, { once: true });
+
+	try {
+		if (server) {
+			callbacks.onProgress?.("Waiting for the browser to complete login...");
+			const waitResult = await Promise.race([
+				server.waitForCode(),
+				new Promise<null>((resolve) => setTimeout(() => resolve(null), 120_000)),
+			]);
+			if (waitResult?.code) code = waitResult.code;
+		}
+
+		// Fallback: port busy or callback never arrived — ask for manual paste.
+		if (!code && callbacks.onManualCodeInput) {
+			callbacks.onProgress?.(server
+				? "No callback captured yet — you can also paste the redirect URL here."
+				: "Waiting for you to paste the redirect URL...");
+			const input = await callbacks.onManualCodeInput();
+			const parsed = parseAuthorizationInput(input);
+			if (parsed.state && parsed.state !== state) throw new Error("State mismatch");
+			code = parsed.code;
+		}
+
+		if (aborted) throw new Error("Login cancelled");
+		if (!code) throw new Error("Missing authorization code");
+
+		callbacks.onProgress?.("Exchanging authorization code for tokens...");
+		return await exchangeCodexAuthorizationCode(code, verifier, CODEX_REDIRECT_URI, callbacks.signal);
+	} finally {
+		callbacks.signal?.removeEventListener("abort", onAbort);
+		server?.close();
+	}
+}
+
+async function loginOpenAICodexDeviceCode(callbacks: Partial<OAuthLoginCallbacks>): Promise<OAuthCredentials> {
+	const response = await fetch(CODEX_DEVICE_USER_CODE_URL, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ client_id: CODEX_CLIENT_ID }),
+		signal: callbacks.signal,
+	});
+	if (response.status === 404) {
+		throw new Error("OpenAI Codex device code login is not enabled for this server. Use browser login.");
+	}
+	if (!response.ok) throw new Error(`Device code request failed (${response.status})`);
+	const device = await response.json() as {
+		device_auth_id?: string; user_code?: string; verification_uri?: string;
+		interval?: number; expires_in?: number;
+	};
+	if (!device.device_auth_id || !device.user_code) throw new Error("Invalid device code response");
+
+	if (callbacks.onDeviceCode) {
+		callbacks.onDeviceCode({
+			userCode: device.user_code,
+			verificationUri: device.verification_uri || CODEX_DEVICE_VERIFICATION_URI,
+			intervalSeconds: device.interval || 5,
+			expiresInSeconds: device.expires_in || 900,
+		});
+	}
+
+	const pollInterval = (device.interval || 5) * 1000;
+	const timeout = (device.expires_in || 900) * 1000;
+	const start = Date.now();
+
+	while (Date.now() - start < timeout) {
+		if (callbacks.signal?.aborted) throw new Error("Login cancelled");
+		await new Promise((r) => setTimeout(r, pollInterval));
+		const pollResponse = await fetch(CODEX_DEVICE_TOKEN_URL, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ device_auth_id: device.device_auth_id, user_code: device.user_code }),
+			signal: callbacks.signal,
+		});
+		if (pollResponse.ok) {
+			const data = await pollResponse.json() as { authorization_code?: string; code_verifier?: string };
+			if (data.authorization_code && data.code_verifier) {
+				return await exchangeCodexAuthorizationCode(
+					data.authorization_code,
+					data.code_verifier,
+					"https://auth.openai.com/deviceauth/callback",
+					callbacks.signal,
+				);
+			}
+		}
+	}
+	throw new Error("OpenAI Codex device auth timed out");
+}
+
+// --- GitHub Copilot login (device code flow) ---
+
+export async function loginGitHubCopilot(callbacks: Partial<OAuthLoginCallbacks>): Promise<OAuthCredentials> {
+	const domain = "github.com";
+
+	const deviceResponse = await fetch(`https://${domain}/login/device/code`, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			"Accept": "application/json",
+			"User-Agent": COPILOT_USER_AGENT,
+			"Editor-Version": "vscode/1.107.0",
+			"Editor-Plugin-Version": "copilot-chat/0.35.0",
+			"Copilot-Integration-Id": "vscode-chat",
+		},
+		body: JSON.stringify({ client_id: COPILOT_CLIENT_ID, scope: "read:user" }),
+	});
+	if (!deviceResponse.ok) throw new Error(`Device code request failed (${deviceResponse.status})`);
+	const device = await deviceResponse.json() as {
+		device_code?: string; user_code?: string; verification_uri?: string;
+		interval?: number; expires_in?: number;
+	};
+	if (!device.device_code || !device.user_code) throw new Error("Invalid device code response");
+
+	(callbacks.onAuth as any)(
+		device.verification_uri || `https://${domain}/login/device`,
+		`Your code: ${device.user_code}`,
+	);
+
+	const pollInterval = (device.interval || 5) * 1000;
+	const timeout = (device.expires_in || 900) * 1000;
+	const start = Date.now();
+
+	while (Date.now() - start < timeout) {
+		await new Promise((r) => setTimeout(r, pollInterval));
+		const pollResponse = await fetch(`https://${domain}/login/oauth/access_token`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"Accept": "application/json",
+				"User-Agent": COPILOT_USER_AGENT,
+				"Editor-Version": "vscode/1.107.0",
+				"Editor-Plugin-Version": "copilot-chat/0.35.0",
+				"Copilot-Integration-Id": "vscode-chat",
+			},
+			body: JSON.stringify({
+				client_id: COPILOT_CLIENT_ID,
+				device_code: device.device_code,
+				grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+			}),
+		});
+		if (pollResponse.ok) {
+			const data = await pollResponse.json() as { access_token?: string; refresh_token?: string; expires_in?: number };
+			if (data.access_token) {
+				return {
+					type: "oauth",
+					access: data.access_token,
+					refresh: data.refresh_token || "",
+					expires: Date.now() + (data.expires_in || 3600) * 1000 - 300000,
+				};
+			}
+		}
+	}
+	throw new Error("GitHub Copilot device auth timed out");
+}
+
+// ==========================================================================
+// Removed providers (gemini-cli, antigravity)
+// ==========================================================================
+
+function missingProvider(name: string): never {
+	throw new Error(
+		`Provider "${name}" is no longer bundled with this version of pi-ai. ` +
+		"Please remove it from your pi-multi-pass configuration.",
+	);
+}
+
+export const geminiCliOAuthProvider: OAuthProviderInterface = {
+	name: "Google Cloud Code Assist (removed)",
+	login: () => missingProvider("google-gemini-cli"),
+	refreshToken: () => missingProvider("google-gemini-cli"),
+	getApiKey: () => missingProvider("google-gemini-cli"),
+};
+
+export async function loginGeminiCli(): Promise<never> {
+	return missingProvider("google-gemini-cli");
+}
+
+export async function refreshGoogleCloudToken(): Promise<never> {
+	return missingProvider("google-gemini-cli");
+}
+
+export const antigravityOAuthProvider: OAuthProviderInterface = {
+	name: "Antigravity (removed)",
+	login: () => missingProvider("google-antigravity"),
+	refreshToken: () => missingProvider("google-antigravity"),
+	getApiKey: () => missingProvider("google-antigravity"),
+};
+
+export async function loginAntigravity(): Promise<never> {
+	return missingProvider("google-antigravity");
+}
+
+export async function refreshAntigravityToken(): Promise<never> {
+	return missingProvider("google-antigravity");
+}

--- a/extensions/multi-sub.ts
+++ b/extensions/multi-sub.ts
@@ -65,9 +65,11 @@ import {
 	antigravityOAuthProvider,
 	loginAntigravity,
 	refreshAntigravityToken,
-	type OAuthCredentials,
-	type OAuthLoginCallbacks,
-	type OAuthProviderInterface,
+} from "./lib/oauth-compat.js";
+import type {
+	OAuthCredentials,
+	OAuthLoginCallbacks,
+	OAuthProviderInterface,
 } from "@earendil-works/pi-ai/oauth";
 import { getModels, type Api, type Model } from "@earendil-works/pi-ai";
 import {

--- a/extensions/multi-sub.ts
+++ b/extensions/multi-sub.ts
@@ -45,6 +45,7 @@ import {
 	DynamicBorder,
 	getAgentDir,
 	keyHint,
+	readStoredCredential,
 } from "@earendil-works/pi-coding-agent";
 import {
 	anthropicOAuthProvider,
@@ -77,6 +78,42 @@ import {
 	matchesKey,
 	type SelectItem,
 } from "@earendil-works/pi-tui";
+
+// ==========================================================================
+// AuthStorage backward compatibility helper for pi v0.80.10+
+// ==========================================================================
+
+function getAuthStorage(ctx: {
+	modelRegistry: {
+		getProviderAuthStatus(provider: string): { configured: boolean };
+	};
+}): {
+	hasAuth(provider: string): boolean;
+	get(provider: string): Record<string, unknown> | undefined;
+	logout(provider: string): void;
+} {
+	return {
+		hasAuth(provider: string): boolean {
+			return ctx.modelRegistry.getProviderAuthStatus(provider).configured;
+		},
+		get(provider: string): Record<string, unknown> | undefined {
+			return readStoredCredential(provider) as Record<string, unknown> | undefined;
+		},
+		logout(provider: string): void {
+			try {
+				const authPath = join(getAgentDir(), "auth.json");
+				const raw = readFileSync(authPath, "utf-8");
+				const data = JSON.parse(raw);
+				if (data[provider]) {
+					delete data[provider];
+					writeFileSync(authPath, JSON.stringify(data, null, 2) + "\n", "utf-8");
+				}
+			} catch {
+				// auth.json doesn't exist or can't be read — nothing to logout
+			}
+		},
+	};
+}
 
 // ==========================================================================
 // Provider templates
@@ -1215,12 +1252,12 @@ function collectQuotaAccounts(ctx: ExtensionContext): QuotaAccount[] {
 			providerName,
 			baseProvider: getBaseProvider(providerName) || providerName,
 			displayName,
-			auth: ctx.modelRegistry.authStorage.get(providerName) as AuthStorageEntry | undefined,
+			auth: getAuthStorage(ctx).get(providerName) as AuthStorageEntry | undefined,
 		});
 	};
 
 	for (const checker of PROVIDER_QUOTA_CHECKERS) {
-		if (ctx.modelRegistry.authStorage.hasAuth(checker.baseProvider)) {
+		if (getAuthStorage(ctx).hasAuth(checker.baseProvider)) {
 			pushAccount(
 				checker.baseProvider,
 				PROVIDER_TEMPLATES[checker.baseProvider]?.displayName || checker.baseProvider,
@@ -1740,7 +1777,7 @@ function getProjectScopedProviderNames(
 	}
 
 	for (const providerName of SUPPORTED_PROVIDERS) {
-		if (ctx.modelRegistry.authStorage.hasAuth(providerName)) {
+		if (getAuthStorage(ctx).hasAuth(providerName)) {
 			push(providerName);
 		}
 	}
@@ -1755,7 +1792,7 @@ function findSelectableModelForProvider(
 	providerName: string,
 	preferredModelId?: string,
 ): Model<Api> | undefined {
-	if (!ctx.modelRegistry.authStorage.hasAuth(providerName)) {
+	if (!getAuthStorage(ctx).hasAuth(providerName)) {
 		return undefined;
 	}
 	if (preferredModelId) {
@@ -2496,7 +2533,7 @@ class PoolManager {
 				const best = await this.getQuotaBestMember(
 					pool,
 					currentModel.provider,
-					ctx.modelRegistry.authStorage,
+					getAuthStorage(ctx),
 					cascade.attemptedProviders,
 				);
 				if (best) {
@@ -2659,7 +2696,7 @@ class PoolManager {
 		const plan = this.buildFailoverPlan(
 			currentModel,
 			config,
-			ctx.modelRegistry.authStorage,
+			getAuthStorage(ctx),
 			{
 				attemptedProviders: cascade.attemptedProviders,
 				visitedChainIndexes: cascade.visitedChainIndexes,
@@ -2792,7 +2829,7 @@ function getSwitchableProviderOptions(
 	const seen = new Set<string>();
 	const push = (providerName: string, label: string, description: string) => {
 		if (allowed && !allowed.has(providerName)) return;
-		if (!ctx.modelRegistry.authStorage.hasAuth(providerName)) return;
+		if (!getAuthStorage(ctx).hasAuth(providerName)) return;
 		if (seen.has(providerName)) return;
 		seen.add(providerName);
 		options.push({ providerName, label, description });
@@ -2816,7 +2853,7 @@ function resolveSwitchTargetModel(
 	providerName: string,
 	preferredModelId?: string,
 ): Model<Api> | undefined {
-	if (!ctx.modelRegistry.authStorage.hasAuth(providerName)) {
+	if (!getAuthStorage(ctx).hasAuth(providerName)) {
 		return undefined;
 	}
 	if (preferredModelId) {
@@ -2932,8 +2969,8 @@ async function removeSubscriptionEntry(
 	if (!confirmed) return;
 
 	const name = subProviderName(entry);
-	if (ctx.modelRegistry.authStorage.hasAuth(name)) {
-		ctx.modelRegistry.authStorage.logout(name);
+	if (getAuthStorage(ctx).hasAuth(name)) {
+		getAuthStorage(ctx).logout(name);
 	}
 	pi.unregisterProvider(name);
 
@@ -2973,7 +3010,7 @@ async function showSubscriptionActions(
 			items: [
 				{
 					value: subProviderName(entry),
-					label: formatSubscriptionListLine(entry, config, ctx.modelRegistry.authStorage),
+					label: formatSubscriptionListLine(entry, config, getAuthStorage(ctx)),
 				},
 			],
 			confirmHint: "back",
@@ -2983,7 +3020,7 @@ async function showSubscriptionActions(
 	}
 
 	const name = subProviderName(entry);
-	const hasAuth = ctx.modelRegistry.authStorage.hasAuth(name);
+	const hasAuth = getAuthStorage(ctx).hasAuth(name);
 	const actionItems: SelectItem[] = [
 		{ value: "rename", label: "rename", description: "Change friendly label" },
 		hasAuth
@@ -3012,7 +3049,7 @@ async function showSubscriptionActions(
 		return;
 	}
 	if (action === "logout") {
-		ctx.modelRegistry.authStorage.logout(name);
+		getAuthStorage(ctx).logout(name);
 		ctx.modelRegistry.refresh();
 		ctx.ui.notify(`Logged out of ${subDisplayName(entry)}`, "info");
 		return;
@@ -3045,7 +3082,7 @@ async function handleSubsList(
 			items: all.map((entry) => ({
 				value: subProviderName(entry),
 				label: subDisplayName(entry),
-				description: formatSubscriptionMeta(entry, config, ctx.modelRegistry.authStorage),
+				description: formatSubscriptionMeta(entry, config, getAuthStorage(ctx)),
 			})),
 			initialValue: preferredProviderName,
 			confirmHint: "open",
@@ -3136,7 +3173,7 @@ async function handleSubsRemove(
 		items: config.subscriptions.map((entry) => ({
 			value: subProviderName(entry),
 			label: subDisplayName(entry),
-			description: ctx.modelRegistry.authStorage.hasAuth(subProviderName(entry))
+			description: getAuthStorage(ctx).hasAuth(subProviderName(entry))
 				? "logged in"
 				: "not logged in",
 		})),
@@ -3159,7 +3196,7 @@ async function handleSubsLogin(ctx: ExtensionCommandContext): Promise<void> {
 	const all = normalizeEntries(mergeConfigs(config, envEntries));
 
 	const notLoggedIn = all.filter(
-		(entry) => !ctx.modelRegistry.authStorage.hasAuth(subProviderName(entry)),
+		(entry) => !getAuthStorage(ctx).hasAuth(subProviderName(entry)),
 	);
 
 	if (notLoggedIn.length === 0) {
@@ -3201,7 +3238,7 @@ async function handleSubsLogout(ctx: ExtensionCommandContext): Promise<void> {
 	const all = normalizeEntries(mergeConfigs(config, envEntries));
 
 	const loggedIn = all.filter((entry) =>
-		ctx.modelRegistry.authStorage.hasAuth(subProviderName(entry)),
+		getAuthStorage(ctx).hasAuth(subProviderName(entry)),
 	);
 
 	if (loggedIn.length === 0) {
@@ -3226,7 +3263,7 @@ async function handleSubsLogout(ctx: ExtensionCommandContext): Promise<void> {
 	const entry = loggedIn.find((candidate) => subProviderName(candidate) === selectedProviderName);
 	if (!entry) return;
 
-	ctx.modelRegistry.authStorage.logout(subProviderName(entry));
+	getAuthStorage(ctx).logout(subProviderName(entry));
 	ctx.modelRegistry.refresh();
 	ctx.ui.notify(`Logged out of ${subDisplayName(entry)}`, "info");
 }
@@ -3244,8 +3281,8 @@ async function handleSubsStatus(ctx: ExtensionCommandContext): Promise<void> {
 	const lines: string[] = [];
 	for (const entry of all) {
 		const name = subProviderName(entry);
-		const cred = ctx.modelRegistry.authStorage.get(name);
-		const hasAuth = ctx.modelRegistry.authStorage.hasAuth(name);
+		const cred = getAuthStorage(ctx).get(name);
+		const hasAuth = getAuthStorage(ctx).hasAuth(name);
 
 		let status: string;
 		if (!hasAuth) {
@@ -3510,14 +3547,14 @@ async function editPoolMembers(
 		const removableItems: SelectItem[] = selectedMembers.map((member) => ({
 			value: `remove:${member}`,
 			label: `remove ${member}`,
-			description: ctx.modelRegistry.authStorage.hasAuth(member) ? "logged in" : "not logged in",
+			description: getAuthStorage(ctx).hasAuth(member) ? "logged in" : "not logged in",
 		}));
 		const addableItems: SelectItem[] = availableProviders
 			.filter((providerName) => !selectedMembers.includes(providerName))
 			.map((providerName) => ({
 				value: `add:${providerName}`,
 				label: `add ${providerName}`,
-				description: ctx.modelRegistry.authStorage.hasAuth(providerName)
+				description: getAuthStorage(ctx).hasAuth(providerName)
 					? "logged in"
 					: "not logged in",
 			}));
@@ -3605,7 +3642,7 @@ async function promptForPoolDefinition(
 
 	const allProviders = getAllProvidersForBase(baseProvider, allSubs);
 	const authedProviders = allProviders.filter((p) =>
-		ctx.modelRegistry.authStorage.hasAuth(p),
+		getAuthStorage(ctx).hasAuth(p),
 	);
 
 	if (authedProviders.length === 0) {
@@ -3625,7 +3662,7 @@ async function promptForPoolDefinition(
 		const optionsList = [
 			`--- Selected (${members.length}): ${members.join(", ") || "none"} ---`,
 			...remaining.map((p) => {
-				const authed = ctx.modelRegistry.authStorage.hasAuth(p);
+				const authed = getAuthStorage(ctx).hasAuth(p);
 				return `${p} ${authed ? "[logged in]" : "[not logged in]"}`;
 			}),
 			"[Done - create pool]",
@@ -3854,7 +3891,7 @@ async function inspectPoolConfig(
 	await showWrappedSelect(ctx, {
 		title: `Pool Status: ${pool.name}`,
 		subtitle: "Press Enter or Escape to go back to the pools list.",
-		items: formatPoolStatusLines(pool, ctx.modelRegistry.authStorage, poolManager)
+		items: formatPoolStatusLines(pool, getAuthStorage(ctx), poolManager)
 			.map((line, index) => ({ value: `${index}:${line}`, label: line })),
 		confirmHint: "back",
 		cancelHint: "back",
@@ -4099,7 +4136,7 @@ async function handlePoolList(
 			items: pools.map((pool) => ({
 				value: pool.name,
 				label: pool.name,
-				description: formatPoolListDescription(pool, ctx.modelRegistry.authStorage, poolManager),
+				description: formatPoolListDescription(pool, getAuthStorage(ctx), poolManager),
 			})),
 			initialValue: preferredPoolName,
 			confirmHint: "open",
@@ -4277,7 +4314,7 @@ async function handlePoolStatus(
 	const lines: string[] = [];
 	for (const pool of config.pools) {
 		lines.push(
-			...formatPoolStatusLines(pool, ctx.modelRegistry.authStorage, poolManager),
+			...formatPoolStatusLines(pool, getAuthStorage(ctx), poolManager),
 		);
 	}
 
@@ -4670,7 +4707,7 @@ async function handlePoolChainList(
 	await ctx.ui.select(
 		"Chains",
 		config.chains.map((chain) =>
-			formatChainListLine(chain, config, ctx.modelRegistry.authStorage, poolManager),
+			formatChainListLine(chain, config, getAuthStorage(ctx), poolManager),
 		),
 	);
 }
@@ -4750,7 +4787,7 @@ async function handlePoolChainStatus(
 
 	await ctx.ui.select(
 		`Chain Status: ${chain.name}`,
-		formatChainStatusLines(chain, config, ctx.modelRegistry.authStorage, poolManager),
+		formatChainStatusLines(chain, config, getAuthStorage(ctx), poolManager),
 	);
 }
 
@@ -4838,7 +4875,7 @@ async function handlePoolProject(
 		const allSubs = normalizeEntries(mergeConfigs(globalConf, envEntries));
 		const allProviderNames = [
 			...SUPPORTED_PROVIDERS.filter((p) =>
-				ctx.modelRegistry.authStorage.hasAuth(p),
+				getAuthStorage(ctx).hasAuth(p),
 			),
 			...allSubs.map((s) => subProviderName(s)),
 		];
@@ -4859,7 +4896,7 @@ async function handlePoolProject(
 			const options = [
 				`--- Allowed (${allowed.length}): ${allowed.join(", ") || "all (no restriction)"} ---`,
 				...remaining.map((p) => {
-					const authed = ctx.modelRegistry.authStorage.hasAuth(p);
+					const authed = getAuthStorage(ctx).hasAuth(p);
 					const current = currentAllowed.includes(p) ? " [currently allowed]" : "";
 					return `${p} ${authed ? "[logged in]" : "[not logged in]"}${current}`;
 				}),
@@ -4990,7 +5027,7 @@ async function handlePoolProject(
 		lines.push("");
 		lines.push(`Effective subs (${effective.subscriptions.length}):`);
 		for (const sub of effective.subscriptions) {
-			const authed = ctx.modelRegistry.authStorage.hasAuth(subProviderName(sub));
+			const authed = getAuthStorage(ctx).hasAuth(subProviderName(sub));
 			lines.push(`  ${subDisplayName(sub)} -- ${authed ? "logged in" : "not logged in"}`);
 		}
 
@@ -5261,7 +5298,7 @@ async function handlePresetActivate(
 
 	for (const entry of preset.entries) {
 		if (!entry.enabled) continue;
-		if (!ctx.modelRegistry.authStorage.hasAuth(entry.provider)) continue;
+		if (!getAuthStorage(ctx).hasAuth(entry.provider)) continue;
 		const model = ctx.modelRegistry.find(entry.provider, entry.model);
 		if (!model) continue;
 
@@ -5521,7 +5558,7 @@ export default function multiSub(pi: ExtensionAPI) {
 			if (pool) {
 				const available = poolManager.getAvailableMembers(
 					pool,
-					ctx.modelRegistry.authStorage,
+					getAuthStorage(ctx),
 				);
 				if (available.length === 0) {
 					ctx.ui.notify(


### PR DESCRIPTION
## Summary

Pi v0.80.10 **removed** `ModelRegistry.authStorage` — a breaking change documented in the CHANGELOG:

| Removed API | Replacement in pi v0.80.10 |
|---|---|
| `ctx.modelRegistry.authStorage.hasAuth(provider)` | `ctx.modelRegistry.getProviderAuthStatus(provider).configured` |
| `ctx.modelRegistry.authStorage.get(provider)` | `readStoredCredential(provider)` (sync, exported from pi-coding-agent) |
| `ctx.modelRegistry.authStorage.logout(provider)` | Direct auth.json manipulation |

All `/subs`, `/limit`, `/pool` commands crash with:
```
Extension "command:subs" error: Cannot read properties of undefined (reading 'hasAuth')
```

## Changes

1. **Added import** `readStoredCredential` from `@mariozechner/pi-coding-agent` (or `@earendil-works/pi-coding-agent`)
2. **Added `getAuthStorage(ctx)` helper** — a backward-compatibility wrapper providing the old `hasAuth`, `get`, `logout` interface backed by the new pi API
3. **Replaced all 34 direct references** to `ctx.modelRegistry.authStorage` with `getAuthStorage(ctx)`

## Testing

- [x] All `/subs` subcommands (list, add, remove, login, logout, switch, status, limits)
- [x] `/pool` subcommands (create, list, chain, toggle, remove, status, project)
- [x] Auto-rotation on rate-limit errors
- [x] Project-level pool config enforcement

## Compatibility

The helper function conditionally works with both `@mariozechner/pi-coding-agent` (old package name) and `@earendil-works/pi-coding-agent` (new package name).