### PR TITLE
fix: restore secondary Codex OAuth login on Pi 0.80.10

### DIFF
--- a/extensions/multi-sub.ts
+++ b/extensions/multi-sub.ts
@@ -47,28 +47,22 @@ import {
 	keyHint,
 } from "@earendil-works/pi-coding-agent";
 import {
-	anthropicOAuthProvider,
 	loginAnthropic,
 	refreshAnthropicToken,
-	openaiCodexOAuthProvider,
-	loginOpenAICodex,
-	refreshOpenAICodexToken,
-	githubCopilotOAuthProvider,
 	loginGitHubCopilot,
 	refreshGitHubCopilotToken,
 	getGitHubCopilotBaseUrl,
 	normalizeDomain,
-	geminiCliOAuthProvider,
 	loginGeminiCli,
 	refreshGoogleCloudToken,
-	antigravityOAuthProvider,
 	loginAntigravity,
 	refreshAntigravityToken,
 	type OAuthCredentials,
 	type OAuthLoginCallbacks,
-	type OAuthProviderInterface,
 } from "@earendil-works/pi-ai/oauth";
 import { getModels, type Api, type Model } from "@earendil-works/pi-ai";
+import { builtinProviders } from "@earendil-works/pi-ai/providers/all";
+import { createOAuthInteraction, toOAuthCredential } from "../src/oauth-compat.mts";
 import {
 	Container,
 	Key,
@@ -85,18 +79,24 @@ import {
 type CopilotCredentials = OAuthCredentials & { enterpriseUrl?: string };
 type GeminiCredentials = OAuthCredentials & { projectId?: string };
 
+const openaiCodexOAuth = builtinProviders().find(({ id }) => id === "openai-codex")?.auth.oauth;
+if (!openaiCodexOAuth) {
+	throw new Error("pi-multi-pass: the installed pi-ai OpenAI Codex provider has no OAuth flow");
+}
+
+type RegisteredProviderConfig = Parameters<ExtensionAPI["registerProvider"]>[1];
+type LegacyOAuthProvider = NonNullable<RegisteredProviderConfig["oauth"]>;
+
 interface ProviderTemplate {
 	displayName: string;
-	builtinOAuth: OAuthProviderInterface;
 	usesCallbackServer?: boolean;
-	buildOAuth(index: number): Omit<OAuthProviderInterface, "id">;
-	buildModifyModels?(providerName: string): OAuthProviderInterface["modifyModels"];
+	buildOAuth(index: number): LegacyOAuthProvider;
+	buildModifyModels?(providerName: string): LegacyOAuthProvider["modifyModels"];
 }
 
 const PROVIDER_TEMPLATES: Record<string, ProviderTemplate> = {
 	anthropic: {
 		displayName: "Anthropic (Claude Pro/Max)",
-		builtinOAuth: anthropicOAuthProvider,
 		buildOAuth(index: number) {
 			return {
 				name: `Anthropic #${index}`,
@@ -120,22 +120,16 @@ const PROVIDER_TEMPLATES: Record<string, ProviderTemplate> = {
 
 	"openai-codex": {
 		displayName: "ChatGPT Plus/Pro (Codex)",
-		builtinOAuth: openaiCodexOAuthProvider,
 		usesCallbackServer: true,
 		buildOAuth(index: number) {
 			return {
 				name: `ChatGPT Codex #${index}`,
 				usesCallbackServer: true,
 				async login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
-					return loginOpenAICodex({
-						onAuth: callbacks.onAuth,
-						onPrompt: callbacks.onPrompt,
-						onProgress: callbacks.onProgress,
-						onManualCodeInput: callbacks.onManualCodeInput,
-					});
+					return openaiCodexOAuth.login(createOAuthInteraction(callbacks));
 				},
 				async refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
-					return refreshOpenAICodexToken(credentials.refresh);
+					return openaiCodexOAuth.refresh(toOAuthCredential(credentials));
 				},
 				getApiKey(credentials: OAuthCredentials): string {
 					return credentials.access;
@@ -146,7 +140,6 @@ const PROVIDER_TEMPLATES: Record<string, ProviderTemplate> = {
 
 	"github-copilot": {
 		displayName: "GitHub Copilot",
-		builtinOAuth: githubCopilotOAuthProvider,
 		buildOAuth(index: number) {
 			return {
 				name: `GitHub Copilot #${index}`,
@@ -184,7 +177,6 @@ const PROVIDER_TEMPLATES: Record<string, ProviderTemplate> = {
 
 	"google-gemini-cli": {
 		displayName: "Google Cloud Code Assist",
-		builtinOAuth: geminiCliOAuthProvider,
 		usesCallbackServer: true,
 		buildOAuth(index: number) {
 			return {
@@ -212,7 +204,6 @@ const PROVIDER_TEMPLATES: Record<string, ProviderTemplate> = {
 
 	"google-antigravity": {
 		displayName: "Antigravity",
-		builtinOAuth: antigravityOAuthProvider,
 		usesCallbackServer: true,
 		buildOAuth(index: number) {
 			return {

--- a/src/oauth-compat.mts
+++ b/src/oauth-compat.mts
@@ -1,0 +1,106 @@
+import type { OAuthLoginCallbacks } from "@earendil-works/pi-ai/oauth";
+import type {
+	AuthEvent,
+	AuthInteraction,
+	AuthPrompt,
+	OAuthCredential,
+	OAuthCredentials,
+} from "@earendil-works/pi-ai";
+
+function abortError(signal: AbortSignal): Error {
+	return signal.reason instanceof Error ? signal.reason : new Error("OAuth prompt cancelled");
+}
+
+async function waitForLegacyPrompt<T>(start: () => Promise<T>, signal?: AbortSignal): Promise<T> {
+	if (!signal) return start();
+
+	return new Promise<T>((resolve, reject) => {
+		const onAbort = () => {
+			signal.removeEventListener("abort", onAbort);
+			reject(abortError(signal));
+		};
+		signal.addEventListener("abort", onAbort, { once: true });
+		if (signal.aborted) {
+			onAbort();
+			return;
+		}
+
+		let promise: Promise<T>;
+		try {
+			promise = start();
+		} catch (error: unknown) {
+			signal.removeEventListener("abort", onAbort);
+			reject(error);
+			return;
+		}
+		promise.then(
+			(value) => {
+				signal.removeEventListener("abort", onAbort);
+				resolve(value);
+			},
+			(error: unknown) => {
+				signal.removeEventListener("abort", onAbort);
+				reject(error);
+			},
+		);
+	});
+}
+
+function notifyLegacyOAuth(callbacks: OAuthLoginCallbacks, event: AuthEvent): void {
+	switch (event.type) {
+		case "auth_url":
+			callbacks.onAuth({ url: event.url, instructions: event.instructions });
+			return;
+		case "device_code":
+			callbacks.onDeviceCode({
+				userCode: event.userCode,
+				verificationUri: event.verificationUri,
+				intervalSeconds: event.intervalSeconds,
+				expiresInSeconds: event.expiresInSeconds,
+			});
+			return;
+		case "info":
+		case "progress":
+			callbacks.onProgress?.(event.message);
+	}
+}
+
+async function promptLegacyOAuth(
+	callbacks: OAuthLoginCallbacks,
+	prompt: AuthPrompt,
+): Promise<string> {
+	if (prompt.type === "select") {
+		const selected = await waitForLegacyPrompt(
+			() => callbacks.onSelect({
+				message: prompt.message,
+				options: prompt.options.map(({ id, label }) => ({ id, label })),
+			}),
+			prompt.signal,
+		);
+		if (selected === undefined) throw new Error("OAuth selection cancelled");
+		return selected;
+	}
+
+	return waitForLegacyPrompt(
+		() => prompt.type === "manual_code" && callbacks.onManualCodeInput
+			? callbacks.onManualCodeInput()
+			: callbacks.onPrompt({
+					message: prompt.message,
+					placeholder: prompt.placeholder,
+					allowEmpty: false,
+				}),
+		prompt.signal,
+	);
+}
+
+export function createOAuthInteraction(callbacks: OAuthLoginCallbacks): AuthInteraction {
+	return {
+		signal: callbacks.signal,
+		notify: (event) => notifyLegacyOAuth(callbacks, event),
+		prompt: (prompt) => promptLegacyOAuth(callbacks, prompt),
+	};
+}
+
+export function toOAuthCredential(credentials: OAuthCredentials): OAuthCredential {
+	return { ...credentials, type: "oauth" };
+}

--- a/tests/codex-oauth-compat-check.mjs
+++ b/tests/codex-oauth-compat-check.mjs
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import {
+  createOAuthInteraction,
+  toOAuthCredential,
+} from "../src/oauth-compat.mts";
+
+function callbacks(overrides = {}) {
+  return {
+    onAuth() {},
+    onDeviceCode() {},
+    async onPrompt() { return "prompt-result"; },
+    async onSelect() { return "browser"; },
+    ...overrides,
+  };
+}
+
+const source = readFileSync(new URL("../extensions/multi-sub.ts", import.meta.url), "utf8");
+assert.doesNotMatch(
+  source,
+  /\b(?:loginOpenAICodex|refreshOpenAICodexToken)\b/,
+  "Codex must not call runtime functions removed from @earendil-works/pi-ai/oauth",
+);
+assert.match(source, /from "@earendil-works\/pi-ai\/providers\/all"/);
+assert.match(source, /id === "openai-codex"/);
+
+const events = [];
+const interaction = createOAuthInteraction(callbacks({
+  onAuth: (event) => events.push(["auth", event]),
+  onDeviceCode: (event) => events.push(["device", event]),
+  onProgress: (message) => events.push(["progress", message]),
+  onSelect: async (prompt) => {
+    assert.deepEqual(prompt, {
+      message: "Choose",
+      options: [{ id: "browser", label: "Browser login" }],
+    });
+    return "browser";
+  },
+}));
+
+interaction.notify({ type: "auth_url", url: "https://example.test", instructions: "Sign in" });
+interaction.notify({
+  type: "device_code",
+  userCode: "ABCD-EFGH",
+  verificationUri: "https://example.test/device",
+  intervalSeconds: 5,
+  expiresInSeconds: 900,
+});
+interaction.notify({ type: "progress", message: "Waiting" });
+interaction.notify({ type: "info", message: "Ready" });
+assert.deepEqual(events, [
+  ["auth", { url: "https://example.test", instructions: "Sign in" }],
+  ["device", {
+    userCode: "ABCD-EFGH",
+    verificationUri: "https://example.test/device",
+    intervalSeconds: 5,
+    expiresInSeconds: 900,
+  }],
+  ["progress", "Waiting"],
+  ["progress", "Ready"],
+]);
+assert.equal(await interaction.prompt({
+  type: "select",
+  message: "Choose",
+  options: [{ id: "browser", label: "Browser login", description: "Default" }],
+}), "browser");
+
+const cancelledSelection = createOAuthInteraction(callbacks({ onSelect: async () => undefined }));
+await assert.rejects(
+  cancelledSelection.prompt({ type: "select", message: "Choose", options: [] }),
+  /OAuth selection cancelled/,
+);
+
+let manualPromptStarted = false;
+const promptAbort = new AbortController();
+const pendingManualPrompt = createOAuthInteraction(callbacks({
+  onManualCodeInput: () => {
+    manualPromptStarted = true;
+    return new Promise(() => {});
+  },
+})).prompt({
+  type: "manual_code",
+  message: "Paste redirect URL",
+  signal: promptAbort.signal,
+});
+assert.equal(manualPromptStarted, true);
+const abortReason = new Error("callback server completed");
+promptAbort.abort(abortReason);
+await assert.rejects(pendingManualPrompt, (error) => error === abortReason);
+
+const alreadyAborted = new AbortController();
+alreadyAborted.abort(abortReason);
+let abortedPromptStarted = false;
+await assert.rejects(
+  createOAuthInteraction(callbacks({
+    onManualCodeInput: async () => {
+      abortedPromptStarted = true;
+      return "unused";
+    },
+  })).prompt({
+    type: "manual_code",
+    message: "Paste redirect URL",
+    signal: alreadyAborted.signal,
+  }),
+  (error) => error === abortReason,
+);
+assert.equal(abortedPromptStarted, false);
+
+const synchronousAbort = new AbortController();
+const synchronousAbortReason = new Error("callback completed synchronously");
+await assert.rejects(
+  createOAuthInteraction(callbacks({
+    onManualCodeInput: () => {
+      synchronousAbort.abort(synchronousAbortReason);
+      return new Promise(() => {});
+    },
+  })).prompt({
+    type: "manual_code",
+    message: "Paste redirect URL",
+    signal: synchronousAbort.signal,
+  }),
+  (error) => error === synchronousAbortReason,
+);
+
+assert.deepEqual(
+  toOAuthCredential({
+    access: "access-token",
+    refresh: "refresh-token",
+    expires: 123,
+    accountId: "account-1",
+  }),
+  {
+    type: "oauth",
+    access: "access-token",
+    refresh: "refresh-token",
+    expires: 123,
+    accountId: "account-1",
+  },
+);
+
+console.log("codex OAuth compatibility checks passed");


### PR DESCRIPTION
Closes #23.

## Summary

Secondary Codex accounts currently call runtime functions that Pi 0.80.10 no longer exports. This patch routes those accounts through Pi's public built-in Codex provider and translates its canonical authentication interaction to the extension callback contract.

Issue #23 contains a standalone reproduction, acceptance criteria, and a prompt maintainers can give another agent if they prefer to implement the fix independently. This PR is a tested implementation of that contract.

## Context and root cause

`extensions/multi-sub.ts` imports `loginOpenAICodex` and `refreshOpenAICodexToken` from `@earendil-works/pi-ai/oauth`. In Pi 0.80.10, that subpath is type-only at runtime. Selecting `ChatGPT Codex #2` or later therefore throws:

```text
(0 , _oauth.loginOpenAICodex) is not a function
```

Pi exposes the current Codex OAuth implementation through the public `@earendil-works/pi-ai/providers/all` entry point. That implementation uses canonical `AuthInteraction` and `OAuthCredential` values, while extension provider registration still accepts legacy `OAuthLoginCallbacks` and `OAuthCredentials`.

This change does not include the separate `authStorage` compatibility work from #22 and PR #21.

## Reproduction

On upstream `main` at `b9d9d1d` with Pi 0.80.10:

1. Configure `openai-codex-2` through `/subs add` or `multi-pass.json`.
2. Run `/login openai-codex-2`.
3. Select the secondary Codex account.

Before this patch, login ends with the missing-function error. After this patch, Pi shows the browser/device-code method selector.

## Fix

- Find the built-in `openai-codex` OAuth implementation through `builtinProviders()`.
- Add a small adapter from canonical auth events and prompts to legacy extension callbacks.
- Attach per-prompt abort listeners before invoking legacy callbacks. This covers cancellation before startup, during startup, and while a prompt is pending.
- Convert stored legacy credentials to canonical `{ type: "oauth", ... }` credentials before refresh while preserving extra fields such as `accountId`.
- Derive the extension OAuth config type from `ExtensionAPI["registerProvider"]` rather than importing removed compatibility types.
- Remove unused runtime provider-object imports. Other provider login functions are unchanged.

The patch does not import private `dist/` files or depend on a global npm installation path.

## Automated tests

Red evidence on `b9d9d1d`:

```text
node tests/codex-oauth-compat-check.mjs
AssertionError: Codex must not call runtime functions removed from @earendil-works/pi-ai/oauth
exit 1
```

Green checks:

```text
for test_file in tests/*.mjs; do node "$test_file"; done
# all seven checks passed

pi --offline --no-extensions --no-skills --no-prompt-templates \
  --no-context-files --approve \
  --extension ./extensions/multi-sub.ts \
  --list-models openai-codex-2
# extension loaded and secondary Codex models were listed

git diff --check
# passed
```

A temporary clean Pi agent directory with subscriptions through `openai-codex-5` was also used to run `/login openai-codex-5`. Pi 0.80.10 displayed:

```text
Select OpenAI Codex login method:
  Browser login (default)
  Device code login (headless)
```

No live account login or token refresh was completed. The test stops at the login-method selector to avoid changing credentials.

## Production and rollout instructions

The trigger is selecting any secondary Codex account. The current failure prevents authentication for that account.

No credential or configuration migration is expected. Update the extension, then restart or reload Pi. Validate by opening `/login` for a secondary Codex provider and checking that the login-method selector appears. Roll back by pinning the prior extension commit.

## Maintainer self-fix prompt

If you would rather reproduce and implement this independently, this prompt captures the observed contract and acceptance criteria:

```text
Read every applicable contributor and agent instruction in this repository before editing. Reproduce the secondary OpenAI Codex login failure on pi-multi-pass main at b9d9d1d with @earendil-works/pi-coding-agent 0.80.10. Inspect extensions/multi-sub.ts and the installed public Pi provider/authentication contracts. Add a focused failing regression test that proves the secondary provider calls runtime exports no longer provided by @earendil-works/pi-ai/oauth.

Implement the smallest fix at the Codex compatibility boundary. Use public package entry points. Preserve auth URL, device code, progress, login-method selection, manual-code input, per-prompt cancellation, refresh fields, and explicit compatibility errors. Do not hard-code installation paths, copy Pi's OAuth protocol code, alter authStorage behavior, or refactor unrelated providers.

Run every tests/*.mjs check, load the extension through Pi 0.80.10, and verify that /login for a secondary Codex account reaches the browser/device-code selector. Report focused red and green evidence plus any step that requires a real account.
```

Thanks for reviewing it.