### PR TITLE
Add MiniMax subscription support

### DIFF
--- a/extensions/multi-sub.ts
+++ b/extensions/multi-sub.ts
@@ -30,6 +30,8 @@
  *   - github-copilot     (GitHub Copilot)
  *   - google-gemini-cli  (Google Cloud Code Assist)
  *   - google-antigravity (Antigravity)
+ *   - minimax             (MiniMax global API key)
+ *   - minimax-cn          (MiniMax China API key)
  */
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
@@ -87,11 +89,17 @@ type GeminiCredentials = OAuthCredentials & { projectId?: string };
 
 interface ProviderTemplate {
 	displayName: string;
-	builtinOAuth: OAuthProviderInterface;
+	builtinOAuth?: OAuthProviderInterface;
 	usesCallbackServer?: boolean;
-	buildOAuth(index: number): Omit<OAuthProviderInterface, "id">;
+	apiKey?: string;
+	baseUrl?: string;
+	api?: Api;
+	modelIds?: readonly string[];
+	buildOAuth?(index: number): Omit<OAuthProviderInterface, "id">;
 	buildModifyModels?(providerName: string): OAuthProviderInterface["modifyModels"];
 }
+
+const MINIMAX_MODEL_IDS = ["MiniMax-M3", "MiniMax-M2.7"] as const;
 
 const PROVIDER_TEMPLATES: Record<string, ProviderTemplate> = {
 	anthropic: {
@@ -236,6 +244,22 @@ const PROVIDER_TEMPLATES: Record<string, ProviderTemplate> = {
 				},
 			};
 		},
+	},
+
+	minimax: {
+		displayName: "MiniMax (Global)",
+		apiKey: "$MINIMAX_API_KEY",
+		baseUrl: "https://api.minimax.io/anthropic",
+		api: "anthropic-messages",
+		modelIds: MINIMAX_MODEL_IDS,
+	},
+
+	"minimax-cn": {
+		displayName: "MiniMax (China)",
+		apiKey: "$MINIMAX_CN_API_KEY",
+		baseUrl: "https://api.minimaxi.com/anthropic",
+		api: "anthropic-messages",
+		modelIds: MINIMAX_MODEL_IDS,
 	},
 };
 
@@ -1860,6 +1884,11 @@ function subDisplayName(entry: SubEntry): string {
 	return `${entry.label} — ${providerName}`;
 }
 
+function subscriptionLoginName(entry: SubEntry): string {
+	const oauth = PROVIDER_TEMPLATES[entry.provider]?.buildOAuth?.(entry.index);
+	return oauth?.name || subProviderName(entry);
+}
+
 /** Get the base provider type from a provider name, e.g. "openai-codex-2" -> "openai-codex" */
 function getBaseProvider(providerName: string): string | undefined {
 	// Direct match
@@ -1874,8 +1903,13 @@ function getBaseProvider(providerName: string): string | undefined {
 // Model cloning
 // ==========================================================================
 
-function cloneModels(originalProvider: string, index: number) {
-	const models = getModels(originalProvider as any) as Model<Api>[];
+function cloneModels(originalProvider: string, index: number, modelIds?: readonly string[]) {
+	const availableModels = getModels(originalProvider as any) as Model<Api>[];
+	const models = modelIds
+		? modelIds
+			.map((modelId) => availableModels.find((model) => model.id === modelId))
+			.filter((model): model is Model<Api> => model !== undefined)
+		: availableModels;
 	return models.map((m) => ({
 		id: m.id,
 		name: `${m.name} (#${index})`,
@@ -1900,16 +1934,22 @@ function registerSub(pi: ExtensionAPI, entry: SubEntry): void {
 	if (!template) return;
 
 	const name = subProviderName(entry);
-	const oauth = template.buildOAuth(entry.index);
-	const modifyModels = template.buildModifyModels?.(name);
+	const oauth = template.buildOAuth?.(entry.index);
+	const modifyModels = oauth ? template.buildModifyModels?.(name) : undefined;
 	const builtinModels = getModels(entry.provider as any) as Model<Api>[];
-	const baseUrl = builtinModels[0]?.baseUrl || "";
-	const models = cloneModels(entry.provider, entry.index);
+	const baseUrl = template.baseUrl || builtinModels[0]?.baseUrl || "";
+	const models = cloneModels(entry.provider, entry.index, template.modelIds);
+	const oauthConfig = oauth
+		? modifyModels
+			? { ...oauth, modifyModels }
+			: oauth
+		: undefined;
 
 	pi.registerProvider(name, {
 		baseUrl,
-		api: builtinModels[0]?.api,
-		oauth: modifyModels ? { ...oauth, modifyModels } : oauth,
+		api: template.api || builtinModels[0]?.api,
+		apiKey: template.apiKey,
+		oauth: oauthConfig,
 		models,
 	});
 }
@@ -3006,7 +3046,7 @@ async function showSubscriptionActions(
 	}
 	if (action === "login") {
 		ctx.ui.notify(
-			`Use /login and select "${PROVIDER_TEMPLATES[entry.provider]?.buildOAuth(entry.index).name}" to authenticate.`,
+			`Use /login and select "${subscriptionLoginName(entry)}" to authenticate.`,
 			"info",
 		);
 		return;
@@ -3110,7 +3150,7 @@ async function handleSubsAdd(pi: ExtensionAPI, ctx: ExtensionCommandContext): Pr
 
 	if (loginNow) {
 		ctx.ui.notify(
-			`Use /login and select "${PROVIDER_TEMPLATES[entry.provider]?.buildOAuth(entry.index).name}" to authenticate.`,
+			`Use /login and select "${subscriptionLoginName(entry)}" to authenticate.`,
 			"info",
 		);
 	} else {
@@ -3190,7 +3230,7 @@ async function handleSubsLogin(ctx: ExtensionCommandContext): Promise<void> {
 	if (!entry) return;
 
 	ctx.ui.notify(
-		`Use /login and select "${PROVIDER_TEMPLATES[entry.provider]?.buildOAuth(entry.index).name}" to authenticate.`,
+		`Use /login and select "${subscriptionLoginName(entry)}" to authenticate.`,
 		"info",
 	);
 }

--- a/tests/minimax-provider-check.mjs
+++ b/tests/minimax-provider-check.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+const sourcePath = fileURLToPath(new URL("../extensions/multi-sub.ts", import.meta.url));
+const source = await readFile(sourcePath, "utf8");
+
+assert.match(source, /apiKey\?: string;/);
+assert.match(source, /baseUrl\?: string;/);
+assert.match(source, /modelIds\?: readonly string\[\];/);
+assert.match(source, /const MINIMAX_MODEL_IDS = \["MiniMax-M3", "MiniMax-M2\.7"\]/);
+
+for (const [provider, apiKey, endpoint] of [
+  ["minimax", "$MINIMAX_API_KEY", "https://api.minimax.io/anthropic"],
+  ["minimax-cn", "$MINIMAX_CN_API_KEY", "https://api.minimaxi.com/anthropic"],
+]) {
+  const providerPattern = provider === "minimax-cn"
+    ? /"minimax-cn": \{([\s\S]*?)\n\t\},/
+    : /\n\tminimax: \{([\s\S]*?)\n\t\},/;
+  const match = source.match(providerPattern);
+  assert.ok(match, `missing provider template: ${provider}`);
+  assert.ok(match[1].includes(`apiKey: "${apiKey}"`));
+  assert.ok(match[1].includes(`baseUrl: "${endpoint}"`));
+  assert.match(match[1], /modelIds: MINIMAX_MODEL_IDS/);
+  assert.match(match[1], /api: "anthropic-messages"/);
+}
+
+const registerStart = source.indexOf("function registerSub(");
+const registerEnd = source.indexOf("\n// ==========================================================================\n// Pool rotation engine", registerStart);
+assert.ok(registerStart >= 0 && registerEnd > registerStart, "registerSub body not found");
+const registerBody = source.slice(registerStart, registerEnd);
+assert.match(registerBody, /template\.baseUrl/);
+assert.match(registerBody, /template\.modelIds/);
+assert.match(registerBody, /apiKey: template\.apiKey/);
+assert.match(registerBody, /buildOAuth\?\./);
+assert.doesNotMatch(source, /buildOAuth\(entry\.index\)\.name/);
+
+console.log("MiniMax provider checks passed");


### PR DESCRIPTION
Reason: Add MiniMax API-key subscriptions for the global and China service endpoints.

- Register global and China MiniMax templates with API-key authentication.
- Clone MiniMax-M3 and MiniMax-M2.7 for additional subscription entries.
- Add a focused provider registration contract check.

Checks:
- `for test_file in tests/*.mjs; do node "$test_file"; done`
- `git diff --check origin/main...HEAD`
- Secret scan of the branch diff
