### PR TITLE
fix: refresh cloned models on remote catalog update

### DIFF
--- a/extensions/model-clone.ts
+++ b/extensions/model-clone.ts
@@ -1,0 +1,75 @@
+/**
+ * Pure model-cloning logic for multi-pass subscription providers.
+ * Extracted from multi-sub.ts for testability (no pi-ai dependency).
+ */
+
+export interface CloneableModel {
+	provider: string;
+	id: string;
+	name: string;
+	api: string;
+	reasoning: boolean;
+	thinkingLevelMap?: Record<string, unknown> | undefined;
+	input: readonly string[];
+	cost: Record<string, unknown>;
+	contextWindow: number;
+	maxTokens: number;
+	headers?: Record<string, string> | undefined;
+	compat?: unknown;
+}
+
+export interface ClonedModel {
+	id: string;
+	name: string;
+	api: string;
+	reasoning: boolean;
+	thinkingLevelMap?: Record<string, unknown> | undefined;
+	input: readonly string[];
+	cost: Record<string, unknown>;
+	contextWindow: number;
+	maxTokens: number;
+	headers?: Record<string, string> | undefined;
+	compat?: unknown;
+}
+
+/** Clone a single model with the (#index) suffix. */
+export function cloneOne(m: CloneableModel, index: number): ClonedModel {
+	return {
+		id: m.id,
+		name: `${m.name} (#${index})`,
+		api: m.api,
+		reasoning: m.reasoning,
+		thinkingLevelMap: m.thinkingLevelMap ? { ...m.thinkingLevelMap } : undefined,
+		input: m.input as ("text" | "image")[],
+		cost: { ...m.cost },
+		contextWindow: m.contextWindow,
+		maxTokens: m.maxTokens,
+		headers: m.headers ? { ...m.headers } : undefined,
+		compat: m.compat,
+	};
+}
+
+/** Clone models from a static list. */
+export function cloneFromList(models: CloneableModel[], index: number): ClonedModel[] {
+	return models.map((m) => cloneOne(m, index));
+}
+
+/**
+ * Clone models from the live registry catalog for a base provider.
+ * Falls back to the static list when the registry is unavailable or
+ * has no models for the requested provider.
+ */
+export function cloneModelsLive(
+	registry: { getAll(): CloneableModel[] } | undefined,
+	originalProvider: string,
+	index: number,
+	staticFallback: () => ClonedModel[],
+): ClonedModel[] {
+	if (registry) {
+		const live = registry.getAll().filter((m) => m.provider === originalProvider);
+		if (live.length > 0) {
+			return live.map((m) => cloneOne(m, index));
+		}
+	}
+	return staticFallback();
+}

--- a/extensions/multi-sub.ts
+++ b/extensions/multi-sub.ts
@@ -1891,6 +1891,36 @@ function cloneModels(originalProvider: string, index: number) {
 	}));
 }
 
+/**
+ * Clone models from the model registry's live catalog for the base provider.
+ * Unlike cloneModels() (static pi-ai builtin list), this includes remote
+ * catalog updates (e.g. new models pushed via the pi.dev model catalog).
+ * Falls back to the static list when the registry is not yet available.
+ */
+let _modelRegistry: { getAll(): Model<Api>[] } | undefined;
+
+function cloneModelsLive(originalProvider: string, index: number) {
+	if (_modelRegistry) {
+		const live = _modelRegistry.getAll().filter((m) => m.provider === originalProvider);
+		if (live.length > 0) {
+			return live.map((m) => ({
+				id: m.id,
+				name: `${m.name} (#${index})`,
+				api: m.api,
+				reasoning: m.reasoning,
+				thinkingLevelMap: m.thinkingLevelMap ? { ...m.thinkingLevelMap } : undefined,
+				input: m.input as ("text" | "image")[],
+				cost: { ...m.cost },
+				contextWindow: m.contextWindow,
+				maxTokens: m.maxTokens,
+				headers: m.headers ? { ...m.headers } : undefined,
+				compat: m.compat,
+			}));
+		}
+	}
+	return cloneModels(originalProvider, index);
+}
+
 // ==========================================================================
 // Register a single subscription as a provider
 // ==========================================================================
@@ -1911,6 +1941,9 @@ function registerSub(pi: ExtensionAPI, entry: SubEntry): void {
 		api: builtinModels[0]?.api,
 		oauth: modifyModels ? { ...oauth, modifyModels } : oauth,
 		models,
+		// Re-clone from the live catalog on each model refresh so remote
+		// catalog updates propagate to cloned subscription providers.
+		refreshModels: async () => cloneModelsLive(entry.provider, entry.index),
 	});
 }
 
@@ -5440,6 +5473,8 @@ export default function multiSub(pi: ExtensionAPI) {
 
 	// On session start, reload pools with project-level config
 	pi.on("session_start", async (_event, ctx) => {
+		// Capture the registry so refreshModels can clone from the live catalog.
+		_modelRegistry = ctx.modelRegistry;
 		const effective = loadEffectiveConfig(ctx.cwd);
 		poolManager.loadPools(effective.pools);
 

--- a/extensions/multi-sub.ts
+++ b/extensions/multi-sub.ts
@@ -69,6 +69,7 @@ import {
 	type OAuthProviderInterface,
 } from "@earendil-works/pi-ai/oauth";
 import { getModels, type Api, type Model } from "@earendil-works/pi-ai";
+import { cloneFromList, cloneModelsLive as cloneModelsLiveCore, type CloneableModel } from "./model-clone.ts";
 import {
 	Container,
 	Key,
@@ -1876,19 +1877,7 @@ function getBaseProvider(providerName: string): string | undefined {
 
 function cloneModels(originalProvider: string, index: number) {
 	const models = getModels(originalProvider as any) as Model<Api>[];
-	return models.map((m) => ({
-		id: m.id,
-		name: `${m.name} (#${index})`,
-		api: m.api,
-		reasoning: m.reasoning,
-		thinkingLevelMap: m.thinkingLevelMap ? { ...m.thinkingLevelMap } : undefined,
-		input: m.input as ("text" | "image")[],
-		cost: { ...m.cost },
-		contextWindow: m.contextWindow,
-		maxTokens: m.maxTokens,
-		headers: m.headers ? { ...m.headers } : undefined,
-		compat: m.compat,
-	}));
+	return cloneFromList(models as unknown as CloneableModel[], index);
 }
 
 /**
@@ -1900,25 +1889,12 @@ function cloneModels(originalProvider: string, index: number) {
 let _modelRegistry: { getAll(): Model<Api>[] } | undefined;
 
 function cloneModelsLive(originalProvider: string, index: number) {
-	if (_modelRegistry) {
-		const live = _modelRegistry.getAll().filter((m) => m.provider === originalProvider);
-		if (live.length > 0) {
-			return live.map((m) => ({
-				id: m.id,
-				name: `${m.name} (#${index})`,
-				api: m.api,
-				reasoning: m.reasoning,
-				thinkingLevelMap: m.thinkingLevelMap ? { ...m.thinkingLevelMap } : undefined,
-				input: m.input as ("text" | "image")[],
-				cost: { ...m.cost },
-				contextWindow: m.contextWindow,
-				maxTokens: m.maxTokens,
-				headers: m.headers ? { ...m.headers } : undefined,
-				compat: m.compat,
-			}));
-		}
-	}
-	return cloneModels(originalProvider, index);
+	return cloneModelsLiveCore(
+		_modelRegistry as { getAll(): CloneableModel[] } | undefined,
+		originalProvider,
+		index,
+		() => cloneModels(originalProvider, index),
+	);
 }
 
 // ==========================================================================

--- a/tests/model-refresh.test.ts
+++ b/tests/model-refresh.test.ts
@@ -1,0 +1,101 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { cloneModelsLive, cloneFromList, type CloneableModel } from "../extensions/model-clone.ts";
+
+// WHY: registerSub() snapshots models at load time via cloneModels(). Without a
+// refreshModels callback on registerProvider, cloned subscription providers
+// (anthropic-2, etc.) NEVER receive remote catalog updates (e.g. new Opus pushed
+// via pi.dev). This is the bug that kept opus-5 off multipass subs while the
+// primary subscription had it. These tests fail if the callback is dropped or
+// the live-clone path breaks.
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SRC = readFileSync(join(HERE, "..", "extensions", "multi-sub.ts"), "utf8");
+
+// ---------------------------------------------------------------------------
+// 1. STRUCTURAL: registerSub passes refreshModels to BOTH registerProvider calls
+// ---------------------------------------------------------------------------
+
+test("registerSub passes refreshModels to BOTH registerProvider calls (api_key + oauth)", () => {
+	const start = SRC.indexOf("function registerSub(");
+	assert.ok(start >= 0, "registerSub not found");
+	const end = SRC.indexOf("\n// ====", start + 1);
+	assert.ok(end > start, "registerSub end boundary not found");
+	const body = SRC.slice(start, end);
+
+	const callStarts = [...body.matchAll(/pi\.registerProvider\(/g)].map((m) => m.index!);
+	assert.equal(callStarts.length, 2, `expected 2 registerProvider calls, found ${callStarts.length}`);
+
+	for (const [i, callStart] of callStarts.entries()) {
+		const callEnd = body.indexOf("\n\t});", callStart);
+		assert.ok(callEnd > callStart, `registerProvider call #${i + 1} has no closing`);
+		const call = body.slice(callStart, callEnd);
+		assert.ok(
+			call.includes("refreshModels"),
+			`registerProvider call #${i + 1} is missing the refreshModels callback — cloned models will go stale on catalog update`,
+		);
+	}
+});
+
+// ---------------------------------------------------------------------------
+// 2. FUNCTIONAL: cloneModelsLive returns live-catalog models with (#index) suffix
+// ---------------------------------------------------------------------------
+
+const FAKE_OPUS5: CloneableModel = {
+	provider: "anthropic",
+	id: "claude-opus-5",
+	name: "Claude Opus 5",
+	api: "anthropic-messages",
+	reasoning: true,
+	thinkingLevelMap: undefined,
+	input: ["text", "image"],
+	cost: { input: 15, output: 75, cacheRead: 1.5, cacheWrite: 18.75 },
+	contextWindow: 1000000,
+	maxTokens: 128000,
+	headers: undefined,
+	compat: undefined,
+};
+
+test("cloneModelsLive returns models from the live registry (not just static builtin)", () => {
+	const registry = { getAll: () => [FAKE_OPUS5] };
+	const result = cloneModelsLive(registry, "anthropic", 2, () => []);
+
+	const opus5 = result.find((m) => m.id === "claude-opus-5");
+	assert.ok(opus5, "live-catalog model (claude-opus-5) must appear in cloneModelsLive result");
+	assert.equal(opus5!.name, "Claude Opus 5 (#2)", "cloned model must carry the (#index) suffix");
+	assert.equal(opus5!.contextWindow, 1000000, "field values must be preserved from the live model");
+	assert.deepEqual(opus5!.cost, FAKE_OPUS5.cost, "cost must be deep-copied");
+});
+
+test("cloneModelsLive filters to the requested base provider only", () => {
+	const other: CloneableModel = { ...FAKE_OPUS5, provider: "openai-codex", id: "gpt-5" };
+	const registry = { getAll: () => [FAKE_OPUS5, other] };
+	const result = cloneModelsLive(registry, "anthropic", 2, () => []);
+
+	assert.equal(result.length, 1, "must only include models for the requested provider");
+	assert.equal(result[0].id, "claude-opus-5");
+});
+
+// ---------------------------------------------------------------------------
+// 3. FUNCTIONAL: fallback to static cloneModels when registry is unavailable
+// ---------------------------------------------------------------------------
+
+test("cloneModelsLive falls back to static list when registry is undefined", () => {
+	const staticModels = cloneFromList([FAKE_OPUS5], 3);
+	const result = cloneModelsLive(undefined, "anthropic", 3, () => staticModels);
+
+	assert.ok(result.length > 0, "fallback must return non-empty model list");
+	assert.equal(result[0].name, "Claude Opus 5 (#3)", "fallback models must carry the (#index) suffix");
+});
+
+test("cloneModelsLive falls back to static list when registry has no models for the provider", () => {
+	const registry = { getAll: () => [] as CloneableModel[] };
+	const staticModels = cloneFromList([FAKE_OPUS5], 4);
+	const result = cloneModelsLive(registry, "anthropic", 4, () => staticModels);
+
+	assert.ok(result.length > 0, "fallback must return non-empty model list when registry yields nothing");
+	assert.equal(result[0].name, "Claude Opus 5 (#4)");
+});

--- a/tests/model-refresh.test.ts
+++ b/tests/model-refresh.test.ts
@@ -26,12 +26,21 @@ test("registerSub passes refreshModels to BOTH registerProvider calls (api_key +
 	assert.ok(end > start, "registerSub end boundary not found");
 	const body = SRC.slice(start, end);
 
+	// Direct count: exactly TWO refreshModels property occurrences in registerSub.
+	// Fails if EITHER call site drops the callback — indentation-independent.
+	const refreshCount = (body.match(/refreshModels\s*[,:]/g) ?? []).length;
+	assert.equal(
+		refreshCount,
+		2,
+		`registerSub must have exactly 2 refreshModels occurrences (one per registerProvider call), found ${refreshCount}`,
+	);
+
+	// Per-call guard: slice by call boundaries (not brace indentation).
 	const callStarts = [...body.matchAll(/pi\.registerProvider\(/g)].map((m) => m.index!);
 	assert.equal(callStarts.length, 2, `expected 2 registerProvider calls, found ${callStarts.length}`);
 
 	for (const [i, callStart] of callStarts.entries()) {
-		const callEnd = body.indexOf("\n\t});", callStart);
-		assert.ok(callEnd > callStart, `registerProvider call #${i + 1} has no closing`);
+		const callEnd = callStarts[i + 1] ?? body.length;
 		const call = body.slice(callStart, callEnd);
 		assert.ok(
 			call.includes("refreshModels"),


### PR DESCRIPTION
Fixes #25

## Problem

Cloned subscription providers (`anthropic-2`, etc.) never receive remote model catalog updates. `registerSub()` snapshots models at load time via `cloneModels()` → pi-ai's static `getModels()`, and no `refreshModels` callback is provided to `pi.registerProvider()`. When the pi.dev model catalog adds new models to the base provider, cloned subs keep their stale list forever.

## Fix

- **`extensions/model-clone.ts`** (new) — extracted pure model-cloning logic with no pi-ai dependency, testable in isolation.
- **`cloneModelsLive()`** — clones from `modelRegistry.getAll()` (the live catalog, including remote updates from pi.dev). Falls back to the static `cloneModels()` when the registry isn't available yet (first-refresh race on cold start).
- **`refreshModels` callback** added to `registerProvider` in `registerSub` — pi's `MutableModels.refresh()` now re-clones sub models on every catalog refresh cycle.
- **`_modelRegistry`** captured on `session_start` (earliest point the registry is available to extensions).

## Tests

`tests/model-refresh.test.ts` — 5 regression tests:
1. **Structural:** `registerSub` passes `refreshModels` to BOTH `registerProvider` calls (fails if callback is dropped)
2. **Functional:** `cloneModelsLive` returns live-catalog models with `(#index)` suffix (stubs registry with a model absent from static builtin)
3. **Functional:** `cloneModelsLive` filters to the requested base provider only
4. **Functional:** Fallback when registry is `undefined`
5. **Functional:** Fallback when registry has no models for the provider

## Timing note

On the very first refresh of a cold start, there's a parallel race: `anthropic-2`'s `refreshModels` may run before `anthropic`'s remote fetch completes. The fallback to the static list handles this gracefully — new models are picked up on the next refresh (every `reloadConfig`, login/logout, or session start).
