### PR TITLE
fix: port pi-multi-pass to pi 0.84.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -285,6 +285,37 @@ If the script throws, returns an invalid provider name, or the file is missing, 
 4. During retry replays for the same prompt, it preserves cascade state and avoids re-trying already attempted providers
 5. Session status shows the active chain start entry: `chain:<name> | starts <pool> -> <model>`
 
+## Tiers: keeping your model's class across a chain hop
+
+A chain entry names one model, so before tiers every hop landed on that model no matter what the session was running. A cheap recon session got promoted to a flagship model, and a flagship session could be quietly demoted mid-task. Neither is an error; you find out from the bill or from a suddenly worse answer.
+
+Add an optional `tiers` table to `~/.pi/agent/multi-pass.json` and the hop keeps the **class** of model you were on:
+
+```json
+"tiers": [
+  { "name": "flagship", "models": { "anthropic": "claude-opus-5",    "openai-codex": "gpt-5.6-sol"  } },
+  { "name": "mid",      "models": { "anthropic": "claude-sonnet-5",  "openai-codex": "gpt-5.5"      } },
+  { "name": "cheap",    "models": { "anthropic": "claude-haiku-4-5", "openai-codex": "gpt-5.4-mini" } }
+]
+```
+
+A `claude-sonnet-5` session whose anthropic pool dries up now lands on `gpt-5.5`, and the status line says which decided it:
+
+```
+advancing to chain all#2; active openai-codex (gpt-5.5) [tier: mid]
+advancing to chain all#2; active openai-codex (gpt-5.6-sol) [chain default]
+```
+
+Rules worth knowing:
+
+- **Optional.** No `tiers` key means the old behaviour, byte for byte, including the status strings.
+- **Keyed by base provider, not by account.** Write `anthropic`, not `anthropic-2`: a second account on the same subscription shares one catalogue, and by the time a cascade hops it has usually rotated within the pool already.
+- **Any gap falls back to the chain entry's model** - a model in no tier, a tier that names nothing for the target provider, or a tier pointing at a model that provider does not serve. That last check matters: an unusable model would otherwise abort the whole cascade.
+- **A model in two tiers is a config error**; the first match wins, deterministically.
+- **Same-pool rotation is untouched.** It always kept your model.
+- **Chains only.** Presets are a separate ordered route list and are not tier-mapped.
+- Do not try to infer tiers from model names. `-mini`, `-opus` and `sol` are vendor marketing and they change; the table is explicit on purpose.
+
 ## Model presets
 
 Presets are named routing shortcuts that map to an ordered list of provider+model entries across different providers. Think of them as intent-based routing: `coding-premium`, `coding-budget`, `fastest`, etc.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 Multi-subscription extension for [pi](https://github.com/earendil-works/pi-coding-agent) -- use multiple OAuth accounts per provider with automatic rate-limit rotation and project-level affinity.
 
+## Working on this fork
+
+`~/.pi/agent/npm/node_modules/pi-multi-pass/extensions/multi-sub.ts` is a **file copy** of the published package, not a symlink to this checkout. Committing here changes nothing that pi runs until you copy it across:
+
+```bash
+bash scripts/deploy.sh          # copy over the installed extension (backs the old one up)
+bash scripts/deploy.sh --check  # report drift only, exit 1 if they differ
+```
+
+Already-running pi sessions keep the old copy - extensions load per process. And `pi package update` will overwrite the deployed file with upstream, silently dropping every local fix, so re-run the script afterwards.
+
 ## Install
 
 ```bash

--- a/docs/HANDOFF-tier-preserving-failover.md
+++ b/docs/HANDOFF-tier-preserving-failover.md
@@ -1,5 +1,23 @@
 # Handoff: tier-preserving failover across chain hops
 
+**Status: implemented 2026-09-02.** `resolveTierEquivalent` + the chain-hop mapping, guarded by
+`tests/tier-mapping-check.mjs`, documented in the README under "Tiers". Live evidence, a
+mid-tier session on an exhausted anthropic pool:
+
+```
+advancing to chain all#2; active openai-codex (gpt-5.5) [tier: mid]
+```
+
+and a flagship one on the same config landing on `gpt-5.6-sol [tier: flagship]`.
+
+One correction to the plan below, found while building it: the table must be keyed by the
+pool's **baseProvider**, not by the account. By the time a cascade reaches a chain hop it has
+usually rotated within the pool, so `currentModel.provider` is `anthropic-2`, which no table
+lists. Keying by account silently disabled every mapping; there is a planted-defect test for
+exactly that.
+
+The rest of the file is kept as written, because the reasoning still applies.
+
 Written 2026-09-02 for an agent that will implement this in `~/MYNE/Projects/tools/pi-multi-pass`, branch `fix/pi-0.84-model-runtime`.
 
 Read this whole file before changing anything. Every line number below was checked against the working tree on 2026-09-02; re-verify them before editing, the file is 5,886 lines and moves.

--- a/docs/HANDOFF-tier-preserving-failover.md
+++ b/docs/HANDOFF-tier-preserving-failover.md
@@ -1,0 +1,209 @@
+# Handoff: tier-preserving failover across chain hops
+
+Written 2026-09-02 for an agent that will implement this in `~/MYNE/Projects/tools/pi-multi-pass`, branch `fix/pi-0.84-model-runtime`.
+
+Read this whole file before changing anything. Every line number below was checked against the working tree on 2026-09-02; re-verify them before editing, the file is 5,886 lines and moves.
+
+---
+
+## Correction, 2026-09-02, added after the first version shipped
+
+**The first version of this handoff got the priority wrong, and it is worth knowing why before you trust the rest of it.**
+
+Joel's actual ask, in his words, was: *"if something does not work with the agents, it should fall back to the other accounts using the pool and the chain, no?"* Tier preservation was the **refinement** he added afterwards (*"it shouldn't change back to the default used by the pool... it should change to the same model but in the other account"*). The first version of this file promoted the refinement to the headline and left the primary ask - failover happening at all - as an unexamined aside: *"it did not roll to the codex entry... I have not investigated it."*
+
+That aside was the bug. Investigated on 2026-09-02:
+
+`PoolManager.handleError` (line ~2789) exits on its second line unless `isRateLimitError(errorMessage)` is true. Anthropic reports subscription exhaustion as **HTTP 400 `invalid_request_error`** with the body `You're out of extra usage. Ask your workspace admin to add more so you can keep going.` That string matches **none** of the eight original `RATE_LIMIT_PATTERNS` - no `limit`, no `quota`, no `429`. So `handleError` returned `false`, `buildFailoverPlan` was never called, and the pool and the chain were never consulted. Verified by evaluating the eight regexes against the verbatim provider string.
+
+**Consequence for the work described below:** the chain hop was not "the hot path", it was **dead code for this error**. Tier mapping at the chain-hop site would have changed nothing observable, and the acceptance criteria in this file would have been satisfied by unit tests while Joel's real session kept dying exactly as before.
+
+**Fixed** in the same change that added this correction: three patterns added to `RATE_LIMIT_PATTERNS` (`out of (extra )?usage`, `credit balance is too low`, `insufficient[_ ]credit`), with a comment at the definition saying the list means *"rotate to another account"* and not *"was this a 429"*. Guarded by `tests/error-classification-check.mjs`, which parses the array out of the source rather than copying it, asserts 9 real provider strings rotate and 5 real non-quota errors do not, and was confirmed to fail when the new pattern is deleted.
+
+**The lesson for whoever writes the next handoff:** a precisely-located finding is not the same as the user's problem. The asymmetry at lines 2445/2516 was real, exact, and second in line. Order the work by what the user observed, not by what you found first.
+
+---
+
+## The one-sentence goal
+
+When failover crosses from one pool to another, keep the **tier** of the model the user was actually using, instead of jumping to whatever single model the chain entry hardcodes.
+
+---
+
+## Why this matters, concretely
+
+Joel's live config (`~/.pi/agent/multi-pass.json`):
+
+```json
+"pools": [
+  { "name": "anthropic", "baseProvider": "anthropic",     "members": ["anthropic", "anthropic-2"] },
+  { "name": "codex",     "baseProvider": "openai-codex",  "members": ["openai-codex"] }
+],
+"chains": [
+  { "name": "all", "entries": [
+      { "pool": "anthropic", "model": "claude-opus-5", "enabled": true },
+      { "pool": "codex",     "model": "gpt-5.6-sol",   "enabled": true }
+  ]}
+]
+```
+
+A cheap recon agent runs on `openai-codex/gpt-5.4-mini`. Its pool is exhausted. Failover hops to the next chain entry and lands on... whatever `entry.model` says. A `gpt-5.4-mini` session gets upgraded to a flagship model, silently, and the cost of a "fast, cheap" step multiplies.
+
+The same in reverse: a flagship `claude-opus-5` session can hop to a chain entry naming a cheap model and quietly lose capability mid-task.
+
+**Neither is a crash. Both are silent.** The user sees the work continue and finds out from the bill or from a suddenly worse answer.
+
+## Where it actually goes wrong
+
+`extensions/multi-sub.ts`, class `PoolManager`, method `buildFailoverPlan(currentModel: Model<Api>, ...)` at **line 2402**.
+
+The method builds two kinds of candidate, and they disagree with each other:
+
+```ts
+// ~line 2445 — SAME-POOL failover, another member of the same pool
+candidates.push({
+  poolName: pool.name,
+  provider: candidate,
+  modelId: currentModel.id,     // ← keeps the model the user was on. Correct.
+  source: "pool",
+});
+
+// ~line 2516 — CHAIN HOP, crossing into a different pool
+candidates.push({
+  poolName: targetPool.name,
+  provider: member,
+  modelId: entry.model,         // ← discards it for the chain entry's hardcoded model.
+  source: "chain",
+});
+```
+
+Seventy lines apart, in one function. Same-pool rotation already does the right thing. Only the chain hop throws the model away, because a chain entry was designed as "pool + the model to use there" rather than "pool + how to translate into it".
+
+That is the whole bug.
+
+---
+
+## What to build
+
+### A tier table, and `entry.model` demoted to a fallback
+
+Add an optional top-level `tiers` array to `MultiPassConfig` (interface at **line 1695**):
+
+```json
+"tiers": [
+  { "name": "flagship", "models": { "anthropic": "claude-opus-5",    "openai-codex": "gpt-5.6-sol"  } },
+  { "name": "mid",      "models": { "anthropic": "claude-sonnet-5",  "openai-codex": "gpt-5.4"      } },
+  { "name": "cheap",    "models": { "anthropic": "claude-haiku-4-5", "openai-codex": "gpt-5.4-mini" } }
+]
+```
+
+Resolution order at the chain-hop site:
+
+1. Find the tier whose `models[currentModel.provider] === currentModel.id`.
+2. If found, and that tier names a model for the candidate `member`'s provider, use it.
+3. Otherwise fall back to `entry.model`, exactly as today.
+
+Step 3 is what makes this **backwards compatible**: a config with no `tiers` key behaves exactly as it does now, and every existing test keeps passing. Do not make `tiers` required.
+
+Keyed by **provider name**, not by pool name, because a pool can hold several providers (`anthropic` and `anthropic-2`) that share a model catalogue.
+
+### Suggested shape
+
+```ts
+interface TierConfig {
+  /** Tier name, user-defined. Cosmetic — used in log lines. */
+  name: string;
+  /** provider name → model id for that provider at this tier. */
+  models: Record<string, string>;
+}
+```
+
+A small pure resolver, exported for tests:
+
+```ts
+export function resolveTierEquivalent(
+  tiers: TierConfig[] | undefined,
+  fromProvider: string,
+  fromModelId: string,
+  toProvider: string,
+): string | undefined
+```
+
+Then at the chain-hop candidate push:
+
+```ts
+const mapped = resolveTierEquivalent(config.tiers, currentModel.provider, currentModel.id, member);
+candidates.push({
+  poolName: targetPool.name,
+  provider: member,
+  modelId: mapped ?? entry.model,
+  source: "chain",
+  chainName: applicable.chain.name,
+  chainIndex,
+});
+```
+
+Keep it a pure function. It is the whole testable surface of this change.
+
+### Tell the user which happened
+
+The failover status lines are built by `formatFailoverTransition` (**line 4565**) and friends around **4532–4576**. A tier-mapped hop and a fallback hop must be distinguishable in the status line, because "why am I suddenly on a different model" is exactly the question this feature exists to answer. Something like `codex/gpt-5.4-mini (tier: cheap)` versus `codex/gpt-5.6-sol (chain default)`.
+
+---
+
+## Ambiguities to settle before coding — do not guess
+
+1. **A model in no tier.** A user on `claude-fable-5` with no tier entry. Fall back to `entry.model` (proposed), or refuse to hop? Proposal: fall back, and say so in the status line.
+2. **A tier with no model for the target provider.** `cheap` names anthropic and codex, target pool is a third provider. Fall back to `entry.model`.
+3. **A model listed in two tiers.** Config error. Proposal: first match wins, and surface a warning at config load rather than silently picking.
+4. **Interaction with `presets`** (`PresetConfig`, ~line 1636, `entries: PresetEntry[]`). Presets are a separate ordered route list. Decide explicitly whether tier mapping applies to preset traversal too, or only to chains. Proposal: chains only in this change; note it in the README.
+5. **Does `--model` on the CLI pin the tier or the exact model?** Today it pins the exact model. Tier mapping should not override an explicitly requested model on the *first* attempt — only on failover. Verify that is what happens.
+
+---
+
+## Acceptance criteria
+
+Observable, not "it looks right":
+
+1. With the `tiers` table above and both anthropic members exhausted, a session on **`openai-codex/gpt-5.4-mini`** that fails over lands on the **cheap** anthropic model, not on `claude-opus-5`. Paste the failover status line.
+2. Same table, a session on **`anthropic/claude-opus-5`** lands on **`gpt-5.6-sol`**. Paste the line.
+3. A config with **no `tiers` key** produces byte-identical failover behaviour to `main`. Every existing test in `tests/` passes unchanged.
+4. A model absent from every tier falls back to `entry.model` and the status line says so.
+5. Same-pool rotation is untouched — it already preserves `currentModel.id` and must keep doing so.
+
+## Tests
+
+`tests/` holds plain `.mjs` checks run directly with `node` (there is **no** npm script — `package.json` has no `scripts` key). `tests/runtime-failover-check.mjs` is the closest existing harness; extend it or add `tests/tier-mapping-check.mjs` alongside.
+
+Cover at minimum: mapped hop, unmapped model falls back, tier missing the target provider falls back, no-`tiers` config unchanged, and same-pool rotation still preserves the model.
+
+**Plant a defect and confirm the test catches it.** Revert `modelId: mapped ?? entry.model` to `modelId: entry.model` and the mapped-hop test must fail. A test that has never failed proves nothing.
+
+---
+
+## The other half of Joel's intent, which lives in the subagents repo
+
+This was filed as "out of scope, tracked separately" in the first version. Nothing tracked it. It is now tracked in `~/MYNE/Projects/tools/pi-interactive-subagents/docs/INTENT-subagent-failover.md`, and it is the half Joel asked for first.
+
+**Sub-agents do not load multi-pass at all.** `pi-interactive-subagents` launches every restricted child with `--no-extensions` (`pi-extension/subagents/index.ts:922`) and then re-enables only the extensions backing that child's whitelisted *tools*. Multi-pass backs no tool, so nothing re-enables it — a sub-agent gets a bare `--model <provider>/<id>`, one account, no pool, no chain.
+
+Verified 2026-09-02: a sub-agent pinned to `anthropic/claude-opus-5` died in 2s with `400 ... "You're out of extra usage"` and `exitCode: 1`, while the parent session on `chain:all` kept running.
+
+That fix belongs in the subagents repo, not here. Note it because **tier-preserving failover buys sub-agents nothing until that lands** — but the two changes are independent and can be built in either order.
+
+---
+
+## Evidence behind this handoff
+
+- `extensions/multi-sub.ts:2402` `buildFailoverPlan`, the two candidate pushes at ~2445 and ~2516.
+- `MultiPassConfig` interface at line 1695; `ChainEntryConfig` at 1677; `PoolConfig` at 1655; `PresetConfig` at ~1636.
+- Failover status formatting, lines 4532–4576.
+- Joel's live `~/.pi/agent/multi-pass.json`: two pools, one chain `all`, entries `anthropic/claude-opus-5` then `codex/gpt-5.6-sol`, no `presets`.
+- Observed on 2026-09-02: `anthropic` returns `400 invalid_request_error "You're out of extra usage"`; `anthropic-2` reports `not_ready`; `openai-codex` is the only live account. So the anthropic pool is exhausted on both members, which is what makes the chain hop the hot path rather than a rarity.
+
+## What not to do
+
+- Do not make `tiers` required, and do not rewrite existing configs. Absent key = today's behaviour.
+- Do not move the tier lookup inside the member loop's skip classification — it is a pure mapping, keep it at the candidate push.
+- Do not touch same-pool rotation. It is already correct.
+- Do not infer tiers from model names by string matching (`*-mini`, `*-opus`). Naming is a vendor decision and it will break. The table is explicit on purpose.

--- a/extensions/multi-sub.ts
+++ b/extensions/multi-sub.ts
@@ -45,6 +45,7 @@ import {
 	DynamicBorder,
 	getAgentDir,
 	keyHint,
+	LoginDialogComponent,
 	readStoredCredential,
 } from "@earendil-works/pi-coding-agent";
 import type { OAuthCredentials, OAuthLoginCallbacks } from "@earendil-works/pi-ai/oauth";
@@ -303,6 +304,7 @@ interface AuthStorageEntry {
 interface AuthCompat {
 	hasAuth(provider: string): boolean;
 	get(provider: string): AuthStorageEntry | undefined;
+	set(provider: string, credential: AuthStorageEntry): void;
 	logout(provider: string): void;
 }
 
@@ -332,6 +334,12 @@ function createAuthCompat(modelRegistry: ExtensionContext["modelRegistry"]): Aut
 		get(provider: string): AuthStorageEntry | undefined {
 			return readStoredCredential(provider) as AuthStorageEntry | undefined;
 		},
+		set(provider: string, credential: AuthStorageEntry): void {
+			const data = readAuthJson();
+			data[provider] = credential;
+			writeFileSync(authJsonPath(), JSON.stringify(data, null, 2), { mode: 0o600 });
+			void modelRegistry.refresh({ providers: [provider] });
+		},
 		logout(provider: string): void {
 			const data = readAuthJson();
 			if (!(provider in data)) return;
@@ -349,6 +357,87 @@ function createAuthCompat(modelRegistry: ExtensionContext["modelRegistry"]): Aut
 function ctxAuth(ctx: ExtensionContext | ExtensionCommandContext): AuthCompat {
 	rememberRegistry(ctx);
 	return createAuthCompat(ctx.modelRegistry);
+}
+
+type SubscriptionLoginResult =
+	| { ok: true }
+	| { ok: false; cancelled: boolean; error?: string };
+
+function loginWasCancelled(error: unknown): boolean {
+	return error instanceof Error && (error.message === "Login cancelled" || error.name === "AbortError");
+}
+
+/** Start and persist the selected cloned provider's OAuth flow directly. */
+async function loginSubscription(ctx: ExtensionCommandContext, entry: SubEntry): Promise<boolean> {
+	if (!ctx.hasUI) {
+		ctx.ui.notify("Subscription login requires interactive UI.", "error");
+		return false;
+	}
+
+	rememberRegistry(ctx);
+	const providerName = subProviderName(entry);
+	const displayName = subDisplayName(entry);
+	const oauth = PROVIDER_TEMPLATES[entry.provider]?.buildOAuth(entry.index);
+	if (!oauth) {
+		ctx.ui.notify(`No OAuth flow is available for ${displayName}.`, "error");
+		return false;
+	}
+
+	const result = await ctx.ui.custom<SubscriptionLoginResult>((tui, _theme, _keybindings, done) => {
+		let finished = false;
+		const finish = (value: SubscriptionLoginResult): void => {
+			if (finished) return;
+			finished = true;
+			done(value);
+		};
+
+		const dialog = new LoginDialogComponent(
+			tui,
+			providerName,
+			(_success, message) => finish({ ok: false, cancelled: true, error: message }),
+			displayName,
+		);
+
+		void (async () => {
+			try {
+				const credential = await oauth.login({
+					onAuth: (info) => dialog.showAuth(info.url, info.instructions),
+					onDeviceCode: (info) => {
+						dialog.showDeviceCode(info);
+						dialog.showWaiting("Waiting for authentication...");
+					},
+					onPrompt: (prompt) => dialog.showPrompt(prompt.message, prompt.placeholder),
+					onProgress: (message) => dialog.showProgress(message),
+					onManualCodeInput: () => dialog.showManualInput("Paste the authorization code"),
+					onSelect: async (prompt) => {
+						const labels = prompt.options.map((option) => option.label);
+						const selected = await ctx.ui.select(prompt.message, labels);
+						return prompt.options.find((option) => option.label === selected)?.id;
+					},
+					signal: dialog.signal,
+				});
+				ctxAuth(ctx).set(providerName, { ...credential, type: "oauth" });
+				finish({ ok: true });
+			} catch (error) {
+				finish({
+					ok: false,
+					cancelled: loginWasCancelled(error) || dialog.signal.aborted,
+					error: error instanceof Error ? error.message : String(error),
+				});
+			}
+		})();
+
+		return dialog;
+	});
+
+	if (result.ok) {
+		ctx.ui.notify(`Logged in to ${displayName}`, "info");
+		return true;
+	}
+	if (!result.cancelled) {
+		ctx.ui.notify(`Login failed for ${displayName}: ${result.error ?? "Unknown error"}`, "error");
+	}
+	return false;
 }
 
 interface QuotaAccount {
@@ -2789,7 +2878,14 @@ class PoolManager {
 
 		if (lastUserPrompt) {
 			this.suppressNextStartTurn = true;
-			this.pi.sendUserMessage(lastUserPrompt);
+			// Failover runs while the failed turn is still streaming, so the replay
+			// must declare how to queue itself. Without deliverAs, pi 0.84.4 throws
+			// "Agent is already processing. Specify streamingBehavior ('steer' or
+			// 'followUp') to queue the message." and the rotation notification is
+			// immediately followed by an extension error. "followUp" (not "steer")
+			// because the replay must be a new turn on the new provider, not an
+			// injection into the turn that just failed. Ignored when not streaming.
+			this.pi.sendUserMessage(lastUserPrompt, { deliverAs: "followUp" });
 		}
 
 		return true;
@@ -3068,10 +3164,7 @@ async function showSubscriptionActions(
 		return renameSubscriptionLabel(ctx, config, entry);
 	}
 	if (action === "login") {
-		ctx.ui.notify(
-			`Use /login and select "${PROVIDER_TEMPLATES[entry.provider]?.buildOAuth(entry.index).name}" to authenticate.`,
-			"info",
-		);
+		await loginSubscription(ctx, entry);
 		return;
 	}
 	if (action === "logout") {
@@ -3172,10 +3265,7 @@ async function handleSubsAdd(pi: ExtensionAPI, ctx: ExtensionCommandContext): Pr
 	);
 
 	if (loginNow) {
-		ctx.ui.notify(
-			`Use /login and select "${PROVIDER_TEMPLATES[entry.provider]?.buildOAuth(entry.index).name}" to authenticate.`,
-			"info",
-		);
+		await loginSubscription(ctx, entry);
 	} else {
 		ctx.ui.notify(`Added ${subDisplayName(entry)}. Use /subs login to authenticate.`, "info");
 	}
@@ -3237,7 +3327,7 @@ async function handleSubsLogin(ctx: ExtensionCommandContext): Promise<void> {
 
 	const selectedProviderName = await showWrappedSelect(ctx, {
 		title: "Login to subscription",
-		subtitle: "Select a subscription to see login instructions.",
+		subtitle: "Select a subscription to start its OAuth login.",
 		initialValue: ctx.model?.provider,
 		items: notLoggedIn.map((entry) => ({
 			value: subProviderName(entry),
@@ -3252,10 +3342,7 @@ async function handleSubsLogin(ctx: ExtensionCommandContext): Promise<void> {
 	const entry = notLoggedIn.find((candidate) => subProviderName(candidate) === selectedProviderName);
 	if (!entry) return;
 
-	ctx.ui.notify(
-		`Use /login and select "${PROVIDER_TEMPLATES[entry.provider]?.buildOAuth(entry.index).name}" to authenticate.`,
-		"info",
-	);
+	await loginSubscription(ctx, entry);
 }
 
 async function handleSubsLogout(ctx: ExtensionCommandContext): Promise<void> {

--- a/extensions/multi-sub.ts
+++ b/extensions/multi-sub.ts
@@ -2298,7 +2298,6 @@ class PoolManager {
 	private providerToPool: Map<string, string> = new Map();
 	private pi: ExtensionAPI;
 	private cascadeState: FailoverCascadeState | null = null;
-	private suppressNextStartTurn = false;
 
 	constructor(pi: ExtensionAPI) {
 		this.pi = pi;
@@ -2749,10 +2748,6 @@ class PoolManager {
 	}
 
 	startTurn(prompt: string | null, currentModel?: Model<Api>): void {
-		if (this.suppressNextStartTurn) {
-			this.suppressNextStartTurn = false;
-			return;
-		}
 		if (!prompt) {
 			this.cascadeState = null;
 			return;
@@ -2875,18 +2870,6 @@ class PoolManager {
 			"info",
 		);
 		ctx.ui.setStatus("multi-pass", formatFailoverStatus(nextCandidate));
-
-		if (lastUserPrompt) {
-			this.suppressNextStartTurn = true;
-			// Failover runs while the failed turn is still streaming, so the replay
-			// must declare how to queue itself. Without deliverAs, pi 0.84.4 throws
-			// "Agent is already processing. Specify streamingBehavior ('steer' or
-			// 'followUp') to queue the message." and the rotation notification is
-			// immediately followed by an extension error. "followUp" (not "steer")
-			// because the replay must be a new turn on the new provider, not an
-			// injection into the turn that just failed. Ignored when not streaming.
-			this.pi.sendUserMessage(lastUserPrompt, { deliverAs: "followUp" });
-		}
 
 		return true;
 	}
@@ -5685,7 +5668,9 @@ export default function multiSub(pi: ExtensionAPI) {
 		poolManager.startTurn(event.prompt, ctx.model);
 	});
 
-	// Listen for errors to trigger pool rotation
+	// agent_end is emitted before pi 0.84.4's automatic retry settles. Rotate
+	// only: AgentSession retries the same turn with agent.continue(). Enqueuing
+	// lastUserPrompt here would create one duplicate follow-up per failed account.
 	pi.on("agent_end", async (event: AgentEndEvent, ctx: ExtensionContext) => {
 		if (!event.messages || event.messages.length === 0) return;
 

--- a/extensions/multi-sub.ts
+++ b/extensions/multi-sub.ts
@@ -1692,11 +1692,77 @@ interface ChainConfig {
 	enabled: boolean;
 }
 
+/**
+ * One rung of the capability ladder, listing the equivalent model at each
+ * provider. Optional: a config without `tiers` keeps the pre-tier behaviour,
+ * where a chain hop uses the chain entry's model whatever the session was on.
+ */
+interface TierConfig {
+	/** User-defined, cosmetic. Appears in the failover status line. */
+	name: string;
+	/** provider name -> model id for that provider at this tier. */
+	models: Record<string, string>;
+}
+
 interface MultiPassConfig {
 	subscriptions: SubEntry[];
 	pools: PoolConfig[];
 	chains: ChainConfig[];
 	presets: PresetConfig[];
+	/** Optional model-equivalence table used when failover crosses pools. */
+	tiers?: TierConfig[];
+}
+
+/**
+ * The model at `toProvider` that sits on the same tier as `fromModelId` does at
+ * `fromProvider`, or undefined when the table cannot answer.
+ *
+ * Keyed by **provider**, never by pool: a pool holds `anthropic` and
+ * `anthropic-2`, which are two accounts on one catalogue, and a pool key could
+ * not distinguish them.
+ *
+ * Callers pass the pool's **baseProvider**, not the account name. By the time a
+ * cascade reaches a chain hop it has usually rotated within the pool already, so
+ * `currentModel.provider` is `anthropic-2` - which no sane table lists, because
+ * a second account on the same subscription has the same catalogue and the same
+ * tiers. Keying the table by account would force every entry to be written
+ * twice and would silently stop mapping the day a third account is added.
+ *
+ * Undefined is a normal answer, not a failure - the
+ * caller falls back to the chain entry's model, which is what makes a config
+ * without `tiers` behave exactly as before.
+ *
+ * Pure, and exported for tests: it is the whole decision surface of tiering.
+ */
+export function resolveTierEquivalent(
+	tiers: TierConfig[] | undefined,
+	fromProvider: string,
+	fromModelId: string,
+	toProvider: string,
+): string | undefined {
+	if (!Array.isArray(tiers)) return undefined;
+	for (const tier of tiers) {
+		if (!tier || typeof tier !== "object" || !tier.models) continue;
+		// First match wins. A model listed in two tiers is a config error; picking
+		// deterministically beats picking the last one read.
+		if (tier.models[fromProvider] !== fromModelId) continue;
+		const mapped = tier.models[toProvider];
+		return typeof mapped === "string" && mapped !== "" ? mapped : undefined;
+	}
+	return undefined;
+}
+
+/** The tier a model belongs to, for the status line. */
+function findTierName(
+	tiers: TierConfig[] | undefined,
+	provider: string,
+	modelId: string,
+): string | undefined {
+	if (!Array.isArray(tiers)) return undefined;
+	for (const tier of tiers) {
+		if (tier?.models?.[provider] === modelId) return tier.name;
+	}
+	return undefined;
 }
 
 /** Project-level config (.pi/multi-pass.json) */
@@ -1717,6 +1783,8 @@ interface EffectiveConfig {
 	pools: PoolConfig[];
 	chains: ChainConfig[];
 	presets: PresetConfig[];
+	/** Model-equivalence table. Global only - a project cannot redefine tiers. */
+	tiers?: TierConfig[];
 	/** Exact provider names allowed in this project, if restricted. */
 	allowedProviderNames?: string[];
 	/** Which project config was loaded from, if any */
@@ -1735,13 +1803,33 @@ function emptyMultiPassConfig(): MultiPassConfig {
 	return { subscriptions: [], pools: [], chains: [], presets: [] };
 }
 
+/** Keep only well-formed tiers, so one bad entry cannot break failover. */
+function normalizeTiers(raw: unknown): TierConfig[] | undefined {
+	if (!Array.isArray(raw)) return undefined;
+	const tiers: TierConfig[] = [];
+	for (const entry of raw) {
+		if (!entry || typeof entry !== "object") continue;
+		const candidate = entry as Partial<TierConfig>;
+		if (typeof candidate.name !== "string" || !candidate.name) continue;
+		if (!candidate.models || typeof candidate.models !== "object") continue;
+		const models: Record<string, string> = {};
+		for (const [provider, modelId] of Object.entries(candidate.models)) {
+			if (typeof modelId === "string" && modelId !== "") models[provider] = modelId;
+		}
+		if (Object.keys(models).length > 0) tiers.push({ name: candidate.name, models });
+	}
+	return tiers.length > 0 ? tiers : undefined;
+}
+
 function normalizeMultiPassConfig(raw: unknown): MultiPassConfig {
 	const parsed = raw && typeof raw === "object" ? (raw as Partial<MultiPassConfig>) : {};
+	const tiers = normalizeTiers(parsed.tiers);
 	return {
 		subscriptions: Array.isArray(parsed.subscriptions) ? parsed.subscriptions : [],
 		pools: Array.isArray(parsed.pools) ? parsed.pools : [],
 		chains: Array.isArray(parsed.chains) ? parsed.chains : [],
 		presets: Array.isArray(parsed.presets) ? parsed.presets : [],
+		...(tiers ? { tiers } : {}),
 	};
 }
 
@@ -1819,6 +1907,7 @@ function loadEffectiveConfig(cwd: string): EffectiveConfig {
 			pools: global.pools,
 			chains: global.chains,
 			presets: global.presets,
+			...(global.tiers ? { tiers: global.tiers } : {}),
 		};
 	}
 
@@ -1841,6 +1930,7 @@ function loadEffectiveConfig(cwd: string): EffectiveConfig {
 		pools,
 		chains,
 		presets: global.presets,
+		...(global.tiers ? { tiers: global.tiers } : {}),
 		allowedProviderNames,
 		projectConfigPath: projectConfigPath(cwd),
 	};
@@ -2577,13 +2667,45 @@ class PoolManager {
 					continue;
 				}
 				foundEligible = true;
+				// A chain entry was designed as "pool + the model to use there". Read
+				// as "pool + how to translate into it", entry.model becomes the
+				// fallback and the session keeps its tier across the hop. Same-pool
+				// rotation above already keeps currentModel.id; this makes the two
+				// agree instead of contradicting each other 70 lines apart.
+				const tierModel = resolveTierEquivalent(
+					config.tiers,
+					pool.baseProvider || currentModel.provider,
+					currentModel.id,
+					targetPool.baseProvider || member,
+				);
+				// A tier naming a model this provider does not serve must not be used:
+				// handleError bails out entirely when modelRegistry.find misses, so one
+				// typo in the table would disable failover rather than degrade it.
+				const tierModelUsable =
+					tierModel !== undefined &&
+					(registryRef?.find(member, tierModel) !== undefined || registryRef === undefined);
+				const useTier = tierModel !== undefined && tierModelUsable;
 				candidates.push({
 					poolName: targetPool.name,
 					provider: member,
-					modelId: entry.model,
+					modelId: useTier ? (tierModel as string) : entry.model,
 					source: "chain",
 					chainName: applicable.chain.name,
 					chainIndex,
+					// Only annotate when a tier table exists, so configs without one
+					// keep byte-identical status lines.
+					...(config.tiers
+						? useTier
+							? {
+								modelSource: "tier" as const,
+								tierName: findTierName(
+									config.tiers,
+									pool.baseProvider || currentModel.provider,
+									currentModel.id,
+								),
+							}
+							: { modelSource: "chain-default" as const }
+						: {}),
 				});
 			}
 			if (!foundEligible) {
@@ -4576,6 +4698,16 @@ interface FailoverCandidate {
 	source: "pool" | "chain";
 	chainName?: string;
 	chainIndex?: number;
+	/**
+	 * Where modelId came from on a chain hop. "tier" means the tier table
+	 * translated the running model into the target provider's equivalent;
+	 * "chain-default" means it fell back to the chain entry's model. The two are
+	 * distinguished in the status line because "why am I suddenly on a different
+	 * model" is the question tiering exists to answer.
+	 */
+	modelSource?: "tier" | "chain-default";
+	/** Tier name when modelSource is "tier". */
+	tierName?: string;
 }
 
 interface FailoverSkip {
@@ -4615,13 +4747,23 @@ interface FailoverCascadeState {
 	visitedChainIndexes: Set<number>;
 }
 
-function formatFailoverTarget(candidate: Pick<FailoverCandidate, "provider" | "modelId">): string {
+function formatFailoverTarget(
+	candidate: Pick<FailoverCandidate, "provider" | "modelId" | "modelSource" | "tierName">,
+): string {
+	// No suffix when nothing translated the model, so a config without tiers
+	// produces exactly the strings it always did.
+	if (candidate.modelSource === "tier" && candidate.tierName) {
+		return `${candidate.provider} (${candidate.modelId}) [tier: ${candidate.tierName}]`;
+	}
+	if (candidate.modelSource === "chain-default") {
+		return `${candidate.provider} (${candidate.modelId}) [chain default]`;
+	}
 	return `${candidate.provider} (${candidate.modelId})`;
 }
 
 function formatFailoverStatus(
 	candidate:
-		| Pick<FailoverCandidate, "provider" | "modelId" | "source" | "poolName" | "chainName" | "chainIndex">
+		| Pick<FailoverCandidate, "provider" | "modelId" | "source" | "poolName" | "chainName" | "chainIndex" | "modelSource" | "tierName">
 		| null,
 	fallbackPoolName?: string,
 ): string {
@@ -4637,7 +4779,7 @@ function formatFailoverStatus(
 }
 
 function formatFailoverContinuation(
-	nextCandidate: Pick<FailoverCandidate, "provider" | "modelId" | "source" | "poolName" | "chainName" | "chainIndex"> | undefined,
+	nextCandidate: Pick<FailoverCandidate, "provider" | "modelId" | "source" | "poolName" | "chainName" | "chainIndex" | "modelSource" | "tierName"> | undefined,
 ): string {
 	if (!nextCandidate) {
 		return "cascade exhausted; no later eligible target";
@@ -4651,7 +4793,7 @@ function formatFailoverContinuation(
 function formatFailoverTransition(
 	poolName: string,
 	currentProvider: string,
-	nextCandidate: Pick<FailoverCandidate, "provider" | "modelId" | "source" | "poolName" | "chainName" | "chainIndex">,
+	nextCandidate: Pick<FailoverCandidate, "provider" | "modelId" | "source" | "poolName" | "chainName" | "chainIndex" | "modelSource" | "tierName">,
 ): string {
 	const phase = nextCandidate.source === "chain"
 		? `advancing to chain ${nextCandidate.chainName}#${(nextCandidate.chainIndex ?? 0) + 1}`
@@ -5780,6 +5922,7 @@ export default function multiSub(pi: ExtensionAPI) {
 				pools: effective.pools,
 				chains: effective.chains,
 				presets: effective.presets,
+				tiers: effective.tiers,
 			}),
 		);
 

--- a/extensions/multi-sub.ts
+++ b/extensions/multi-sub.ts
@@ -45,30 +45,10 @@ import {
 	DynamicBorder,
 	getAgentDir,
 	keyHint,
+	readStoredCredential,
 } from "@earendil-works/pi-coding-agent";
-import {
-	anthropicOAuthProvider,
-	loginAnthropic,
-	refreshAnthropicToken,
-	openaiCodexOAuthProvider,
-	loginOpenAICodex,
-	refreshOpenAICodexToken,
-	githubCopilotOAuthProvider,
-	loginGitHubCopilot,
-	refreshGitHubCopilotToken,
-	getGitHubCopilotBaseUrl,
-	normalizeDomain,
-	geminiCliOAuthProvider,
-	loginGeminiCli,
-	refreshGoogleCloudToken,
-	antigravityOAuthProvider,
-	loginAntigravity,
-	refreshAntigravityToken,
-	type OAuthCredentials,
-	type OAuthLoginCallbacks,
-	type OAuthProviderInterface,
-} from "@earendil-works/pi-ai/oauth";
-import { getModels, type Api, type Model } from "@earendil-works/pi-ai";
+import type { OAuthCredentials, OAuthLoginCallbacks } from "@earendil-works/pi-ai/oauth";
+import { getModels, type Api, type Model } from "@earendil-works/pi-ai/compat";
 import {
 	Container,
 	Key,
@@ -85,157 +65,176 @@ import {
 type CopilotCredentials = OAuthCredentials & { enterpriseUrl?: string };
 type GeminiCredentials = OAuthCredentials & { projectId?: string };
 
+/**
+ * OAuth compatibility shim for pi 0.84.4.
+ *
+ * `@earendil-works/pi-ai/oauth` used to export the concrete flows
+ * (`loginAnthropic`, `refreshAnthropicToken`, `anthropicOAuthProvider`, ...).
+ * In 0.84.4 that entrypoint is TYPE-ONLY: verified at runtime inside pi, it
+ * has 0 runtime exports, so every one of those imports is `undefined`. The
+ * flows now live behind `Provider.auth.oauth` on the built-in provider,
+ * loaded lazily by pi itself.
+ *
+ * So instead of importing the flows, we borrow them from the built-in
+ * provider at call time. `provider.auth.oauth` is an `OAuthAuth`:
+ *
+ *   login(interaction: { prompt(p), notify(e), signal }): Promise<Credential>
+ *   refresh(credential, signal): Promise<Credential>
+ *
+ * while `pi.registerProvider({ oauth })` still takes the legacy
+ * callback-shaped config (`login(callbacks)`, `refreshToken`, `getApiKey`).
+ * pi's own `adaptOAuth()` converts legacy -> canonical; the adapter below is
+ * its inverse, so a cloned subscription runs the exact same flow as /login on
+ * the base provider.
+ *
+ * Providers are resolved lazily because `registerSub()` runs at extension
+ * load, before any ExtensionContext exists. A login can only happen after the
+ * UI is up, by which point `rememberRegistry()` has captured one.
+ */
+type ModelRegistryLike = ExtensionContext["modelRegistry"];
+
+let registryRef: ModelRegistryLike | undefined;
+
+function rememberRegistry(ctx: ExtensionContext | ExtensionCommandContext): void {
+	registryRef = ctx.modelRegistry;
+}
+
+interface BuiltinOAuthFlow {
+	name?: string;
+	isSubscription?: boolean;
+	login(interaction: {
+		signal: AbortSignal;
+		prompt(prompt: Record<string, unknown>): Promise<string>;
+		notify(event: Record<string, unknown>): void;
+	}): Promise<OAuthCredentials>;
+	refresh(credential: OAuthCredentials, signal: AbortSignal): Promise<OAuthCredentials>;
+}
+
+function getBuiltinOAuthFlow(baseProvider: string): BuiltinOAuthFlow {
+	const registry = registryRef;
+	if (!registry) {
+		throw new Error(
+			`Cannot start OAuth for "${baseProvider}": pi has not handed this extension a context yet.`,
+		);
+	}
+	const provider = registry.getProvider(baseProvider) as
+		| { auth?: { oauth?: BuiltinOAuthFlow } }
+		| undefined;
+	const flow = provider?.auth?.oauth;
+	if (!flow || typeof flow.login !== "function" || typeof flow.refresh !== "function") {
+		throw new Error(
+			`Provider "${baseProvider}" exposes no built-in OAuth flow in this pi version.`,
+		);
+	}
+	return flow;
+}
+
+/**
+ * Inverse of pi's `adaptOAuth()`: legacy extension callbacks -> the canonical
+ * `AuthInteraction` the built-in flow expects.
+ */
+function toAuthInteraction(callbacks: OAuthLoginCallbacks): {
+	signal: AbortSignal;
+	prompt(prompt: Record<string, unknown>): Promise<string>;
+	notify(event: Record<string, unknown>): void;
+} {
+	return {
+		signal: callbacks.signal ?? new AbortController().signal,
+		async prompt(prompt: Record<string, unknown>): Promise<string> {
+			const type = prompt.type;
+			if (type === "select") {
+				const options = (prompt.options ?? []) as { id: string; label: string }[];
+				const chosen = await callbacks.onSelect({
+					message: String(prompt.message ?? ""),
+					options: options.map((option) => ({ id: option.id, label: option.label })),
+				});
+				if (chosen === undefined) throw new Error("Selection cancelled");
+				return chosen;
+			}
+			if (type === "manual_code" && callbacks.onManualCodeInput) {
+				return callbacks.onManualCodeInput();
+			}
+			return callbacks.onPrompt({
+				message: String(prompt.message ?? ""),
+				placeholder: prompt.placeholder as string | undefined,
+			});
+		},
+		notify(event: Record<string, unknown>): void {
+			const type = event.type;
+			if (type === "auth_url") {
+				callbacks.onAuth({
+					url: String(event.url ?? ""),
+					instructions: event.instructions as string | undefined,
+				});
+				return;
+			}
+			if (type === "device_code") {
+				callbacks.onDeviceCode({
+					userCode: String(event.userCode ?? ""),
+					verificationUri: String(event.verificationUri ?? ""),
+					intervalSeconds: event.intervalSeconds as number | undefined,
+					expiresInSeconds: event.expiresInSeconds as number | undefined,
+				});
+				return;
+			}
+			callbacks.onProgress?.(String(event.message ?? ""));
+		},
+	};
+}
+
+/** Legacy-shaped OAuth config for `pi.registerProvider`, backed by the built-in flow. */
+function buildOAuthFromBuiltin(
+	baseProvider: string,
+	name: string,
+): {
+	name: string;
+	isSubscription: boolean;
+	login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials>;
+	refreshToken(credentials: OAuthCredentials, signal?: AbortSignal): Promise<OAuthCredentials>;
+	getApiKey(credentials: OAuthCredentials): string;
+} {
+	return {
+		name,
+		isSubscription: true,
+		async login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
+			return getBuiltinOAuthFlow(baseProvider).login(toAuthInteraction(callbacks));
+		},
+		async refreshToken(credentials: OAuthCredentials, signal?: AbortSignal): Promise<OAuthCredentials> {
+			return getBuiltinOAuthFlow(baseProvider).refresh(
+				credentials,
+				signal ?? new AbortController().signal,
+			);
+		},
+		getApiKey(credentials: OAuthCredentials): string {
+			return credentials.access;
+		},
+	};
+}
+
 interface ProviderTemplate {
 	displayName: string;
-	builtinOAuth: OAuthProviderInterface;
-	usesCallbackServer?: boolean;
-	buildOAuth(index: number): Omit<OAuthProviderInterface, "id">;
-	buildModifyModels?(providerName: string): OAuthProviderInterface["modifyModels"];
+	/** Built-in provider id whose OAuth flow this subscription reuses. */
+	baseProvider: string;
+	buildOAuth(index: number): ReturnType<typeof buildOAuthFromBuiltin>;
 }
 
 const PROVIDER_TEMPLATES: Record<string, ProviderTemplate> = {
 	anthropic: {
 		displayName: "Anthropic (Claude Pro/Max)",
-		builtinOAuth: anthropicOAuthProvider,
-		buildOAuth(index: number) {
-			return {
-				name: `Anthropic #${index}`,
-				async login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
-					return loginAnthropic({
-						onAuth: callbacks.onAuth,
-						onPrompt: callbacks.onPrompt,
-						onProgress: callbacks.onProgress,
-						onManualCodeInput: callbacks.onManualCodeInput,
-					});
-				},
-				async refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
-					return refreshAnthropicToken(credentials.refresh);
-				},
-				getApiKey(credentials: OAuthCredentials): string {
-					return credentials.access;
-				},
-			};
-		},
+		baseProvider: "anthropic",
+		buildOAuth: (index: number) => buildOAuthFromBuiltin("anthropic", `Anthropic #${index}`),
 	},
 
 	"openai-codex": {
 		displayName: "ChatGPT Plus/Pro (Codex)",
-		builtinOAuth: openaiCodexOAuthProvider,
-		usesCallbackServer: true,
-		buildOAuth(index: number) {
-			return {
-				name: `ChatGPT Codex #${index}`,
-				usesCallbackServer: true,
-				async login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
-					return loginOpenAICodex({
-						onAuth: callbacks.onAuth,
-						onPrompt: callbacks.onPrompt,
-						onProgress: callbacks.onProgress,
-						onManualCodeInput: callbacks.onManualCodeInput,
-					});
-				},
-				async refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
-					return refreshOpenAICodexToken(credentials.refresh);
-				},
-				getApiKey(credentials: OAuthCredentials): string {
-					return credentials.access;
-				},
-			};
-		},
+		baseProvider: "openai-codex",
+		buildOAuth: (index: number) => buildOAuthFromBuiltin("openai-codex", `ChatGPT Codex #${index}`),
 	},
 
 	"github-copilot": {
 		displayName: "GitHub Copilot",
-		builtinOAuth: githubCopilotOAuthProvider,
-		buildOAuth(index: number) {
-			return {
-				name: `GitHub Copilot #${index}`,
-				async login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
-					return loginGitHubCopilot({
-						onAuth: (url: string, instructions?: string) =>
-							callbacks.onAuth({ url, instructions }),
-						onPrompt: callbacks.onPrompt,
-						onProgress: callbacks.onProgress,
-						signal: callbacks.signal,
-					});
-				},
-				async refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
-					const creds = credentials as CopilotCredentials;
-					return refreshGitHubCopilotToken(creds.refresh, creds.enterpriseUrl);
-				},
-				getApiKey(credentials: OAuthCredentials): string {
-					return credentials.access;
-				},
-			};
-		},
-		buildModifyModels(providerName: string) {
-			return (models: Model<Api>[], credentials: OAuthCredentials): Model<Api>[] => {
-				const creds = credentials as CopilotCredentials;
-				const domain = creds.enterpriseUrl
-					? (normalizeDomain(creds.enterpriseUrl) ?? undefined)
-					: undefined;
-				const baseUrl = getGitHubCopilotBaseUrl(creds.access, domain);
-				return models.map((m) =>
-					m.provider === providerName ? { ...m, baseUrl } : m,
-				);
-			};
-		},
-	},
-
-	"google-gemini-cli": {
-		displayName: "Google Cloud Code Assist",
-		builtinOAuth: geminiCliOAuthProvider,
-		usesCallbackServer: true,
-		buildOAuth(index: number) {
-			return {
-				name: `Google Cloud Code Assist #${index}`,
-				usesCallbackServer: true,
-				async login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
-					return loginGeminiCli(
-						callbacks.onAuth,
-						callbacks.onProgress,
-						callbacks.onManualCodeInput,
-					);
-				},
-				async refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
-					const creds = credentials as GeminiCredentials;
-					if (!creds.projectId) throw new Error("Missing projectId");
-					return refreshGoogleCloudToken(creds.refresh, creds.projectId);
-				},
-				getApiKey(credentials: OAuthCredentials): string {
-					const creds = credentials as GeminiCredentials;
-					return JSON.stringify({ token: creds.access, projectId: creds.projectId });
-				},
-			};
-		},
-	},
-
-	"google-antigravity": {
-		displayName: "Antigravity",
-		builtinOAuth: antigravityOAuthProvider,
-		usesCallbackServer: true,
-		buildOAuth(index: number) {
-			return {
-				name: `Antigravity #${index}`,
-				usesCallbackServer: true,
-				async login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
-					return loginAntigravity(
-						callbacks.onAuth,
-						callbacks.onProgress,
-						callbacks.onManualCodeInput,
-					);
-				},
-				async refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
-					const creds = credentials as GeminiCredentials;
-					if (!creds.projectId) throw new Error("Missing projectId");
-					return refreshAntigravityToken(creds.refresh, creds.projectId);
-				},
-				getApiKey(credentials: OAuthCredentials): string {
-					const creds = credentials as GeminiCredentials;
-					return JSON.stringify({ token: creds.access, projectId: creds.projectId });
-				},
-			};
-		},
+		baseProvider: "github-copilot",
+		buildOAuth: (index: number) => buildOAuthFromBuiltin("github-copilot", `GitHub Copilot #${index}`),
 	},
 };
 
@@ -278,6 +277,78 @@ interface AuthStorageEntry {
 	accountId?: string;
 	projectId?: string;
 	[key: string]: unknown;
+}
+
+/**
+ * Compatibility shim for pi >= 0.79 (model-runtime refactor).
+ *
+ * `ModelRegistry.authStorage` was removed in pi commit 9993c9690
+ * ("replace model registry with model runtime"), shipped in 0.84.x. This
+ * extension used it as a *synchronous* credential store. The replacements
+ * on ModelRegistry are:
+ *
+ *   hasAuth(p) -> getProviderAuthStatus(p).configured   (sync, exists)
+ *   get(p)     -> NOT getProviderAuth(p). That returns a resolved
+ *                 AuthResult ({ auth: { apiKey, headers } }), not the raw
+ *                 stored credential, and it is async. The raw OAuth
+ *                 credential this extension needs (access/refresh/expires)
+ *                 comes from readStoredCredential(), which is synchronous
+ *                 and reads auth.json directly.
+ *   logout(p)  -> no ModelRegistry method. ModelRuntime.logout() exists but
+ *                 is not reachable from ExtensionContext, so we fall back to
+ *                 editing auth.json and asking the registry to refresh.
+ *
+ * Keeping hasAuth/get synchronous avoids turning ~30 call sites async.
+ */
+interface AuthCompat {
+	hasAuth(provider: string): boolean;
+	get(provider: string): AuthStorageEntry | undefined;
+	logout(provider: string): void;
+}
+
+function authJsonPath(): string {
+	return join(getAgentDir(), "auth.json");
+}
+
+function readAuthJson(): Record<string, unknown> {
+	try {
+		const raw = readFileSync(authJsonPath(), "utf-8").replace(/^\uFEFF/, "");
+		const parsed = JSON.parse(raw) as unknown;
+		return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : {};
+	} catch {
+		return {};
+	}
+}
+
+function createAuthCompat(modelRegistry: ExtensionContext["modelRegistry"]): AuthCompat {
+	return {
+		hasAuth(provider: string): boolean {
+			try {
+				return modelRegistry.getProviderAuthStatus(provider).configured === true;
+			} catch {
+				return false;
+			}
+		},
+		get(provider: string): AuthStorageEntry | undefined {
+			return readStoredCredential(provider) as AuthStorageEntry | undefined;
+		},
+		logout(provider: string): void {
+			const data = readAuthJson();
+			if (!(provider in data)) return;
+			delete data[provider];
+			try {
+				writeFileSync(authJsonPath(), JSON.stringify(data, null, 2), { mode: 0o600 });
+			} catch {
+				return;
+			}
+			void modelRegistry.refresh({ providers: [provider] });
+		},
+	};
+}
+
+function ctxAuth(ctx: ExtensionContext | ExtensionCommandContext): AuthCompat {
+	rememberRegistry(ctx);
+	return createAuthCompat(ctx.modelRegistry);
 }
 
 interface QuotaAccount {
@@ -964,20 +1035,12 @@ async function resolveGoogleQuotaAccess(
 		&& auth.access.length > 0
 		&& (typeof auth.expires !== "number" || auth.expires > Date.now() + 60_000);
 	if (hasFreshAccess) {
-		return { accessToken: auth.access, projectId };
+		return { accessToken: auth.access as string, projectId };
 	}
 
-	if (typeof auth.refresh === "string" && auth.refresh.length > 0) {
-		const credentials = account.baseProvider === "google-gemini-cli"
-			? await refreshGoogleCloudToken(auth.refresh, projectId || "") as Promise<GeminiCredentials>
-			: await refreshAntigravityToken(auth.refresh, projectId || "") as Promise<GeminiCredentials>;
-		return {
-			accessToken: credentials.access,
-			projectId: typeof credentials.projectId === "string" && credentials.projectId.length > 0
-				? credentials.projectId
-				: projectId,
-		};
-	}
+	// pi 0.84.4 removed the exported Google token-refresh flows and ships no
+	// google-gemini-cli / google-antigravity provider, so a stale Google token
+	// cannot be refreshed here. Fall through to the stored access token.
 
 	if (typeof auth.access === "string" && auth.access.length > 0) {
 		return { accessToken: auth.access, projectId };
@@ -1215,12 +1278,12 @@ function collectQuotaAccounts(ctx: ExtensionContext): QuotaAccount[] {
 			providerName,
 			baseProvider: getBaseProvider(providerName) || providerName,
 			displayName,
-			auth: ctx.modelRegistry.authStorage.get(providerName) as AuthStorageEntry | undefined,
+			auth: ctxAuth(ctx).get(providerName) as AuthStorageEntry | undefined,
 		});
 	};
 
 	for (const checker of PROVIDER_QUOTA_CHECKERS) {
-		if (ctx.modelRegistry.authStorage.hasAuth(checker.baseProvider)) {
+		if (ctxAuth(ctx).hasAuth(checker.baseProvider)) {
 			pushAccount(
 				checker.baseProvider,
 				PROVIDER_TEMPLATES[checker.baseProvider]?.displayName || checker.baseProvider,
@@ -1358,11 +1421,12 @@ const googleAntigravityQuotaChecker: ProviderQuotaChecker = {
 	},
 };
 
-const PROVIDER_QUOTA_CHECKERS: ProviderQuotaChecker[] = [
-	codexQuotaChecker,
-	googleGeminiCliQuotaChecker,
-	googleAntigravityQuotaChecker,
-];
+// Google checkers are retained for reference but not registered: pi 0.84.4
+// exposes no google-gemini-cli / google-antigravity provider, so no such
+// subscription can exist to check.
+const PROVIDER_QUOTA_CHECKERS: ProviderQuotaChecker[] = [codexQuotaChecker];
+void googleGeminiCliQuotaChecker;
+void googleAntigravityQuotaChecker;
 
 async function showQuotaDetails(
 	ctx: ExtensionCommandContext,
@@ -1740,7 +1804,7 @@ function getProjectScopedProviderNames(
 	}
 
 	for (const providerName of SUPPORTED_PROVIDERS) {
-		if (ctx.modelRegistry.authStorage.hasAuth(providerName)) {
+		if (ctxAuth(ctx).hasAuth(providerName)) {
 			push(providerName);
 		}
 	}
@@ -1755,7 +1819,7 @@ function findSelectableModelForProvider(
 	providerName: string,
 	preferredModelId?: string,
 ): Model<Api> | undefined {
-	if (!ctx.modelRegistry.authStorage.hasAuth(providerName)) {
+	if (!ctxAuth(ctx).hasAuth(providerName)) {
 		return undefined;
 	}
 	if (preferredModelId) {
@@ -1901,7 +1965,6 @@ function registerSub(pi: ExtensionAPI, entry: SubEntry): void {
 
 	const name = subProviderName(entry);
 	const oauth = template.buildOAuth(entry.index);
-	const modifyModels = template.buildModifyModels?.(name);
 	const builtinModels = getModels(entry.provider as any) as Model<Api>[];
 	const baseUrl = builtinModels[0]?.baseUrl || "";
 	const models = cloneModels(entry.provider, entry.index);
@@ -1909,7 +1972,7 @@ function registerSub(pi: ExtensionAPI, entry: SubEntry): void {
 	pi.registerProvider(name, {
 		baseUrl,
 		api: builtinModels[0]?.api,
-		oauth: modifyModels ? { ...oauth, modifyModels } : oauth,
+		oauth,
 		models,
 	});
 }
@@ -2205,7 +2268,7 @@ class PoolManager {
 	/** Get available (non-exhausted, authenticated) members of a pool */
 	getAvailableMembers(
 		pool: PoolConfig,
-		authStorage: { hasAuth(provider: string): boolean },
+		authStorage: AuthCompat,
 	): string[] {
 		const state = this.getOrCreatePoolState(pool.name);
 		const now = Date.now();
@@ -2251,7 +2314,7 @@ class PoolManager {
 	buildFailoverPlan(
 		currentModel: Model<Api>,
 		config: MultiPassConfig,
-		authStorage: { hasAuth(provider: string): boolean },
+		authStorage: AuthCompat,
 		options?: FailoverPlanOptions,
 	): FailoverPlan {
 		const attemptedProviders = options?.attemptedProviders ?? new Set<string>();
@@ -2404,7 +2467,7 @@ class PoolManager {
 	getNextMember(
 		pool: PoolConfig,
 		currentProvider: string,
-		authStorage: { hasAuth(provider: string): boolean },
+		authStorage: AuthCompat,
 	): string | undefined {
 		const state = this.getOrCreatePoolState(pool.name);
 		const available = this.getAvailableMembers(pool, authStorage);
@@ -2439,7 +2502,7 @@ class PoolManager {
 	async getQuotaBestMember(
 		pool: PoolConfig,
 		currentProvider: string,
-		authStorage: { hasAuth(provider: string): boolean; get(provider: string): unknown },
+		authStorage: AuthCompat,
 		excludeProviders?: Set<string>,
 	): Promise<string | undefined> {
 		const available = this.getAvailableMembers(pool, authStorage);
@@ -2496,7 +2559,7 @@ class PoolManager {
 				const best = await this.getQuotaBestMember(
 					pool,
 					currentModel.provider,
-					ctx.modelRegistry.authStorage,
+					ctxAuth(ctx),
 					cascade.attemptedProviders,
 				);
 				if (best) {
@@ -2659,7 +2722,7 @@ class PoolManager {
 		const plan = this.buildFailoverPlan(
 			currentModel,
 			config,
-			ctx.modelRegistry.authStorage,
+			ctxAuth(ctx),
 			{
 				attemptedProviders: cascade.attemptedProviders,
 				visitedChainIndexes: cascade.visitedChainIndexes,
@@ -2756,7 +2819,7 @@ function getSubscriptionSource(config: MultiPassConfig, entry: SubEntry): "confi
 function formatSubscriptionMeta(
 	entry: SubEntry,
 	config: MultiPassConfig,
-	authStorage: { hasAuth(provider: string): boolean },
+	authStorage: AuthCompat,
 ): string {
 	const name = subProviderName(entry);
 	const hasAuth = authStorage.hasAuth(name);
@@ -2768,7 +2831,7 @@ function formatSubscriptionMeta(
 function formatSubscriptionListLine(
 	entry: SubEntry,
 	config: MultiPassConfig,
-	authStorage: { hasAuth(provider: string): boolean },
+	authStorage: AuthCompat,
 ): string {
 	return `${subDisplayName(entry)} -- ${formatSubscriptionMeta(entry, config, authStorage)}`;
 }
@@ -2792,7 +2855,7 @@ function getSwitchableProviderOptions(
 	const seen = new Set<string>();
 	const push = (providerName: string, label: string, description: string) => {
 		if (allowed && !allowed.has(providerName)) return;
-		if (!ctx.modelRegistry.authStorage.hasAuth(providerName)) return;
+		if (!ctxAuth(ctx).hasAuth(providerName)) return;
 		if (seen.has(providerName)) return;
 		seen.add(providerName);
 		options.push({ providerName, label, description });
@@ -2816,7 +2879,7 @@ function resolveSwitchTargetModel(
 	providerName: string,
 	preferredModelId?: string,
 ): Model<Api> | undefined {
-	if (!ctx.modelRegistry.authStorage.hasAuth(providerName)) {
+	if (!ctxAuth(ctx).hasAuth(providerName)) {
 		return undefined;
 	}
 	if (preferredModelId) {
@@ -2932,8 +2995,8 @@ async function removeSubscriptionEntry(
 	if (!confirmed) return;
 
 	const name = subProviderName(entry);
-	if (ctx.modelRegistry.authStorage.hasAuth(name)) {
-		ctx.modelRegistry.authStorage.logout(name);
+	if (ctxAuth(ctx).hasAuth(name)) {
+		ctxAuth(ctx).logout(name);
 	}
 	pi.unregisterProvider(name);
 
@@ -2973,7 +3036,7 @@ async function showSubscriptionActions(
 			items: [
 				{
 					value: subProviderName(entry),
-					label: formatSubscriptionListLine(entry, config, ctx.modelRegistry.authStorage),
+					label: formatSubscriptionListLine(entry, config, ctxAuth(ctx)),
 				},
 			],
 			confirmHint: "back",
@@ -2983,7 +3046,7 @@ async function showSubscriptionActions(
 	}
 
 	const name = subProviderName(entry);
-	const hasAuth = ctx.modelRegistry.authStorage.hasAuth(name);
+	const hasAuth = ctxAuth(ctx).hasAuth(name);
 	const actionItems: SelectItem[] = [
 		{ value: "rename", label: "rename", description: "Change friendly label" },
 		hasAuth
@@ -3012,7 +3075,7 @@ async function showSubscriptionActions(
 		return;
 	}
 	if (action === "logout") {
-		ctx.modelRegistry.authStorage.logout(name);
+		ctxAuth(ctx).logout(name);
 		ctx.modelRegistry.refresh();
 		ctx.ui.notify(`Logged out of ${subDisplayName(entry)}`, "info");
 		return;
@@ -3045,7 +3108,7 @@ async function handleSubsList(
 			items: all.map((entry) => ({
 				value: subProviderName(entry),
 				label: subDisplayName(entry),
-				description: formatSubscriptionMeta(entry, config, ctx.modelRegistry.authStorage),
+				description: formatSubscriptionMeta(entry, config, ctxAuth(ctx)),
 			})),
 			initialValue: preferredProviderName,
 			confirmHint: "open",
@@ -3136,7 +3199,7 @@ async function handleSubsRemove(
 		items: config.subscriptions.map((entry) => ({
 			value: subProviderName(entry),
 			label: subDisplayName(entry),
-			description: ctx.modelRegistry.authStorage.hasAuth(subProviderName(entry))
+			description: ctxAuth(ctx).hasAuth(subProviderName(entry))
 				? "logged in"
 				: "not logged in",
 		})),
@@ -3159,7 +3222,7 @@ async function handleSubsLogin(ctx: ExtensionCommandContext): Promise<void> {
 	const all = normalizeEntries(mergeConfigs(config, envEntries));
 
 	const notLoggedIn = all.filter(
-		(entry) => !ctx.modelRegistry.authStorage.hasAuth(subProviderName(entry)),
+		(entry) => !ctxAuth(ctx).hasAuth(subProviderName(entry)),
 	);
 
 	if (notLoggedIn.length === 0) {
@@ -3201,7 +3264,7 @@ async function handleSubsLogout(ctx: ExtensionCommandContext): Promise<void> {
 	const all = normalizeEntries(mergeConfigs(config, envEntries));
 
 	const loggedIn = all.filter((entry) =>
-		ctx.modelRegistry.authStorage.hasAuth(subProviderName(entry)),
+		ctxAuth(ctx).hasAuth(subProviderName(entry)),
 	);
 
 	if (loggedIn.length === 0) {
@@ -3226,7 +3289,7 @@ async function handleSubsLogout(ctx: ExtensionCommandContext): Promise<void> {
 	const entry = loggedIn.find((candidate) => subProviderName(candidate) === selectedProviderName);
 	if (!entry) return;
 
-	ctx.modelRegistry.authStorage.logout(subProviderName(entry));
+	ctxAuth(ctx).logout(subProviderName(entry));
 	ctx.modelRegistry.refresh();
 	ctx.ui.notify(`Logged out of ${subDisplayName(entry)}`, "info");
 }
@@ -3244,14 +3307,14 @@ async function handleSubsStatus(ctx: ExtensionCommandContext): Promise<void> {
 	const lines: string[] = [];
 	for (const entry of all) {
 		const name = subProviderName(entry);
-		const cred = ctx.modelRegistry.authStorage.get(name);
-		const hasAuth = ctx.modelRegistry.authStorage.hasAuth(name);
+		const cred = ctxAuth(ctx).get(name);
+		const hasAuth = ctxAuth(ctx).hasAuth(name);
 
 		let status: string;
 		if (!hasAuth) {
 			status = "not logged in";
 		} else if (cred?.type === "oauth") {
-			const expiresIn = cred.expires - Date.now();
+			const expiresIn = (cred.expires ?? 0) - Date.now();
 			if (expiresIn > 0) {
 				const mins = Math.round(expiresIn / 60000);
 				status = `logged in (expires ${mins}m)`;
@@ -3510,14 +3573,14 @@ async function editPoolMembers(
 		const removableItems: SelectItem[] = selectedMembers.map((member) => ({
 			value: `remove:${member}`,
 			label: `remove ${member}`,
-			description: ctx.modelRegistry.authStorage.hasAuth(member) ? "logged in" : "not logged in",
+			description: ctxAuth(ctx).hasAuth(member) ? "logged in" : "not logged in",
 		}));
 		const addableItems: SelectItem[] = availableProviders
 			.filter((providerName) => !selectedMembers.includes(providerName))
 			.map((providerName) => ({
 				value: `add:${providerName}`,
 				label: `add ${providerName}`,
-				description: ctx.modelRegistry.authStorage.hasAuth(providerName)
+				description: ctxAuth(ctx).hasAuth(providerName)
 					? "logged in"
 					: "not logged in",
 			}));
@@ -3605,7 +3668,7 @@ async function promptForPoolDefinition(
 
 	const allProviders = getAllProvidersForBase(baseProvider, allSubs);
 	const authedProviders = allProviders.filter((p) =>
-		ctx.modelRegistry.authStorage.hasAuth(p),
+		ctxAuth(ctx).hasAuth(p),
 	);
 
 	if (authedProviders.length === 0) {
@@ -3625,7 +3688,7 @@ async function promptForPoolDefinition(
 		const optionsList = [
 			`--- Selected (${members.length}): ${members.join(", ") || "none"} ---`,
 			...remaining.map((p) => {
-				const authed = ctx.modelRegistry.authStorage.hasAuth(p);
+				const authed = ctxAuth(ctx).hasAuth(p);
 				return `${p} ${authed ? "[logged in]" : "[not logged in]"}`;
 			}),
 			"[Done - create pool]",
@@ -3854,7 +3917,7 @@ async function inspectPoolConfig(
 	await showWrappedSelect(ctx, {
 		title: `Pool Status: ${pool.name}`,
 		subtitle: "Press Enter or Escape to go back to the pools list.",
-		items: formatPoolStatusLines(pool, ctx.modelRegistry.authStorage, poolManager)
+		items: formatPoolStatusLines(pool, ctxAuth(ctx), poolManager)
 			.map((line, index) => ({ value: `${index}:${line}`, label: line })),
 		confirmHint: "back",
 		cancelHint: "back",
@@ -4099,7 +4162,7 @@ async function handlePoolList(
 			items: pools.map((pool) => ({
 				value: pool.name,
 				label: pool.name,
-				description: formatPoolListDescription(pool, ctx.modelRegistry.authStorage, poolManager),
+				description: formatPoolListDescription(pool, ctxAuth(ctx), poolManager),
 			})),
 			initialValue: preferredPoolName,
 			confirmHint: "open",
@@ -4168,7 +4231,7 @@ async function handlePoolRemove(
 
 function summarizePoolHealth(
 	pool: PoolConfig,
-	authStorage: { hasAuth(provider: string): boolean },
+	authStorage: AuthCompat,
 	poolManager: Pick<PoolManager, "getAvailableMembers" | "isMemberExhausted">,
 ): {
 	availableCount: number;
@@ -4210,7 +4273,7 @@ function summarizePoolHealth(
 
 function formatPoolListDescription(
 	pool: PoolConfig,
-	authStorage: { hasAuth(provider: string): boolean },
+	authStorage: AuthCompat,
 	poolManager: Pick<PoolManager, "getAvailableMembers" | "isMemberExhausted">,
 ): string {
 	const summary = summarizePoolHealth(pool, authStorage, poolManager);
@@ -4220,7 +4283,7 @@ function formatPoolListDescription(
 
 function formatPoolStatusLines(
 	pool: PoolConfig,
-	authStorage: { hasAuth(provider: string): boolean },
+	authStorage: AuthCompat,
 	poolManager: Pick<PoolManager, "getAvailableMembers" | "isMemberExhausted">,
 ): string[] {
 	const summary = summarizePoolHealth(pool, authStorage, poolManager);
@@ -4277,7 +4340,7 @@ async function handlePoolStatus(
 	const lines: string[] = [];
 	for (const pool of config.pools) {
 		lines.push(
-			...formatPoolStatusLines(pool, ctx.modelRegistry.authStorage, poolManager),
+			...formatPoolStatusLines(pool, ctxAuth(ctx), poolManager),
 		);
 	}
 
@@ -4403,7 +4466,7 @@ function formatFailoverExhausted(poolName: string, currentProvider: string): str
 function classifyPoolMemberSkip(
 	poolName: string,
 	provider: string,
-	authStorage: { hasAuth(provider: string): boolean },
+	authStorage: AuthCompat,
 	exhausted: boolean,
 ): FailoverSkip | null {
 	if (!authStorage.hasAuth(provider)) {
@@ -4461,7 +4524,7 @@ function classifyChainEntrySkip(
 function formatChainEntryStatus(
 	entry: ChainEntryConfig,
 	config?: MultiPassConfig,
-	authStorage?: { hasAuth(provider: string): boolean },
+	authStorage?: AuthCompat,
 	poolManager?: Pick<PoolManager, "getAvailableMembers" | "isMemberExhausted">,
 ): string {
 	const entryState = entry.enabled ? "enabled" : "disabled";
@@ -4481,7 +4544,7 @@ function formatChainEntryStatus(
 function formatChainListLine(
 	chain: ChainConfig,
 	config?: MultiPassConfig,
-	authStorage?: { hasAuth(provider: string): boolean },
+	authStorage?: AuthCompat,
 	poolManager?: Pick<PoolManager, "getAvailableMembers" | "isMemberExhausted">,
 ): string {
 	const entryLabel = chain.entries.length === 1 ? "entry" : "entries";
@@ -4517,7 +4580,7 @@ function formatChainRemoveOption(chain: ChainConfig): string {
 function formatChainStatusLines(
 	chain: ChainConfig,
 	config?: MultiPassConfig,
-	authStorage?: { hasAuth(provider: string): boolean },
+	authStorage?: AuthCompat,
 	poolManager?: Pick<PoolManager, "getAvailableMembers" | "isMemberExhausted">,
 ): string[] {
 	const invalidEntries = config
@@ -4670,7 +4733,7 @@ async function handlePoolChainList(
 	await ctx.ui.select(
 		"Chains",
 		config.chains.map((chain) =>
-			formatChainListLine(chain, config, ctx.modelRegistry.authStorage, poolManager),
+			formatChainListLine(chain, config, ctxAuth(ctx), poolManager),
 		),
 	);
 }
@@ -4750,7 +4813,7 @@ async function handlePoolChainStatus(
 
 	await ctx.ui.select(
 		`Chain Status: ${chain.name}`,
-		formatChainStatusLines(chain, config, ctx.modelRegistry.authStorage, poolManager),
+		formatChainStatusLines(chain, config, ctxAuth(ctx), poolManager),
 	);
 }
 
@@ -4838,7 +4901,7 @@ async function handlePoolProject(
 		const allSubs = normalizeEntries(mergeConfigs(globalConf, envEntries));
 		const allProviderNames = [
 			...SUPPORTED_PROVIDERS.filter((p) =>
-				ctx.modelRegistry.authStorage.hasAuth(p),
+				ctxAuth(ctx).hasAuth(p),
 			),
 			...allSubs.map((s) => subProviderName(s)),
 		];
@@ -4859,7 +4922,7 @@ async function handlePoolProject(
 			const options = [
 				`--- Allowed (${allowed.length}): ${allowed.join(", ") || "all (no restriction)"} ---`,
 				...remaining.map((p) => {
-					const authed = ctx.modelRegistry.authStorage.hasAuth(p);
+					const authed = ctxAuth(ctx).hasAuth(p);
 					const current = currentAllowed.includes(p) ? " [currently allowed]" : "";
 					return `${p} ${authed ? "[logged in]" : "[not logged in]"}${current}`;
 				}),
@@ -4990,7 +5053,7 @@ async function handlePoolProject(
 		lines.push("");
 		lines.push(`Effective subs (${effective.subscriptions.length}):`);
 		for (const sub of effective.subscriptions) {
-			const authed = ctx.modelRegistry.authStorage.hasAuth(subProviderName(sub));
+			const authed = ctxAuth(ctx).hasAuth(subProviderName(sub));
 			lines.push(`  ${subDisplayName(sub)} -- ${authed ? "logged in" : "not logged in"}`);
 		}
 
@@ -5261,7 +5324,7 @@ async function handlePresetActivate(
 
 	for (const entry of preset.entries) {
 		if (!entry.enabled) continue;
-		if (!ctx.modelRegistry.authStorage.hasAuth(entry.provider)) continue;
+		if (!ctxAuth(ctx).hasAuth(entry.provider)) continue;
 		const model = ctx.modelRegistry.find(entry.provider, entry.model);
 		if (!model) continue;
 
@@ -5440,6 +5503,8 @@ export default function multiSub(pi: ExtensionAPI) {
 
 	// On session start, reload pools with project-level config
 	pi.on("session_start", async (_event, ctx) => {
+		// Capture a ModelRegistry for the OAuth shim before any /login can run.
+		rememberRegistry(ctx);
 		const effective = loadEffectiveConfig(ctx.cwd);
 		poolManager.loadPools(effective.pools);
 
@@ -5521,7 +5586,7 @@ export default function multiSub(pi: ExtensionAPI) {
 			if (pool) {
 				const available = poolManager.getAvailableMembers(
 					pool,
-					ctx.modelRegistry.authStorage,
+					ctxAuth(ctx),
 				);
 				if (available.length === 0) {
 					ctx.ui.notify(
@@ -5609,7 +5674,7 @@ export default function multiSub(pi: ExtensionAPI) {
 							return handlePoolChainMenu(ctx, poolManager);
 						case "list":
 						case "ls":
-							return handlePoolChainList(ctx);
+							return handlePoolChainList(ctx, poolManager);
 						case "toggle":
 							return handlePoolChainToggle(ctx);
 						case "remove":
@@ -5618,7 +5683,7 @@ export default function multiSub(pi: ExtensionAPI) {
 							return handlePoolChainRemove(ctx);
 						case "status":
 						case "info":
-							return handlePoolChainStatus(ctx);
+							return handlePoolChainStatus(ctx, poolManager);
 						case "create":
 						case "new":
 							return handlePoolChainCreate(ctx, poolManager);
@@ -5694,3 +5759,6 @@ export default function multiSub(pi: ExtensionAPI) {
 		},
 	});
 }
+
+/** Internal surface exposed for tests/auth-compat-check.mjs only. */
+export const __testHooks = { createAuthCompat, buildOAuthFromBuiltin, toAuthInteraction };

--- a/extensions/multi-sub.ts
+++ b/extensions/multi-sub.ts
@@ -2070,6 +2070,19 @@ function registerSub(pi: ExtensionAPI, entry: SubEntry): void {
 // Pool rotation engine
 // ==========================================================================
 
+// Every pattern here is a reason to ROTATE TO ANOTHER ACCOUNT. It is not a
+// "was this a 429" test, despite the name: an account that is out of money and
+// an account that is over its rate limit are the same event for this extension,
+// and both must hand the turn to the next pool member or chain entry.
+//
+// Do not restrict this to 429/5xx. Anthropic reports subscription exhaustion as
+// a *400 invalid_request_error* carrying "You're out of extra usage. Ask your
+// workspace admin to add more so you can keep going." - no "limit", no "quota",
+// no "429". Observed 2026-09-02 on Joel's `anthropic` account: the message hit
+// none of the original eight patterns, so `handleError` returned false on its
+// second line and the pool/chain was never consulted. The session died on a
+// live `openai-codex` account that was one chain entry away. See
+// tests/error-classification-check.mjs, which asserts against the real strings.
 const RATE_LIMIT_PATTERNS = [
 	/usage.?limit/i,
 	/rate.?limit/i,
@@ -2079,8 +2092,16 @@ const RATE_LIMIT_PATTERNS = [
 	/capacity/i,
 	/429/,
 	/quota/i,
+	// Subscription/credit exhaustion, which providers do not phrase as a limit.
+	/out of (extra )?usage/i,
+	/credit balance is too low/i,
+	/insufficient[_ ]credit/i,
 ];
 
+/**
+ * True when the provider error means "this account cannot serve this turn, try
+ * another one" - rate limited, over quota, or out of credit.
+ */
 function isRateLimitError(errorMessage: string): boolean {
 	return RATE_LIMIT_PATTERNS.some((p) => p.test(errorMessage));
 }

--- a/extensions/multi-sub.ts
+++ b/extensions/multi-sub.ts
@@ -32,7 +32,7 @@
  *   - google-antigravity (Antigravity)
  */
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
+import { existsSync, readFileSync, writeFileSync, mkdirSync, renameSync } from "fs";
 import { dirname, join } from "path";
 import type {
 	ExtensionAPI,
@@ -2445,6 +2445,68 @@ interface PoolState {
 	cooldownMs: number;
 }
 
+// ── Shared exhaustion ledger ───────────────────────────────────────────────
+//
+// `state.exhausted` is per-process, and pi runs many processes: one per pane,
+// one per sub-agent. Each learned "this account is out of credit" the only way
+// available to it - by spending a request and failing. Five sub-agents against
+// two dead accounts is ten wasted calls per wave, every wave, and a parent that
+// already knew could not tell them.
+//
+// The ledger is a flat `{ provider: firstFailureMs }` file next to the config.
+// Deliberately dumb: last write wins, no locking, and a lost write costs one
+// extra failed request rather than correctness. It is a cache of a fact the
+// provider will happily repeat.
+
+const EXHAUSTED_LEDGER_CACHE_MS = 1_000;
+/** Entries older than this are pruned on write; the cooldown is much shorter. */
+const EXHAUSTED_LEDGER_MAX_AGE_MS = 60 * 60 * 1000;
+
+let exhaustedLedgerCache: { readAt: number; data: Record<string, number> } | null = null;
+
+function exhaustedLedgerPath(): string {
+	return join(getAgentDir(), "multi-pass-exhausted.json");
+}
+
+/** Read the ledger, memoised for a second so a planning loop is not IO-bound. */
+function readExhaustedLedger(): Record<string, number> {
+	const now = Date.now();
+	if (exhaustedLedgerCache && now - exhaustedLedgerCache.readAt < EXHAUSTED_LEDGER_CACHE_MS) {
+		return exhaustedLedgerCache.data;
+	}
+	const data: Record<string, number> = {};
+	try {
+		const raw = JSON.parse(readFileSync(exhaustedLedgerPath(), "utf-8"));
+		if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+			for (const [provider, at] of Object.entries(raw)) {
+				if (typeof at === "number" && Number.isFinite(at)) data[provider] = at;
+			}
+		}
+	} catch {
+		// Missing or corrupt: an empty ledger just means everyone re-learns.
+	}
+	exhaustedLedgerCache = { readAt: now, data };
+	return data;
+}
+
+function recordExhaustedInLedger(provider: string, at: number): void {
+	const data: Record<string, number> = { ...readExhaustedLedger(), [provider]: at };
+	for (const [name, ts] of Object.entries(data)) {
+		if (at - ts > EXHAUSTED_LEDGER_MAX_AGE_MS) delete data[name];
+	}
+	const path = exhaustedLedgerPath();
+	try {
+		// Write-then-rename: another process reading mid-write gets the old file
+		// rather than half of this one.
+		const tmp = `${path}.${process.pid}.tmp`;
+		writeFileSync(tmp, JSON.stringify(data, null, 1), "utf-8");
+		renameSync(tmp, path);
+		exhaustedLedgerCache = { readAt: Date.now(), data };
+	} catch {
+		// A read-only home directory must not break failover.
+	}
+}
+
 class PoolManager {
 	private pools: Map<string, PoolConfig> = new Map();
 	private poolStates: Map<string, PoolState> = new Map();
@@ -2508,6 +2570,19 @@ class PoolManager {
 	}
 
 	/** Get available (non-exhausted, authenticated) members of a pool */
+	/**
+	 * When this provider was last seen exhausted, by this process or any other.
+	 * The ledger is what lets a sub-agent skip an account its parent already
+	 * killed, instead of paying a request to discover the same thing.
+	 */
+	private exhaustedAt(state: PoolState, provider: string): number | undefined {
+		const local = state.exhausted.get(provider);
+		const shared = readExhaustedLedger()[provider];
+		if (local === undefined) return shared;
+		if (shared === undefined) return local;
+		return Math.max(local, shared);
+	}
+
 	getAvailableMembers(
 		pool: PoolConfig,
 		authStorage: AuthCompat,
@@ -2516,7 +2591,7 @@ class PoolManager {
 		const now = Date.now();
 		return pool.members.filter((member) => {
 			if (!authStorage.hasAuth(member)) return false;
-			const exhaustedAt = state.exhausted.get(member);
+			const exhaustedAt = this.exhaustedAt(state, member);
 			if (exhaustedAt && now - exhaustedAt < state.cooldownMs) return false;
 			if (exhaustedAt && now - exhaustedAt >= state.cooldownMs) {
 				state.exhausted.delete(member);
@@ -2527,7 +2602,7 @@ class PoolManager {
 
 	isMemberExhausted(pool: PoolConfig, provider: string): boolean {
 		const state = this.getOrCreatePoolState(pool.name);
-		const exhaustedAt = state.exhausted.get(provider);
+		const exhaustedAt = this.exhaustedAt(state, provider);
 		if (!exhaustedAt) return false;
 		if (Date.now() - exhaustedAt >= state.cooldownMs) {
 			state.exhausted.delete(provider);
@@ -2734,7 +2809,11 @@ class PoolManager {
 		const poolName = this.providerToPool.get(providerName);
 		if (!poolName) return;
 		const state = this.getOrCreatePoolState(poolName);
-		state.exhausted.set(providerName, Date.now());
+		const at = Date.now();
+		state.exhausted.set(providerName, at);
+		// Publish it so every other pi process - and every sub-agent spawned from
+		// now on - skips this account instead of re-discovering it.
+		recordExhaustedInLedger(providerName, at);
 	}
 
 	/** Get the next available member in a pool, skipping the current one */

--- a/extensions/multi-sub.ts
+++ b/extensions/multi-sub.ts
@@ -3147,7 +3147,7 @@ async function showSubscriptionActions(
 		{ value: "rename", label: "rename", description: "Change friendly label" },
 		hasAuth
 			? { value: "logout", label: "logout", description: "Log out this subscription" }
-			: { value: "login", label: "login", description: "Show login instructions" },
+			: { value: "login", label: "login", description: "Start the OAuth login for this subscription" },
 		{ value: "remove", label: "remove", description: "Remove this subscription" },
 	];
 
@@ -3464,21 +3464,36 @@ function createPoolValidationMessage(members: string[]): string | null {
 	return null;
 }
 
+const SCHEDULE_WINDOW_FORMAT_HINT =
+	'hours "9-17" or "09:00-17:00", days "mon-fri" or "sat", dates "2026-01-01..2026-01-31"';
+
 /** Parse a human-friendly schedule window like "9-17 mon-fri" or "22-6". */
 function parseScheduleWindowInput(raw: string): ScheduleWindow | null {
 	const window: ScheduleWindow = {};
 	const parts = raw.trim().split(/\s+/);
 
 	for (const part of parts) {
-		// Hour range: "9-17" or "22-6"
-		const hourMatch = part.match(/^(\d{1,2})-(\d{1,2})$/);
+		// Hour range: "9-17", "22-6", or clock form "09:00-17:00".
+		// ScheduleWindow.hours holds whole hours only, so a clock form with
+		// non-zero minutes is rejected rather than silently truncated.
+		const hourMatch = part.match(/^(\d{1,2})(?::(\d{2}))?-(\d{1,2})(?::(\d{2}))?$/);
 		if (hourMatch) {
 			const start = parseInt(hourMatch[1], 10);
-			const end = parseInt(hourMatch[2], 10);
-			if (start >= 0 && start <= 23 && end >= 0 && end <= 23) {
+			const end = parseInt(hourMatch[3], 10);
+			const startMinutes = hourMatch[2] ? parseInt(hourMatch[2], 10) : 0;
+			const endMinutes = hourMatch[4] ? parseInt(hourMatch[4], 10) : 0;
+			if (
+				startMinutes === 0 &&
+				endMinutes === 0 &&
+				start >= 0 &&
+				start <= 23 &&
+				end >= 0 &&
+				end <= 23
+			) {
 				window.hours = [start, end];
 				continue;
 			}
+			return null;
 		}
 		// Day range: "mon-fri" or single day: "mon"
 		const dayRangeMatch = part.match(/^([a-z]{3})-([a-z]{3})$/);
@@ -3514,6 +3529,53 @@ function parseScheduleWindowInput(raw: string): ScheduleWindow | null {
 
 	if (!window.hours && !window.days && !window.dateRange) return null;
 	return window;
+}
+
+/**
+ * Prompt for a "preferred" member's time window and build its schedule.
+ *
+ * Unparseable input used to be discarded in silence, which is worse than it
+ * sounds: a member with role "preferred" and zero windows is treated as ALWAYS
+ * active (getScheduledMemberState), so typing "09:00-18:00" in the wrong format
+ * produced a pool that looked scheduled and behaved unscheduled. Now the input
+ * is either understood, or the user is told it was not.
+ */
+async function promptPreferredMemberSchedule(
+	ctx: ExtensionCommandContext,
+	member: string,
+): Promise<MemberSchedule> {
+	const windowDef = await ctx.ui.input(
+		`Time window for ${member}`,
+		`${SCHEDULE_WINDOW_FORMAT_HINT} (empty = always active)`,
+	);
+	const schedule: MemberSchedule = { role: "preferred", windows: [] };
+	const raw = windowDef?.trim();
+	if (!raw) return schedule;
+
+	const window = parseScheduleWindowInput(raw);
+	if (window) {
+		schedule.windows = [window];
+		return schedule;
+	}
+
+	ctx.ui.notify(
+		`Could not read "${raw}" as a time window, so ${member} stays always active. Accepted: ${SCHEDULE_WINDOW_FORMAT_HINT}.`,
+		"warning",
+	);
+	return schedule;
+}
+
+/**
+ * Staged "allowed subs" list for the project restriction editor.
+ *
+ * Seeded from the saved config on purpose: the editor exits into its save path
+ * on both [Done - save] and Escape, so starting from an empty list meant merely
+ * opening the screen and backing out wiped an existing restriction and reported
+ * "Project restriction cleared".
+ */
+function initialAllowedSubs(projectConf: ProjectConfig | undefined, allProviderNames: string[]): string[] {
+	const saved = projectConf?.allowedSubs ?? [];
+	return saved.filter((provider) => allProviderNames.includes(provider));
 }
 
 function buildPoolConfig(input: {
@@ -3837,16 +3899,7 @@ async function promptForPoolDefinition(
 			else if (rolePick.startsWith("overflow")) role = "overflow";
 
 			if (role === "preferred") {
-				const windowDef = await ctx.ui.input(
-					`Time window for ${member}`,
-					"hours e.g. 9-17, days e.g. mon-fri (or leave empty for always)",
-				);
-				const schedule: MemberSchedule = { role, windows: [] };
-				if (windowDef?.trim()) {
-					const window = parseScheduleWindowInput(windowDef.trim());
-					if (window) schedule.windows = [window];
-				}
-				memberSchedule[member] = schedule;
+				memberSchedule[member] = await promptPreferredMemberSchedule(ctx, member);
 			} else if (role === "overflow") {
 				memberSchedule[member] = { role };
 			}
@@ -4094,16 +4147,7 @@ async function changePoolStrategy(
 			else if (rolePick.startsWith("overflow")) role = "overflow";
 
 			if (role === "preferred") {
-				const windowDef = await ctx.ui.input(
-					`Time window for ${member}`,
-					"e.g. 9-17 mon-fri",
-				);
-				const schedule: MemberSchedule = { role, windows: [] };
-				if (windowDef?.trim()) {
-					const window = parseScheduleWindowInput(windowDef.trim());
-					if (window) schedule.windows = [window];
-				}
-				memberSchedule[member] = schedule;
+				memberSchedule[member] = await promptPreferredMemberSchedule(ctx, member);
 			} else if (role === "overflow") {
 				memberSchedule[member] = { role };
 			}
@@ -4999,7 +5043,7 @@ async function handlePoolProject(
 		}
 
 		const currentAllowed = projectConf?.allowedSubs || [];
-		const allowed: string[] = [];
+		const allowed: string[] = initialAllowedSubs(projectConf, allProviderNames);
 		let selecting = true;
 
 		while (selecting) {
@@ -5848,4 +5892,10 @@ export default function multiSub(pi: ExtensionAPI) {
 }
 
 /** Internal surface exposed for tests/auth-compat-check.mjs only. */
-export const __testHooks = { createAuthCompat, buildOAuthFromBuiltin, toAuthInteraction };
+export const __testHooks = {
+	createAuthCompat,
+	buildOAuthFromBuiltin,
+	toAuthInteraction,
+	parseScheduleWindowInput,
+	initialAllowedSubs,
+};

--- a/extensions/multi-sub.ts
+++ b/extensions/multi-sub.ts
@@ -2106,6 +2106,49 @@ function isRateLimitError(errorMessage: string): boolean {
 	return RATE_LIMIT_PATTERNS.some((p) => p.test(errorMessage));
 }
 
+/** Statuses under 500 that pi 0.84.4 retries. Anything else 4xx it gives up on. */
+const PI_RETRYABLE_STATUSES = new Set([408, 409, 429]);
+
+/**
+ * The HTTP status pi folded into `errorMessage`.
+ *
+ * The assistant message carries no status field - captured 2026-09-02, its keys
+ * are role, content, api, provider, model, usage, stopReason, timestamp,
+ * errorMessage - and pi formats the message as `${status} ${body}`:
+ *
+ *   400 {"type":"error","error":{"type":"invalid_request_error", ...
+ *
+ * So the status has to be read back off the string. Returns undefined when the
+ * message carries no status, which callers must treat as "unknown".
+ */
+function parseHttpStatus(errorMessage: string): number | undefined {
+	const leading = errorMessage.match(/^\s*(?:Error:\s*)?(\d{3})\b/);
+	if (leading) return Number(leading[1]);
+	const field = errorMessage.match(/"status"\s*:\s*(\d{3})\b/);
+	if (field) return Number(field[1]);
+	return undefined;
+}
+
+/**
+ * Will pi re-run this turn by itself?
+ *
+ * pi 0.84.4 `isRetryableProviderError` (dist/bundle/chunks/chunk-XNGRGP62.js):
+ * an `x-should-retry` header wins, otherwise 408, 409, 429 and >= 500 retry and
+ * everything else does not.
+ *
+ * This decides whether failover has to replay the prompt after switching
+ * accounts. Getting it wrong is costly in both directions - a missed replay
+ * leaves the turn unexecuted on a healthy account, a spurious one sends the
+ * prompt twice - so an unrecognised message returns **true**: assume pi handles
+ * it, and keep today's rotate-only behaviour rather than risking a duplicate.
+ */
+function piWillRetryTurn(errorMessage: string): boolean {
+	const status = parseHttpStatus(errorMessage);
+	if (status === undefined) return true;
+	if (status >= 500) return true;
+	return PI_RETRYABLE_STATUSES.has(status);
+}
+
 // ==========================================================================
 // Schedule evaluation helpers
 // ==========================================================================
@@ -2891,6 +2934,28 @@ class PoolManager {
 			"info",
 		);
 		ctx.ui.setStatus("multi-pass", formatFailoverStatus(nextCandidate));
+
+		// Switching the model is not the same as running the turn. pi retries the
+		// failed turn on the new account only for the statuses in piWillRetryTurn;
+		// a 400 - which is how Anthropic reports subscription exhaustion - it never
+		// retries. Measured 2026-09-02 in a real pane: the cascade
+		// anthropic -> anthropic-2 -> openai-codex needed three separate prompts,
+		// one per rotation, because each rotation stopped here.
+		//
+		// A human presses Enter again and barely notices. A sub-agent cannot: it
+		// ends up parked on a healthy account with its task unexecuted, printing no
+		// completion sentinel, and its parent polls it until timeout. So replay,
+		// but only when pi will not - c9f4b3f removed the unconditional replay for
+		// the opposite reason, one duplicate follow-up per failed account, and
+		// tests/failover-turn-integrity-check.mjs still guards that direction.
+		//
+		// "followUp" rather than "steer": this is a new turn on the new provider,
+		// not an injection into the turn that just failed. Without deliverAs, pi
+		// 0.84.4 throws "Agent is already processing", because failover runs while
+		// the failed turn is still streaming.
+		if (lastUserPrompt && !piWillRetryTurn(errorMessage)) {
+			this.pi.sendUserMessage(lastUserPrompt, { deliverAs: "followUp" });
+		}
 
 		return true;
 	}
@@ -5689,9 +5754,11 @@ export default function multiSub(pi: ExtensionAPI) {
 		poolManager.startTurn(event.prompt, ctx.model);
 	});
 
-	// agent_end is emitted before pi 0.84.4's automatic retry settles. Rotate
-	// only: AgentSession retries the same turn with agent.continue(). Enqueuing
-	// lastUserPrompt here would create one duplicate follow-up per failed account.
+	// agent_end is emitted before pi 0.84.4's automatic retry settles. For an
+	// error pi retries (408/409/429/5xx) rotating is enough - AgentSession re-runs
+	// the turn with agent.continue() and enqueuing lastUserPrompt here would
+	// create one duplicate follow-up per failed account. For an error pi does not
+	// retry, handleError replays the turn itself; see piWillRetryTurn.
 	pi.on("agent_end", async (event: AgentEndEvent, ctx: ExtensionContext) => {
 		if (!event.messages || event.messages.length === 0) return;
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Copy this working tree's extension over the installed one.
+#
+# pi loads ~/.pi/agent/npm/node_modules/pi-multi-pass/extensions/multi-sub.ts,
+# which is a FILE COPY of the upstream npm package, not a symlink to this repo.
+# A commit here changes nothing until it is copied across. That gap bit three
+# times in one session: tests green, config correct, behaviour unchanged,
+# because the running pi was still on the old file.
+#
+#   bash scripts/deploy.sh          copy, after backing the old file up
+#   bash scripts/deploy.sh --check  report drift only, exit 1 if they differ
+#
+# `pi package update` (or npm) will overwrite the deployed copy with upstream
+# and silently drop every local fix. Re-run this afterwards.
+set -euo pipefail
+
+repo_file="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/extensions/multi-sub.ts"
+installed_file="${PI_CODING_AGENT_DIR:-$HOME/.pi/agent}/npm/node_modules/pi-multi-pass/extensions/multi-sub.ts"
+
+[ -f "$repo_file" ] || { echo "missing repo file: $repo_file" >&2; exit 1; }
+
+if [ ! -f "$installed_file" ]; then
+  echo "multi-pass is not installed at $installed_file" >&2
+  echo "nothing to deploy to - install the package first" >&2
+  exit 1
+fi
+
+if cmp -s "$repo_file" "$installed_file"; then
+  echo "up to date: installed == repo"
+  exit 0
+fi
+
+if [ "${1:-}" = "--check" ]; then
+  echo "DRIFT: installed differs from repo" >&2
+  diff <(wc -l < "$installed_file") <(wc -l < "$repo_file") >/dev/null || true
+  echo "  installed: $(wc -l < "$installed_file" | tr -d ' ') lines  $installed_file" >&2
+  echo "  repo:      $(wc -l < "$repo_file" | tr -d ' ') lines  $repo_file" >&2
+  echo "  run: bash scripts/deploy.sh" >&2
+  exit 1
+fi
+
+backup="$installed_file.bak-$(date +%Y%m%d-%H%M%S)"
+cp "$installed_file" "$backup"
+cp "$repo_file" "$installed_file"
+echo "deployed  $repo_file"
+echo "       -> $installed_file"
+echo "backup    $backup"
+echo
+echo "Already-running pi sessions keep the old copy; extensions load per process."

--- a/tests/auth-compat-check.mjs
+++ b/tests/auth-compat-check.mjs
@@ -1,0 +1,122 @@
+/**
+ * Regression test for the pi 0.84.4 model-runtime port.
+ *
+ * The bug class here is "method silently absent": the extension called
+ * ctx.modelRegistry.authStorage.{hasAuth,get,logout}, which no longer exists.
+ * The other tests in this directory re-implement logic locally and never load
+ * extensions/multi-sub.ts, so they cannot see this at all. This one loads the
+ * real file and drives the real shim against a fake ModelRegistry.
+ */
+import assert from "node:assert/strict";
+import { readFileSync, writeFileSync, mkdtempSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createJiti } from "jiti";
+
+const here = new URL(".", import.meta.url).pathname;
+const extPath = join(here, "..", "extensions", "multi-sub.ts");
+const source = readFileSync(extPath, "utf-8");
+// Strip comments so the API checks below test CODE, not the shim's own
+// explanatory prose (which necessarily names the removed APIs).
+const code = source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/.*$/gm, "$1");
+
+// --- static assertions: the removed pi APIs must not come back -------------
+// Any `.authStorage` member access is the removed API. The shim's own type is
+// named AuthCompat precisely so this check can stay this blunt.
+const authStorageHits = code.match(/\.authStorage\b/g) ?? [];
+assert.deepEqual(
+	authStorageHits,
+	[],
+	`extension still references .authStorage (${authStorageHits.length} site(s)); removed in pi 0.84.4`,
+);
+for (const gone of [
+	"anthropicOAuthProvider",
+	"loginAnthropic",
+	"refreshAnthropicToken",
+	"loginOpenAICodex",
+	"loginGitHubCopilot",
+	"OAuthProviderInterface",
+]) {
+	assert.equal(
+		new RegExp(`^\\s*${gone},`, "m").test(code),
+		false,
+		`extension still imports ${gone} from pi-ai/oauth, which is type-only in pi 0.84.4`,
+	);
+}
+assert.equal(
+	/from "@earendil-works\/pi-ai";/.test(code),
+	false,
+	'getModels must come from "@earendil-works/pi-ai/compat" in pi 0.84.4',
+);
+
+// --- behavioural: drive the real shim -------------------------------------
+const agentDir = mkdtempSync(join(tmpdir(), "multipass-authcompat-"));
+const authPath = join(agentDir, "auth.json");
+writeFileSync(
+	authPath,
+	JSON.stringify({
+		anthropic: { type: "oauth", access: "a-tok", refresh: "a-ref", expires: Date.now() + 3600_000 },
+		"anthropic-2": { type: "oauth", access: "b-tok", refresh: "b-ref", expires: Date.now() + 3600_000 },
+	}),
+);
+
+const refreshCalls = [];
+const registry = {
+	getProviderAuthStatus(provider) {
+		const data = JSON.parse(readFileSync(authPath, "utf-8"));
+		return provider in data ? { configured: true, source: "stored" } : { configured: false };
+	},
+	refresh(options) {
+		refreshCalls.push(options);
+		return Promise.resolve({});
+	},
+	getProvider() {
+		return undefined;
+	},
+};
+
+const jiti = createJiti(import.meta.url, {
+	interopDefault: true,
+	alias: {
+		"@earendil-works/pi-coding-agent": join(here, "stubs", "coding-agent.mjs"),
+		"@earendil-works/pi-ai/compat": join(here, "stubs", "pi-ai.mjs"),
+		"@earendil-works/pi-ai/oauth": join(here, "stubs", "pi-ai.mjs"),
+		"@earendil-works/pi-ai": join(here, "stubs", "pi-ai.mjs"),
+		"@earendil-works/pi-tui": join(here, "stubs", "pi-tui.mjs"),
+	},
+});
+process.env.MULTIPASS_TEST_AGENT_DIR = agentDir;
+
+const mod = await jiti.import(extPath, {});
+const internals = mod.__testHooks;
+assert.ok(internals, "extension must export __testHooks for this test");
+
+const auth = internals.createAuthCompat(registry);
+
+// hasAuth maps the AuthStatus object to a boolean, not the object itself.
+assert.equal(auth.hasAuth("anthropic"), true, "hasAuth must be true for a stored provider");
+assert.equal(auth.hasAuth("nope"), false, "hasAuth must be false for an unknown provider");
+
+// get returns the RAW stored credential (access/refresh/expires), not a
+// resolved AuthResult, and it must be synchronous.
+const cred = auth.get("anthropic");
+assert.ok(cred && typeof cred.then !== "function", "get must be synchronous, not a Promise");
+assert.equal(cred.type, "oauth");
+assert.equal(cred.access, "a-tok", "get must return the raw stored credential");
+assert.equal(auth.get("nope"), undefined);
+
+// logout removes exactly one provider and asks the registry to refresh it.
+auth.logout("anthropic-2");
+const after = JSON.parse(readFileSync(authPath, "utf-8"));
+assert.equal("anthropic-2" in after, false, "logout must delete the provider entry");
+assert.equal("anthropic" in after, true, "logout must not touch other providers");
+assert.equal(auth.hasAuth("anthropic-2"), false, "hasAuth must be false after logout");
+assert.deepEqual(refreshCalls.at(-1), { providers: ["anthropic-2"] }, "logout must refresh that provider");
+
+// logout on an absent provider is a no-op, not a crash or a rewrite.
+const before = readFileSync(authPath, "utf-8");
+auth.logout("not-there");
+assert.equal(readFileSync(authPath, "utf-8"), before, "logout of an unknown provider must be a no-op");
+
+assert.ok(existsSync(authPath));
+console.log("auth-compat-check: all assertions passed");

--- a/tests/auth-compat-check.mjs
+++ b/tests/auth-compat-check.mjs
@@ -48,6 +48,23 @@ assert.equal(
 	false,
 	'getModels must come from "@earendil-works/pi-ai/compat" in pi 0.84.4',
 );
+assert.equal(
+	/Use \/login and select/.test(code),
+	false,
+	"subscription login actions must start OAuth directly, not send the user to /login",
+);
+// Failover replays the prompt while the failed turn is still streaming. pi
+// 0.84.4 throws "Agent is already processing" unless the call declares how to
+// queue itself, so every replay site must pass deliverAs.
+const sendCalls = code.match(/sendUserMessage\([^;]*?\)/g) ?? [];
+assert.ok(sendCalls.length > 0, "expected at least one sendUserMessage call site");
+for (const call of sendCalls) {
+	assert.match(
+		call,
+		/deliverAs:\s*"followUp"/,
+		`sendUserMessage must queue the failover replay: ${call.replace(/\s+/g, " ")}`,
+	);
+}
 
 // --- behavioural: drive the real shim -------------------------------------
 const agentDir = mkdtempSync(join(tmpdir(), "multipass-authcompat-"));
@@ -104,6 +121,19 @@ assert.ok(cred && typeof cred.then !== "function", "get must be synchronous, not
 assert.equal(cred.type, "oauth");
 assert.equal(cred.access, "a-tok", "get must return the raw stored credential");
 assert.equal(auth.get("nope"), undefined);
+
+// set persists the raw OAuth credential under the selected cloned provider,
+// preserving every other provider, then refreshes exactly that provider.
+auth.set("anthropic-2", {
+	type: "oauth",
+	access: "new-a-tok",
+	refresh: "new-a-ref",
+	expires: Date.now() + 7200_000,
+});
+const afterSet = JSON.parse(readFileSync(authPath, "utf-8"));
+assert.equal(afterSet["anthropic-2"].access, "new-a-tok");
+assert.equal(afterSet.anthropic.access, "a-tok", "set must preserve other providers");
+assert.deepEqual(refreshCalls.at(-1), { providers: ["anthropic-2"] }, "set must refresh that provider");
 
 // logout removes exactly one provider and asks the registry to refresh it.
 auth.logout("anthropic-2");

--- a/tests/auth-compat-check.mjs
+++ b/tests/auth-compat-check.mjs
@@ -53,19 +53,6 @@ assert.equal(
 	false,
 	"subscription login actions must start OAuth directly, not send the user to /login",
 );
-// Failover replays the prompt while the failed turn is still streaming. pi
-// 0.84.4 throws "Agent is already processing" unless the call declares how to
-// queue itself, so every replay site must pass deliverAs.
-const sendCalls = code.match(/sendUserMessage\([^;]*?\)/g) ?? [];
-assert.ok(sendCalls.length > 0, "expected at least one sendUserMessage call site");
-for (const call of sendCalls) {
-	assert.match(
-		call,
-		/deliverAs:\s*"followUp"/,
-		`sendUserMessage must queue the failover replay: ${call.replace(/\s+/g, " ")}`,
-	);
-}
-
 // --- behavioural: drive the real shim -------------------------------------
 const agentDir = mkdtempSync(join(tmpdir(), "multipass-authcompat-"));
 const authPath = join(agentDir, "auth.json");

--- a/tests/error-classification-check.mjs
+++ b/tests/error-classification-check.mjs
@@ -1,0 +1,100 @@
+/**
+ * Does a provider error that means "this account is finished" actually trigger
+ * failover?
+ *
+ * `PoolManager.handleError` returns false on its second line when
+ * `isRateLimitError` says no, and then no pool member and no chain entry is
+ * ever considered. So this predicate, eight regexes long, is the gate in front
+ * of the entire failover engine.
+ *
+ * The check reads RATE_LIMIT_PATTERNS out of extensions/multi-sub.ts rather
+ * than restating it. A copy of the list in this file would keep passing after
+ * someone deleted a pattern from the source, which is the only failure this
+ * test exists to catch.
+ *
+ *   node tests/error-classification-check.mjs
+ */
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SOURCE = join(dirname(fileURLToPath(import.meta.url)), "..", "extensions", "multi-sub.ts");
+
+/** Pull the real array out of the extension source and turn it into RegExps. */
+function loadPatterns() {
+	const src = readFileSync(SOURCE, "utf8");
+	const start = src.indexOf("const RATE_LIMIT_PATTERNS = [");
+	assert.notEqual(start, -1, "RATE_LIMIT_PATTERNS not found in extensions/multi-sub.ts");
+	const end = src.indexOf("];", start);
+	assert.notEqual(end, -1, "RATE_LIMIT_PATTERNS array is not terminated");
+	const body = src.slice(start + "const RATE_LIMIT_PATTERNS = [".length, end);
+
+	const patterns = [];
+	for (const line of body.split("\n")) {
+		const trimmed = line.trim();
+		if (!trimmed || trimmed.startsWith("//")) continue;
+		const match = trimmed.match(/^\/(.*)\/([a-z]*),$/);
+		assert.ok(match, `unparsed line in RATE_LIMIT_PATTERNS: ${trimmed}`);
+		patterns.push(new RegExp(match[1], match[2]));
+	}
+	assert.ok(patterns.length >= 8, `expected at least 8 patterns, parsed ${patterns.length}`);
+	return patterns;
+}
+
+const patterns = loadPatterns();
+const isRateLimitError = (message) => patterns.some((p) => p.test(message));
+
+/**
+ * Real strings, copied verbatim from provider responses. Anything here that
+ * returns false is a session that dies with a live account one hop away.
+ */
+const MUST_FAIL_OVER = [
+	// Anthropic subscription exhaustion. HTTP 400, invalid_request_error.
+	// Observed 2026-09-02, `anthropic` account, opus and sonnet alike. This is
+	// the string the original eight patterns all missed.
+	"400 invalid_request_error: You're out of extra usage. Ask your workspace admin to add more so you can keep going.",
+	"You're out of extra usage",
+	// Anthropic pay-as-you-go with an empty balance.
+	"Your credit balance is too low to access the Anthropic API",
+	// The classic cases, which must keep working.
+	"429 rate_limit_error",
+	"You have exceeded your usage limit for this model",
+	"Rate limit reached for requests",
+	"Too Many Requests",
+	"insufficient_quota: You exceeded your current quota",
+	"The server is overloaded, please try again later",
+];
+
+/**
+ * Errors that must NOT rotate the account. Rotating on these burns a second
+ * account on a request that would fail identically everywhere, and hides the
+ * real cause behind a provider switch.
+ */
+const MUST_NOT_FAIL_OVER = [
+	"400 invalid_request_error: model claude-opus-9 not found",
+	"401 authentication_error: OAuth token expired",
+	"ENOENT: no such file or directory, open '/tmp/nope'",
+	"AbortError: The operation was aborted",
+	"prompt is too long: 250000 tokens > 200000 maximum",
+];
+
+let failures = 0;
+for (const message of MUST_FAIL_OVER) {
+	if (!isRateLimitError(message)) {
+		console.error(`FAIL should fail over, did not: ${JSON.stringify(message)}`);
+		failures++;
+	}
+}
+for (const message of MUST_NOT_FAIL_OVER) {
+	if (isRateLimitError(message)) {
+		console.error(`FAIL should not fail over, did: ${JSON.stringify(message)}`);
+		failures++;
+	}
+}
+
+assert.equal(failures, 0, `${failures} error-classification case(s) failed`);
+console.log(
+	`error classification checks passed (${patterns.length} patterns, ` +
+		`${MUST_FAIL_OVER.length} rotate, ${MUST_NOT_FAIL_OVER.length} do-not-rotate)`,
+);

--- a/tests/exhaustion-ledger-check.mjs
+++ b/tests/exhaustion-ledger-check.mjs
@@ -1,0 +1,191 @@
+/**
+ * Does one pi process teach the others which accounts are dead?
+ *
+ * Cooldown used to live in `state.exhausted`, a Map inside PoolManager, so every
+ * process learned the same fact the only way it could: by spending a request and
+ * failing. A parent plus five sub-agents against two exhausted accounts is a
+ * dozen wasted calls per wave, and the parent already knew.
+ *
+ * markExhausted now also writes `multi-pass-exhausted.json` next to the config,
+ * and the exhaustion checks read it. This test drives two independent extension
+ * instances - separate module state, same agent dir - which is exactly the
+ * parent/sub-agent shape.
+ *
+ *   node tests/exhaustion-ledger-check.mjs
+ */
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createJiti } from "jiti";
+
+const here = new URL(".", import.meta.url).pathname;
+const extPath = join(here, "..", "extensions", "multi-sub.ts");
+const agentDir = mkdtempSync(join(tmpdir(), "multipass-ledger-"));
+const ledgerPath = join(agentDir, "multi-pass-exhausted.json");
+
+const POOLS = [
+	{ name: "anthropic", baseProvider: "anthropic", members: ["anthropic", "anthropic-2"], enabled: true },
+	{ name: "codex", baseProvider: "openai-codex", members: ["openai-codex"], enabled: true },
+];
+
+writeFileSync(join(agentDir, "multi-pass.json"), JSON.stringify({
+	subscriptions: [{ provider: "anthropic", index: 2 }],
+	pools: POOLS,
+	chains: [{
+		name: "all",
+		enabled: true,
+		entries: [
+			{ pool: "anthropic", model: "claude-opus-5", enabled: true },
+			{ pool: "codex", model: "gpt-5.6-sol", enabled: true },
+		],
+	}],
+	presets: [],
+}, null, 2));
+writeFileSync(join(agentDir, "auth.json"), JSON.stringify({
+	anthropic: { type: "oauth", access: "a" },
+	"anthropic-2": { type: "oauth", access: "b" },
+	"openai-codex": { type: "oauth", access: "c" },
+}, null, 2));
+
+process.env.MULTIPASS_TEST_AGENT_DIR = agentDir;
+delete process.env.MULTI_SUB;
+
+const models = new Map([
+	["anthropic:claude-opus-5", { provider: "anthropic", id: "claude-opus-5", api: "fake" }],
+	["anthropic-2:claude-opus-5", { provider: "anthropic-2", id: "claude-opus-5", api: "fake" }],
+	["openai-codex:gpt-5.6-sol", { provider: "openai-codex", id: "gpt-5.6-sol", api: "fake" }],
+]);
+
+/** A whole independent pi process, as far as module state is concerned. */
+async function spawnInstance(label) {
+	const jiti = createJiti(import.meta.url, {
+		interopDefault: true,
+		moduleCache: false,
+		alias: {
+			"@earendil-works/pi-coding-agent": join(here, "stubs", "coding-agent.mjs"),
+			"@earendil-works/pi-ai/compat": join(here, "stubs", "pi-ai-failover.mjs"),
+			"@earendil-works/pi-ai/oauth": join(here, "stubs", "pi-ai-failover.mjs"),
+			"@earendil-works/pi-ai": join(here, "stubs", "pi-ai-failover.mjs"),
+			"@earendil-works/pi-tui": join(here, "stubs", "pi-tui.mjs"),
+		},
+	});
+	const mod = await jiti.import(extPath, {});
+	const handlers = new Map();
+	let currentModel = models.get("anthropic:claude-opus-5");
+	const pi = {
+		on(type, handler) {
+			const list = handlers.get(type) ?? [];
+			list.push(handler);
+			handlers.set(type, list);
+		},
+		registerProvider() {},
+		registerCommand() {},
+		async setModel(model) {
+			currentModel = model;
+			return true;
+		},
+		sendUserMessage() {},
+	};
+	mod.default(pi);
+	const ctx = {
+		cwd: agentDir,
+		get model() {
+			return currentModel;
+		},
+		modelRegistry: {
+			find: (provider, id) => models.get(`${provider}:${id}`),
+			getProviderAuthStatus(provider) {
+				const auth = JSON.parse(readFileSync(join(agentDir, "auth.json"), "utf-8"));
+				return { configured: provider in auth, source: "stored" };
+			},
+			getProvider: () => undefined,
+			refresh: () => Promise.resolve({}),
+		},
+		ui: { notify() {}, setStatus() {} },
+	};
+	const emit = async (type, event) => {
+		for (const handler of handlers.get(type) ?? []) await handler(event, ctx);
+	};
+	await emit("session_start", { type: "session_start", reason: "startup" });
+	await emit("before_agent_start", {
+		type: "before_agent_start",
+		prompt: `work from ${label}`,
+		systemPrompt: "",
+		systemPromptOptions: { cwd: agentDir },
+	});
+	return {
+		emit,
+		current: () => currentModel,
+		fail: (provider) => emit("agent_end", {
+			type: "agent_end",
+			messages: [{
+				role: "assistant",
+				provider,
+				model: "claude-opus-5",
+				stopReason: "error",
+				errorMessage: '429 {"type":"error","error":{"type":"rate_limit_error","message":"Rate limit reached"}}',
+				content: [],
+			}],
+		}),
+	};
+}
+
+// ── The parent burns the anthropic pool down ──────────────────────────────
+const parent = await spawnInstance("parent");
+assert.ok(!existsSync(ledgerPath), "no ledger before anything fails");
+
+await parent.fail("anthropic");
+assert.equal(parent.current().provider, "anthropic-2");
+await parent.fail("anthropic-2");
+assert.equal(parent.current().provider, "openai-codex");
+
+const ledger = JSON.parse(readFileSync(ledgerPath, "utf-8"));
+assert.deepEqual(
+	Object.keys(ledger).sort(),
+	["anthropic", "anthropic-2"],
+	"both dead accounts must be published, not just the first",
+);
+assert.ok(
+	Object.values(ledger).every((at) => typeof at === "number" && Date.now() - at < 10_000),
+	"entries carry a fresh timestamp so the cooldown can expire them",
+);
+
+// ── A freshly started process must inherit that knowledge ─────────────────
+const child = await spawnInstance("child");
+
+// Drive it through the same public surface a real cascade uses: with both
+// anthropic members already known-dead, the first failure must skip straight to
+// the codex chain entry instead of trying anthropic-2 first.
+await child.fail("anthropic");
+assert.equal(
+	child.current().provider,
+	"openai-codex",
+	"the child must skip anthropic-2 - the parent already proved it is dead",
+);
+
+// ── An expired entry stops counting ───────────────────────────────────────
+const stale = { anthropic: Date.now() - 6 * 60 * 1000, "anthropic-2": Date.now() - 6 * 60 * 1000 };
+writeFileSync(ledgerPath, JSON.stringify(stale), "utf-8");
+await new Promise((resolve) => setTimeout(resolve, 1100)); // outlive the 1s read cache
+
+const later = await spawnInstance("after-cooldown");
+await later.fail("anthropic");
+assert.equal(
+	later.current().provider,
+	"anthropic-2",
+	"past the 5 minute cooldown the account is worth trying again",
+);
+
+// ── A corrupt ledger must not break failover ──────────────────────────────
+writeFileSync(ledgerPath, "{ this is not json", "utf-8");
+await new Promise((resolve) => setTimeout(resolve, 1100));
+const resilient = await spawnInstance("corrupt-ledger");
+await resilient.fail("anthropic");
+assert.equal(
+	resilient.current().provider,
+	"anthropic-2",
+	"an unreadable ledger degrades to today's behaviour, it does not throw",
+);
+
+console.log("exhaustion ledger checks passed");

--- a/tests/failover-replay-check.mjs
+++ b/tests/failover-replay-check.mjs
@@ -1,0 +1,255 @@
+/**
+ * After a rotation, does the turn actually run again?
+ *
+ * pi only retries a failed turn when the provider error is retryable, and its
+ * rule is narrow (pi 0.84.4, `isRetryableProviderError`):
+ *
+ *     408, 409, 429, >= 500, or an x-should-retry: true header
+ *
+ * A 400 is never retried. Anthropic reports subscription exhaustion as exactly
+ * that - `400 {"type":"error","error":{"type":"invalid_request_error", ...
+ * "You're out of extra usage"}}`, captured verbatim from a real agent_end event
+ * on 2026-09-02 - so multi-pass switches the account and then nothing resumes.
+ * A human presses Enter again. A sub-agent has nobody to press Enter: it lands
+ * on a healthy account with its task unexecuted and the pane goes idle.
+ *
+ * So the replay is conditional, and both halves are load-bearing:
+ *
+ *   - error pi WILL retry      -> rotate only. Replaying would send the prompt
+ *     twice, once by us and once by pi's own retry. That regression is why
+ *     c9f4b3f removed the unconditional replay; tests/failover-turn-integrity-check.mjs
+ *     guards that direction.
+ *   - error pi will NOT retry  -> replay exactly once per rotation.
+ *
+ * This file guards the second direction, plus the "exactly once" part.
+ *
+ *   node tests/failover-replay-check.mjs
+ */
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createJiti } from "jiti";
+
+const here = new URL(".", import.meta.url).pathname;
+const extPath = join(here, "..", "extensions", "multi-sub.ts");
+const agentDir = mkdtempSync(join(tmpdir(), "multipass-replay-"));
+const originalPrompt = "map the bounce classification pipeline and write docs/bounces.md";
+
+writeFileSync(join(agentDir, "multi-pass.json"), JSON.stringify({
+	subscriptions: [{ provider: "anthropic", index: 2 }],
+	pools: [
+		{ name: "anthropic", baseProvider: "anthropic", members: ["anthropic", "anthropic-2"], enabled: true },
+		{ name: "codex", baseProvider: "openai-codex", members: ["openai-codex"], enabled: true },
+	],
+	chains: [{
+		name: "all",
+		enabled: true,
+		entries: [
+			{ pool: "anthropic", model: "claude-opus-5", enabled: true },
+			{ pool: "codex", model: "gpt-5.6-sol", enabled: true },
+		],
+	}],
+	presets: [],
+}, null, 2));
+writeFileSync(join(agentDir, "auth.json"), JSON.stringify({
+	anthropic: { type: "oauth", access: "fake-anthropic" },
+	"anthropic-2": { type: "oauth", access: "fake-anthropic-2" },
+	"openai-codex": { type: "oauth", access: "fake-codex" },
+}, null, 2));
+
+process.env.MULTIPASS_TEST_AGENT_DIR = agentDir;
+delete process.env.MULTI_SUB;
+
+const jiti = createJiti(import.meta.url, {
+	interopDefault: true,
+	alias: {
+		"@earendil-works/pi-coding-agent": join(here, "stubs", "coding-agent.mjs"),
+		"@earendil-works/pi-ai/compat": join(here, "stubs", "pi-ai-failover.mjs"),
+		"@earendil-works/pi-ai/oauth": join(here, "stubs", "pi-ai-failover.mjs"),
+		"@earendil-works/pi-ai": join(here, "stubs", "pi-ai-failover.mjs"),
+		"@earendil-works/pi-tui": join(here, "stubs", "pi-tui.mjs"),
+	},
+});
+const mod = await jiti.import(extPath, {});
+const multiSub = mod.default;
+
+const models = new Map([
+	["anthropic:claude-opus-5", { provider: "anthropic", id: "claude-opus-5", api: "fake" }],
+	["anthropic-2:claude-opus-5", { provider: "anthropic-2", id: "claude-opus-5", api: "fake" }],
+	["openai-codex:gpt-5.6-sol", { provider: "openai-codex", id: "gpt-5.6-sol", api: "fake" }],
+]);
+const handlers = new Map();
+const injectedUserMessages = [];
+const modelSwitches = [];
+let currentModel = models.get("anthropic:claude-opus-5");
+
+const pi = {
+	on(type, handler) {
+		const entries = handlers.get(type) ?? [];
+		entries.push(handler);
+		handlers.set(type, entries);
+	},
+	registerProvider() {},
+	registerCommand() {},
+	async setModel(model) {
+		modelSwitches.push(`${model.provider}:${model.id}`);
+		currentModel = model;
+		return true;
+	},
+	sendUserMessage(content, options) {
+		injectedUserMessages.push({ content, options });
+	},
+};
+
+multiSub(pi);
+
+const notifications = [];
+const modelRegistry = {
+	find(provider, modelId) {
+		return models.get(`${provider}:${modelId}`);
+	},
+	getProviderAuthStatus(provider) {
+		const auth = JSON.parse(readFileSync(join(agentDir, "auth.json"), "utf-8"));
+		return { configured: provider in auth, source: "stored" };
+	},
+	getProvider() {
+		return undefined;
+	},
+	refresh() {
+		return Promise.resolve({});
+	},
+};
+const ctx = {
+	cwd: agentDir,
+	get model() {
+		return currentModel;
+	},
+	modelRegistry,
+	ui: {
+		notify(message, level) {
+			notifications.push({ message, level });
+		},
+		setStatus() {},
+	},
+};
+
+async function emit(type, event) {
+	for (const handler of handlers.get(type) ?? []) {
+		await handler(event, ctx);
+	}
+}
+
+/**
+ * Verbatim from a real agent_end event, 2026-09-02, `anthropic` account.
+ * The leading "400 " is how pi formats `${status} ${body}` into errorMessage;
+ * the assistant message carries no separate status field, so the status has to
+ * be read off this string.
+ */
+function creditExhaustedEvent(provider, model = "claude-opus-5") {
+	return {
+		type: "agent_end",
+		messages: [{
+			role: "assistant",
+			provider,
+			model,
+			stopReason: "error",
+			errorMessage:
+				'400 {"type":"error","error":{"type":"invalid_request_error","message":"You\'re out of extra usage. Ask your workspace admin to add more so you can keep going."},"request_id":"req_011CeeWqkhoUWwzFFQR8Xazb"}',
+			content: [],
+		}],
+	};
+}
+
+/** A 429, which pi retries on its own. Rotate, do not replay. */
+function rateLimitedEvent(provider, model = "claude-opus-5") {
+	return {
+		type: "agent_end",
+		messages: [{
+			role: "assistant",
+			provider,
+			model,
+			stopReason: "error",
+			errorMessage: '429 {"type":"error","error":{"type":"rate_limit_error","message":"Rate limit reached"}}',
+			content: [],
+		}],
+	};
+}
+
+function replayTurn() {
+	return emit("before_agent_start", {
+		type: "before_agent_start",
+		prompt: originalPrompt,
+		systemPrompt: "",
+		systemPromptOptions: { cwd: agentDir },
+	});
+}
+
+await emit("session_start", { type: "session_start", reason: "startup" });
+await emit("input", { type: "input", text: originalPrompt, source: "interactive" });
+await emit("before_agent_start", {
+	type: "before_agent_start",
+	prompt: originalPrompt,
+	systemPrompt: "",
+	systemPromptOptions: { cwd: agentDir },
+});
+
+// ── First failure: a 429, which pi retries itself. Rotate, do not replay. ──
+//
+// This case comes first on purpose. Run it at the end of the cascade instead
+// and it passes for the wrong reason: with every account already attempted,
+// handleError returns false before it ever reaches the replay, so a build that
+// replays unconditionally would still show zero replays here. Caught 2026-09-02
+// by planting exactly that defect and watching this file stay green.
+await emit("agent_end", rateLimitedEvent("anthropic"));
+assert.equal(currentModel.provider, "anthropic-2", "a 429 must still rotate the account");
+assert.equal(
+	injectedUserMessages.length,
+	0,
+	"pi retries a 429 itself; replaying it would send the prompt twice",
+);
+
+await replayTurn();
+
+// ── Second failure: out of credit on a 400, which pi will not retry ──
+await emit("agent_end", creditExhaustedEvent("anthropic-2"));
+assert.equal(currentModel.provider, "openai-codex", "must hop the chain to codex");
+assert.equal(
+	injectedUserMessages.length,
+	1,
+	"pi does not retry a 400, so the rotation must replay the turn itself",
+);
+assert.equal(
+	injectedUserMessages[0].content,
+	originalPrompt,
+	"the replay must carry the original prompt, not a summary of it",
+);
+assert.equal(
+	injectedUserMessages[0].options?.deliverAs,
+	"followUp",
+	'"followUp", not "steer": the replay is a new turn on the new provider, not an injection into the turn that just failed',
+);
+
+assert.deepEqual(modelSwitches, ["anthropic-2:claude-opus-5", "openai-codex:gpt-5.6-sol"]);
+
+// ── Third failure: nothing left to rotate to, so nothing to replay ──
+//
+// pi re-emits before_agent_start for the replayed turn; the cascade must
+// survive it, or this failure starts a fresh cascade and retries the account
+// that just died.
+await replayTurn();
+await emit("agent_end", creditExhaustedEvent("openai-codex", "gpt-5.6-sol"));
+assert.equal(
+	currentModel.provider,
+	"openai-codex",
+	"cascade is exhausted, the model must stay put",
+);
+assert.equal(
+	injectedUserMessages.length,
+	1,
+	"a failed rotation must not replay - that would loop the prompt forever on a dead cascade",
+);
+
+console.log(
+	`failover replay checks passed (${modelSwitches.length} rotations, ${injectedUserMessages.length} replays)`,
+);

--- a/tests/failover-turn-integrity-check.mjs
+++ b/tests/failover-turn-integrity-check.mjs
@@ -1,0 +1,179 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createJiti } from "jiti";
+
+const here = new URL(".", import.meta.url).pathname;
+const extPath = join(here, "..", "extensions", "multi-sub.ts");
+const agentDir = mkdtempSync(join(tmpdir(), "multipass-turn-integrity-"));
+const originalPrompt = "I created some files on this repo a while ago for getting the base of Oportunidades de Motor. domain into a CSV. Can you find it?";
+
+writeFileSync(join(agentDir, "multi-pass.json"), JSON.stringify({
+	subscriptions: [{ provider: "anthropic", index: 2 }],
+	pools: [
+		{
+			name: "anthropic",
+			baseProvider: "anthropic",
+			members: ["anthropic", "anthropic-2"],
+			enabled: true,
+		},
+		{
+			name: "codex",
+			baseProvider: "openai-codex",
+			members: ["openai-codex"],
+			enabled: true,
+		},
+	],
+	chains: [{
+		name: "all",
+		enabled: true,
+		entries: [
+			{ pool: "anthropic", model: "claude-opus-5", enabled: true },
+			{ pool: "codex", model: "gpt-5.6-sol", enabled: true },
+		],
+	}],
+	presets: [],
+}, null, 2));
+writeFileSync(join(agentDir, "auth.json"), JSON.stringify({
+	anthropic: { type: "oauth", access: "fake-anthropic" },
+	"anthropic-2": { type: "oauth", access: "fake-anthropic-2" },
+	"openai-codex": { type: "oauth", access: "fake-codex" },
+}, null, 2));
+
+process.env.MULTIPASS_TEST_AGENT_DIR = agentDir;
+delete process.env.MULTI_SUB;
+
+const jiti = createJiti(import.meta.url, {
+	interopDefault: true,
+	alias: {
+		"@earendil-works/pi-coding-agent": join(here, "stubs", "coding-agent.mjs"),
+		"@earendil-works/pi-ai/compat": join(here, "stubs", "pi-ai-failover.mjs"),
+		"@earendil-works/pi-ai/oauth": join(here, "stubs", "pi-ai-failover.mjs"),
+		"@earendil-works/pi-ai": join(here, "stubs", "pi-ai-failover.mjs"),
+		"@earendil-works/pi-tui": join(here, "stubs", "pi-tui.mjs"),
+	},
+});
+const mod = await jiti.import(extPath, {});
+const multiSub = mod.default;
+
+const models = new Map([
+	["anthropic:claude-opus-5", { provider: "anthropic", id: "claude-opus-5", api: "fake" }],
+	["anthropic-2:claude-opus-5", { provider: "anthropic-2", id: "claude-opus-5", api: "fake" }],
+	["openai-codex:gpt-5.6-sol", { provider: "openai-codex", id: "gpt-5.6-sol", api: "fake" }],
+]);
+const handlers = new Map();
+const injectedUserMessages = [];
+const modelSwitches = [];
+let currentModel = models.get("anthropic:claude-opus-5");
+
+const pi = {
+	on(type, handler) {
+		const entries = handlers.get(type) ?? [];
+		entries.push(handler);
+		handlers.set(type, entries);
+	},
+	registerProvider() {},
+	registerCommand() {},
+	async setModel(model) {
+		modelSwitches.push(`${model.provider}:${model.id}`);
+		currentModel = model;
+		return true;
+	},
+	sendUserMessage(content, options) {
+		injectedUserMessages.push({ content, options });
+	},
+};
+
+multiSub(pi);
+
+const notifications = [];
+const statuses = [];
+const modelRegistry = {
+	find(provider, modelId) {
+		return models.get(`${provider}:${modelId}`);
+	},
+	getProviderAuthStatus(provider) {
+		const auth = JSON.parse(readFileSync(join(agentDir, "auth.json"), "utf-8"));
+		return { configured: provider in auth, source: "stored" };
+	},
+	getProvider() {
+		return undefined;
+	},
+	refresh() {
+		return Promise.resolve({});
+	},
+};
+const ctx = {
+	cwd: agentDir,
+	get model() {
+		return currentModel;
+	},
+	modelRegistry,
+	ui: {
+		notify(message, level) {
+			notifications.push({ message, level });
+		},
+		setStatus(_key, value) {
+			statuses.push(value);
+		},
+	},
+};
+
+async function emit(type, event) {
+	for (const handler of handlers.get(type) ?? []) {
+		await handler(event, ctx);
+	}
+}
+
+function overloadedEvent(provider) {
+	return {
+		type: "agent_end",
+		messages: [{
+			role: "assistant",
+			provider,
+			model: "claude-opus-5",
+			stopReason: "error",
+			errorMessage: '{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
+			content: [],
+		}],
+	};
+}
+
+await emit("session_start", { type: "session_start", reason: "startup" });
+await emit("input", {
+	type: "input",
+	text: originalPrompt,
+	source: "interactive",
+});
+await emit("before_agent_start", {
+	type: "before_agent_start",
+	prompt: originalPrompt,
+	systemPrompt: "",
+	systemPromptOptions: { cwd: agentDir },
+});
+
+// pi 0.84.4 emits agent_end for each failed low-level run, then automatically
+// retries that same turn with agent.continue(). These fake events model two
+// overloaded providers before the third provider takes over.
+await emit("agent_end", overloadedEvent("anthropic"));
+assert.equal(currentModel.provider, "anthropic-2");
+await emit("agent_end", overloadedEvent("anthropic-2"));
+assert.equal(currentModel.provider, "openai-codex");
+
+assert.deepEqual(modelSwitches, [
+	"anthropic-2:claude-opus-5",
+	"openai-codex:gpt-5.6-sol",
+]);
+assert.deepEqual(
+	injectedUserMessages,
+	[],
+	"account/provider failover must rely on pi's retry of the current turn, not enqueue the original prompt as steering or follow-up",
+);
+assert.equal(
+	notifications.filter((entry) => entry.level === "info" && entry.message.includes("Rate limited")).length,
+	2,
+);
+assert.equal(statuses.at(-1), "chain:all#2 | active openai-codex (gpt-5.6-sol)");
+
+console.log("failover turn integrity checks passed");

--- a/tests/runtime-failover-check.mjs
+++ b/tests/runtime-failover-check.mjs
@@ -111,7 +111,6 @@ class RuntimeHarness {
     this.sentPrompts = [];
     this.setModelCalls = [];
     this.cascadeState = null;
-    this.suppressNextStartTurn = false;
 
     for (const pool of config.pools) {
       if (!pool.enabled) continue;
@@ -143,10 +142,6 @@ class RuntimeHarness {
   }
 
   startTurn(prompt, currentModel) {
-    if (this.suppressNextStartTurn) {
-      this.suppressNextStartTurn = false;
-      return;
-    }
     if (!prompt) {
       this.cascadeState = null;
       return;
@@ -381,10 +376,6 @@ class RuntimeHarness {
 
     this.notify(formatFailoverTransition(pool.name, currentModel.provider, nextCandidate), "info");
     this.setStatus("multi-pass", formatFailoverStatus(nextCandidate));
-    if (prompt) {
-      this.suppressNextStartTurn = true;
-      this.sendUserMessage(prompt);
-    }
     return true;
   }
 
@@ -502,7 +493,7 @@ async function runPoolOnlyChecks() {
 
   const snapshot = harness.snapshot();
   assert.deepEqual(snapshot.setModelCalls, ["anthropic-2:claude-sonnet-4"]);
-  assert.deepEqual(snapshot.sentPrompts, [prompt]);
+  assert.deepEqual(snapshot.sentPrompts, []);
   assert.equal(snapshot.statuses.at(-1), "pool:primary | active anthropic-2 (claude-sonnet-4)");
   assert.equal(
     snapshot.notifications.at(-1).message,
@@ -560,7 +551,7 @@ async function runNoLoopChecks() {
     "google-gemini-cli:gemini-2.5-pro",
   ]);
   assert.deepEqual(snapshot.visitedChainIndexes, [1, 2]);
-  assert.deepEqual(snapshot.sentPrompts, [prompt, prompt, prompt, prompt, prompt]);
+  assert.deepEqual(snapshot.sentPrompts, []);
 
   const warningMessages = snapshot.notifications
     .filter((entry) => entry.level === "warning")

--- a/tests/schedule-and-restrict-check.mjs
+++ b/tests/schedule-and-restrict-check.mjs
@@ -1,0 +1,154 @@
+/**
+ * Regression tests for two silent-data-loss bugs in the pool editors.
+ *
+ * Both were found by driving the real TUI, and both were invisible to the rest
+ * of this directory: pool-edit-check.mjs and project-restriction-check.mjs
+ * re-implement the logic locally, so they passed while the shipped code was
+ * wrong. These tests load extensions/multi-sub.ts itself.
+ *
+ * Bug 1 - schedule windows: input the parser could not read was discarded
+ *   without a word. A "preferred" member with zero windows is ALWAYS active
+ *   (getScheduledMemberState), so "09:00-18:00" produced a pool that looked
+ *   scheduled and behaved unscheduled.
+ *
+ * Bug 2 - project restriction: the staged allow-list started empty instead of
+ *   seeded from the saved config, and the editor saves on Escape as well as on
+ *   [Done - save]. Opening the screen and backing out wiped the restriction and
+ *   reported "Project restriction cleared. All subs available."
+ */
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createJiti } from "jiti";
+
+const here = new URL(".", import.meta.url).pathname;
+const extPath = join(here, "..", "extensions", "multi-sub.ts");
+
+const jiti = createJiti(import.meta.url, {
+	interopDefault: true,
+	alias: {
+		"@earendil-works/pi-coding-agent": join(here, "stubs", "coding-agent.mjs"),
+		"@earendil-works/pi-ai/compat": join(here, "stubs", "pi-ai.mjs"),
+		"@earendil-works/pi-ai/oauth": join(here, "stubs", "pi-ai.mjs"),
+		"@earendil-works/pi-ai": join(here, "stubs", "pi-ai.mjs"),
+		"@earendil-works/pi-tui": join(here, "stubs", "pi-tui.mjs"),
+	},
+});
+process.env.MULTIPASS_TEST_AGENT_DIR = mkdtempSync(join(tmpdir(), "multipass-schedule-"));
+
+const mod = await jiti.import(extPath, {});
+const { parseScheduleWindowInput, initialAllowedSubs } = mod.__testHooks;
+assert.ok(parseScheduleWindowInput, "__testHooks must export parseScheduleWindowInput");
+assert.ok(initialAllowedSubs, "__testHooks must export initialAllowedSubs");
+
+// --- bug 1: schedule window parsing --------------------------------------
+
+// Bare hour ranges keep working, including the overnight case.
+assert.deepEqual(parseScheduleWindowInput("9-17").hours, [9, 17]);
+assert.deepEqual(parseScheduleWindowInput("22-6").hours, [22, 6]);
+
+// Clock form is accepted - this is what a user actually types.
+assert.deepEqual(
+	parseScheduleWindowInput("09:00-18:00").hours,
+	[9, 18],
+	'"09:00-18:00" must parse as hours 9-18, not be silently dropped',
+);
+assert.deepEqual(parseScheduleWindowInput("9:00-17:00").hours, [9, 17]);
+
+// Minutes cannot be represented in ScheduleWindow.hours, so a clock form with
+// non-zero minutes must be REJECTED rather than truncated to a wrong window.
+assert.equal(
+	parseScheduleWindowInput("09:30-18:00"),
+	null,
+	"non-zero minutes must be rejected, never truncated to 9-18",
+);
+assert.equal(parseScheduleWindowInput("09:00-18:45"), null);
+
+// Out-of-range hours are not a window.
+assert.equal(parseScheduleWindowInput("9-25"), null);
+assert.equal(parseScheduleWindowInput("30-40"), null);
+
+// Days still work, alone and combined with hours.
+assert.deepEqual(parseScheduleWindowInput("mon-fri").days, [
+	"mon",
+	"tue",
+	"wed",
+	"thu",
+	"fri",
+]);
+const combined = parseScheduleWindowInput("9-17 mon-fri");
+assert.deepEqual(combined.hours, [9, 17]);
+assert.equal(combined.days.length, 5);
+assert.deepEqual(parseScheduleWindowInput("sat").days, ["sat"]);
+
+// Date ranges still work.
+assert.deepEqual(parseScheduleWindowInput("2026-01-01..2026-01-31").dateRange, {
+	from: "2026-01-01",
+	to: "2026-01-31",
+});
+
+// Garbage yields null so the caller can warn instead of pretending it worked.
+assert.equal(parseScheduleWindowInput("whenever"), null);
+assert.equal(parseScheduleWindowInput("9h-17h"), null);
+assert.equal(parseScheduleWindowInput(""), null);
+
+// The caller must actually warn. Only promptPreferredMemberSchedule owns that
+// path, so assert the shipped source warns on unparseable input rather than
+// swallowing it, and that neither editor kept its own silent copy.
+const source = await import("node:fs").then((fs) => fs.readFileSync(extPath, "utf-8"));
+assert.match(
+	source,
+	/Could not read .* as a time window/,
+	"unparseable window input must produce a user-visible warning",
+);
+const silentSchedule = source.match(/if \(window\) schedule\.windows = \[window\];/g) ?? [];
+assert.deepEqual(
+	silentSchedule,
+	[],
+	"schedule editors must go through promptPreferredMemberSchedule, not silently drop the parse result",
+);
+
+// --- bug 2: project restriction seeding ----------------------------------
+
+const allProviders = ["anthropic", "anthropic-2", "openai-codex"];
+
+// Saved restriction is staged, so [Done - save] / Escape re-saves it.
+assert.deepEqual(
+	initialAllowedSubs({ allowedSubs: ["anthropic"] }, allProviders),
+	["anthropic"],
+	"an existing restriction must be staged, not dropped on open",
+);
+assert.deepEqual(initialAllowedSubs({ allowedSubs: ["anthropic", "openai-codex"] }, allProviders), [
+	"anthropic",
+	"openai-codex",
+]);
+
+// No restriction stays no restriction.
+assert.deepEqual(initialAllowedSubs(undefined, allProviders), []);
+assert.deepEqual(initialAllowedSubs({}, allProviders), []);
+assert.deepEqual(initialAllowedSubs({ allowedSubs: [] }, allProviders), []);
+
+// A restriction naming a provider that no longer exists must not resurrect it.
+assert.deepEqual(
+	initialAllowedSubs({ allowedSubs: ["anthropic", "anthropic-9"] }, allProviders),
+	["anthropic"],
+	"stale provider names must be filtered out of the staged list",
+);
+
+// A correct helper the editor does not call fixes nothing, so pin the call site
+// too. This is what the first draft of this test missed: reverting the editor to
+// `const allowed: string[] = []` left every assertion above green.
+assert.match(
+	source,
+	/const allowed: string\[\] = initialAllowedSubs\(projectConf, allProviderNames\);/,
+	"the restriction editor must seed its staged list via initialAllowedSubs",
+);
+const emptyStaging = source.match(/const allowed: string\[\] = \[\];/g) ?? [];
+assert.deepEqual(
+	emptyStaging,
+	[],
+	"the restriction editor must not start staging from an empty list",
+);
+
+console.log("schedule-and-restrict-check: all assertions passed");

--- a/tests/stubs/coding-agent.mjs
+++ b/tests/stubs/coding-agent.mjs
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+export function getAgentDir() {
+	return process.env.MULTIPASS_TEST_AGENT_DIR ?? "/tmp";
+}
+export function readStoredCredential(providerId, authPath = join(getAgentDir(), "auth.json")) {
+	try {
+		return JSON.parse(readFileSync(authPath, "utf-8"))[providerId];
+	} catch {
+		return undefined;
+	}
+}
+export class BorderedLoader {}
+export class DynamicBorder {}
+export function keyHint() { return ""; }

--- a/tests/stubs/pi-ai-failover.mjs
+++ b/tests/stubs/pi-ai-failover.mjs
@@ -1,0 +1,19 @@
+const modelDefaults = {
+	name: "Fake model",
+	api: "fake",
+	baseUrl: "http://fake.invalid",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 1000,
+	maxTokens: 100,
+};
+
+const models = {
+	anthropic: [{ ...modelDefaults, id: "claude-opus-5" }],
+	"openai-codex": [{ ...modelDefaults, id: "gpt-5.6-sol" }],
+};
+
+export function getModels(provider) {
+	return models[provider] ?? [];
+}

--- a/tests/stubs/pi-ai.mjs
+++ b/tests/stubs/pi-ai.mjs
@@ -1,0 +1,1 @@
+export function getModels() { return []; }

--- a/tests/stubs/pi-tui.mjs
+++ b/tests/stubs/pi-tui.mjs
@@ -1,0 +1,5 @@
+export class Container {}
+export class Key {}
+export class SelectList {}
+export class Text {}
+export function matchesKey() { return false; }

--- a/tests/tier-mapping-check.mjs
+++ b/tests/tier-mapping-check.mjs
@@ -1,0 +1,301 @@
+/**
+ * When failover crosses from one pool to another, does the session keep the
+ * TIER of the model it was using?
+ *
+ * A chain entry says "pool + the model to use there", so a hop used entry.model
+ * verbatim regardless of what the session was on. Same-pool rotation already
+ * kept currentModel.id; only the chain hop threw it away, seventy lines further
+ * down the same function.
+ *
+ * What that costs, on the live roster: `implementer` and `tester` run
+ * anthropic/claude-sonnet-5, and the chain's codex entry names gpt-5.6-sol. Both
+ * agents get silently promoted to a flagship model the moment the anthropic pool
+ * dries up, and the only signal is the bill. The reverse is worse to debug - a
+ * flagship session quietly demoted mid-task and answering worse.
+ *
+ * The tier table is explicit on purpose. Do not infer tiers from model names:
+ * "-mini", "-opus" and "sol" are vendor marketing and they change.
+ *
+ *   node tests/tier-mapping-check.mjs
+ */
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createJiti } from "jiti";
+
+const here = new URL(".", import.meta.url).pathname;
+const extPath = join(here, "..", "extensions", "multi-sub.ts");
+
+const TIERS = [
+	{ name: "flagship", models: { anthropic: "claude-opus-5", "openai-codex": "gpt-5.6-sol" } },
+	{ name: "mid", models: { anthropic: "claude-sonnet-5", "openai-codex": "gpt-5.4" } },
+	{ name: "cheap", models: { anthropic: "claude-haiku-4-5", "openai-codex": "gpt-5.4-mini" } },
+];
+
+function writeConfig(agentDir, { tiers }) {
+	writeFileSync(join(agentDir, "multi-pass.json"), JSON.stringify({
+		subscriptions: [{ provider: "anthropic", index: 2 }],
+		pools: [
+			{ name: "anthropic", baseProvider: "anthropic", members: ["anthropic", "anthropic-2"], enabled: true },
+			{ name: "codex", baseProvider: "openai-codex", members: ["openai-codex"], enabled: true },
+		],
+		chains: [{
+			name: "all",
+			enabled: true,
+			entries: [
+				{ pool: "anthropic", model: "claude-opus-5", enabled: true },
+				{ pool: "codex", model: "gpt-5.6-sol", enabled: true },
+			],
+		}],
+		presets: [],
+		...(tiers ? { tiers } : {}),
+	}, null, 2));
+	writeFileSync(join(agentDir, "auth.json"), JSON.stringify({
+		anthropic: { type: "oauth", access: "fake-anthropic" },
+		"anthropic-2": { type: "oauth", access: "fake-anthropic-2" },
+		"openai-codex": { type: "oauth", access: "fake-codex" },
+	}, null, 2));
+}
+
+/**
+ * One extension instance with its own config, driven through a real cascade.
+ * jiti caches by path, so each scenario gets a fresh jiti to keep the module's
+ * top-level state (registryRef, pool cooldowns) from leaking between them.
+ */
+async function scenario({ tiers, startModel, models }) {
+	const agentDir = mkdtempSync(join(tmpdir(), "multipass-tier-"));
+	mkdirSync(join(agentDir, ".pi"), { recursive: true });
+	writeConfig(agentDir, { tiers });
+	process.env.MULTIPASS_TEST_AGENT_DIR = agentDir;
+	delete process.env.MULTI_SUB;
+
+	const jiti = createJiti(import.meta.url, {
+		interopDefault: true,
+		moduleCache: false,
+		alias: {
+			"@earendil-works/pi-coding-agent": join(here, "stubs", "coding-agent.mjs"),
+			"@earendil-works/pi-ai/compat": join(here, "stubs", "pi-ai-failover.mjs"),
+			"@earendil-works/pi-ai/oauth": join(here, "stubs", "pi-ai-failover.mjs"),
+			"@earendil-works/pi-ai": join(here, "stubs", "pi-ai-failover.mjs"),
+			"@earendil-works/pi-tui": join(here, "stubs", "pi-tui.mjs"),
+		},
+	});
+	const mod = await jiti.import(extPath, {});
+
+	const catalog = new Map(models.map((m) => [`${m.provider}:${m.id}`, { ...m, api: "fake" }]));
+	const handlers = new Map();
+	const statuses = [];
+	const notifications = [];
+	let currentModel = catalog.get(startModel);
+	assert.ok(currentModel, `start model ${startModel} missing from the test catalog`);
+
+	const pi = {
+		on(type, handler) {
+			const list = handlers.get(type) ?? [];
+			list.push(handler);
+			handlers.set(type, list);
+		},
+		registerProvider() {},
+		registerCommand() {},
+		async setModel(model) {
+			currentModel = model;
+			return true;
+		},
+		sendUserMessage() {},
+	};
+	mod.default(pi);
+
+	const ctx = {
+		cwd: agentDir,
+		get model() {
+			return currentModel;
+		},
+		modelRegistry: {
+			find(provider, modelId) {
+				return catalog.get(`${provider}:${modelId}`);
+			},
+			getProviderAuthStatus(provider) {
+				const auth = JSON.parse(readFileSync(join(agentDir, "auth.json"), "utf-8"));
+				return { configured: provider in auth, source: "stored" };
+			},
+			getProvider() {
+				return undefined;
+			},
+			refresh() {
+				return Promise.resolve({});
+			},
+		},
+		ui: {
+			notify(message, level) {
+				notifications.push({ message, level });
+			},
+			setStatus(_key, value) {
+				statuses.push(value);
+			},
+		},
+	};
+
+	const emit = async (type, event) => {
+		for (const handler of handlers.get(type) ?? []) await handler(event, ctx);
+	};
+	const prompt = "trace the bounce pipeline";
+	const fail = (provider) => emit("agent_end", {
+		type: "agent_end",
+		messages: [{
+			role: "assistant",
+			provider,
+			model: currentModel.id,
+			stopReason: "error",
+			errorMessage: '429 {"type":"error","error":{"type":"rate_limit_error","message":"Rate limit reached"}}',
+			content: [],
+		}],
+	});
+
+	await emit("session_start", { type: "session_start", reason: "startup" });
+	await emit("before_agent_start", {
+		type: "before_agent_start",
+		prompt,
+		systemPrompt: "",
+		systemPromptOptions: { cwd: agentDir },
+	});
+
+	return { mod, fail, statuses, notifications, current: () => currentModel };
+}
+
+const FULL_CATALOG = [
+	{ provider: "anthropic", id: "claude-opus-5" },
+	{ provider: "anthropic", id: "claude-sonnet-5" },
+	{ provider: "anthropic-2", id: "claude-opus-5" },
+	{ provider: "anthropic-2", id: "claude-sonnet-5" },
+	{ provider: "openai-codex", id: "gpt-5.6-sol" },
+	{ provider: "openai-codex", id: "gpt-5.4" },
+	{ provider: "openai-codex", id: "gpt-5.4-mini" },
+];
+
+// ── 1. The pure resolver ──────────────────────────────────────────────────
+{
+	const { mod } = await scenario({
+		tiers: TIERS,
+		startModel: "anthropic:claude-sonnet-5",
+		models: FULL_CATALOG,
+	});
+	const resolve = mod.resolveTierEquivalent;
+	assert.equal(typeof resolve, "function", "resolveTierEquivalent must be exported for tests");
+
+	assert.equal(resolve(TIERS, "anthropic", "claude-sonnet-5", "openai-codex"), "gpt-5.4");
+	assert.equal(resolve(TIERS, "openai-codex", "gpt-5.4-mini", "anthropic"), "claude-haiku-4-5");
+	assert.equal(
+		resolve(TIERS, "anthropic", "claude-fable-5", "openai-codex"),
+		undefined,
+		"a model in no tier has no equivalent - the caller falls back to entry.model",
+	);
+	assert.equal(
+		resolve(TIERS, "anthropic", "claude-sonnet-5", "google-gemini-cli"),
+		undefined,
+		"a tier that names no model for the target provider has no equivalent",
+	);
+	assert.equal(resolve(undefined, "anthropic", "claude-sonnet-5", "openai-codex"), undefined);
+	assert.equal(resolve([], "anthropic", "claude-sonnet-5", "openai-codex"), undefined);
+
+	// The pool holds anthropic and anthropic-2, which share a catalogue. Keying
+	// by provider (not pool) is what makes the second one resolvable.
+	assert.equal(resolve(TIERS, "anthropic-2", "claude-sonnet-5", "openai-codex"), undefined,
+		"anthropic-2 is not in the table, so it has no tier of its own");
+
+	// A model listed twice is a config error; first match wins, deterministically.
+	const dupes = [
+		{ name: "mid", models: { anthropic: "claude-sonnet-5", "openai-codex": "gpt-5.4" } },
+		{ name: "cheap", models: { anthropic: "claude-sonnet-5", "openai-codex": "gpt-5.4-mini" } },
+	];
+	assert.equal(resolve(dupes, "anthropic", "claude-sonnet-5", "openai-codex"), "gpt-5.4");
+	console.log("  resolver checks passed");
+}
+
+// ── 2. A mid-tier session must not be promoted on a chain hop ─────────────
+{
+	const s = await scenario({
+		tiers: TIERS,
+		startModel: "anthropic:claude-sonnet-5",
+		models: FULL_CATALOG,
+	});
+	await s.fail("anthropic");
+	assert.equal(s.current().provider, "anthropic-2");
+	assert.equal(
+		s.current().id,
+		"claude-sonnet-5",
+		"same-pool rotation already preserved the model and must keep doing so",
+	);
+
+	await s.fail("anthropic-2");
+	assert.equal(s.current().provider, "openai-codex");
+	assert.equal(
+		s.current().id,
+		"gpt-5.4",
+		"the chain hop must land on the codex model at the SAME tier, not on the entry's gpt-5.6-sol",
+	);
+	assert.match(
+		s.statuses.at(-1),
+		/tier: mid/,
+		"the status line must say the model came from the tier table, not the chain entry",
+	);
+	console.log("  mid-tier hop checks passed");
+}
+
+// ── 3. No tiers key: byte-identical to the old behaviour ──────────────────
+{
+	const s = await scenario({
+		tiers: undefined,
+		startModel: "anthropic:claude-sonnet-5",
+		models: FULL_CATALOG,
+	});
+	await s.fail("anthropic");
+	await s.fail("anthropic-2");
+	assert.equal(s.current().id, "gpt-5.6-sol", "without a tiers table the chain entry decides, as before");
+	assert.equal(
+		s.statuses.at(-1),
+		"chain:all#2 | active openai-codex (gpt-5.6-sol)",
+		"the status line must not grow a suffix for configs that have no tiers",
+	);
+	console.log("  no-tiers compatibility checks passed");
+}
+
+// ── 4. A model in no tier falls back, and says so ─────────────────────────
+{
+	const s = await scenario({
+		tiers: TIERS,
+		startModel: "anthropic:claude-fable-5",
+		models: [...FULL_CATALOG, { provider: "anthropic", id: "claude-fable-5" }, { provider: "anthropic-2", id: "claude-fable-5" }],
+	});
+	await s.fail("anthropic");
+	await s.fail("anthropic-2");
+	assert.equal(s.current().id, "gpt-5.6-sol", "an untiered model falls back to the chain entry");
+	assert.match(s.statuses.at(-1), /chain default/, "and the status line says the tier table did not decide");
+	console.log("  untiered fallback checks passed");
+}
+
+// ── 5. A tier naming a model the provider does not have falls back ────────
+//
+// Without this the candidate reaches handleError, ctx.modelRegistry.find returns
+// undefined, and the whole cascade aborts with "model missing at runtime" - one
+// typo in the tier table would disable failover entirely.
+{
+	const s = await scenario({
+		tiers: [
+			{ name: "flagship", models: { anthropic: "claude-opus-5", "openai-codex": "gpt-5.7-does-not-exist" } },
+			...TIERS.slice(1),
+		],
+		startModel: "anthropic:claude-opus-5",
+		models: FULL_CATALOG,
+	});
+	await s.fail("anthropic");
+	await s.fail("anthropic-2");
+	assert.equal(
+		s.current().id,
+		"gpt-5.6-sol",
+		"a tier pointing at a model the target provider does not serve must fall back, not strand the cascade",
+	);
+	console.log("  unknown-mapped-model fallback checks passed");
+}
+
+console.log("tier mapping checks passed");

--- a/tsconfig.check.json
+++ b/tsconfig.check.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["extensions/multi-sub.ts"]
+}


### PR DESCRIPTION
## Problem

`pi-multi-pass@1.3.0` is unusable on pi 0.84.x. Every `/subs`, `/pool` and `/mp-preset` command fails immediately with:

```
Extension "command:subs" error: Cannot read properties of undefined (reading 'hasAuth')
```

The extension reads `ctx.modelRegistry.authStorage`, which pi removed in commit `9993c9690` ("replace model registry with model runtime"). `ModelRegistry` now keeps a private `runtime` and exposes methods instead, so `authStorage` is `undefined` and `.hasAuth(...)` throws. Since this package declares no `engines` and no `peerDependencies`, npm installs it against incompatible pi versions without complaint.

A second break was hiding behind the first: `@earendil-works/pi-ai/oauth` is now **type-only** (zero runtime exports), so `loginAnthropic`, `anthropicOAuthProvider`, `refreshAnthropicToken` and 15 other imports were all `undefined` at runtime.

## Investigation

Both breaks were confirmed by reading pi 0.84.4's sources, not inferred from the error text:

- `packages/coding-agent/src/core/model-registry.ts` - the public surface that replaced `authStorage`.
- `packages/coding-agent/src/modes/interactive/interactive-mode.ts` - how pi's own `/login` drives `LoginDialogComponent`.
- `packages/coding-agent/src/core/agent-session.ts:1214` - the `"Agent is already processing"` guard.

One mapping in particular is not the obvious one. `authStorage.get(p)` looks like it should become `modelRegistry.getProviderAuth(p)`, but that returns a **resolved** `AuthResult` (`{auth:{apiKey}}`), not the raw stored OAuth credential this extension needs, and it is async. The right replacement is `readStoredCredential(p)`, which is synchronous - so the port did not have to make ~30 call sites async.

## Shape of the change

**1. One compatibility shim instead of 30 edits** (`createAuthCompat`):

| Old | New |
|---|---|
| `authStorage.hasAuth(p)` | `modelRegistry.getProviderAuthStatus(p).configured` |
| `authStorage.get(p)` | `readStoredCredential(p)` (sync, raw credential) |
| `authStorage.set(p, c)` | write `auth.json`, then `refresh({providers:[p]})` |
| `authStorage.logout(p)` | delete from `auth.json`, then `refresh({providers:[p]})` |

`ModelRuntime.logout()` exists but is not reachable from `ExtensionContext`, hence the `auth.json` path for `set`/`logout`.

**2. OAuth flows borrowed from the built-in provider at call time.** Rather than importing flows that no longer exist at runtime, `getBuiltinOAuthFlow(base)` reads `modelRegistry.getProvider(base).auth.oauth`, and `toAuthInteraction()` adapts pi's canonical `AuthInteraction` back to the legacy callback shape `pi.registerProvider({ oauth })` still expects - the inverse of pi's own `adaptOAuth()`. A cloned subscription therefore runs the exact same flow as `/login` on its base provider. Providers resolve lazily because `registerSub()` runs at load time, before any `ExtensionContext` exists.

**3. `/subs login` actually logs in.** It previously printed "Use /login and select ...". It now runs the cloned provider's OAuth flow inside a `LoginDialogComponent`, the same component pi uses, and persists the credential. Same for `/subs add` -> "Login now?" and the per-subscription `login` action.

**4. Failover preserves one user turn.** pi 0.84.4 automatically retries retryable assistant errors with `agent.continue()` after `agent_end`. The extension now rotates the active account/model and lets pi continue that same in-flight turn. It no longer calls `sendUserMessage(..., { deliverAs: "followUp" })`, which created one duplicate queued copy of the original prompt per failed account.

**5. Two silent-data-loss bugs in the pool editors**, both found by driving the real TUI:

- **Project restriction wiped itself.** The staged allow-list started empty instead of seeded from the saved config, and the editor saves on Escape as well as on `[Done - save]`. Opening `/pool project` -> `restrict` and backing out deleted an existing restriction and reported "Project restriction cleared. All subs available." Now seeded via `initialAllowedSubs()`, which also drops provider names that no longer exist.
- **Schedule windows vanished.** Input the parser could not read was discarded without a word. A `preferred` member with zero windows is treated as **always active** by `getScheduledMemberState`, so typing `09:00-18:00` produced a pool that looked scheduled and behaved unscheduled. The clock form is now accepted (whole hours only - non-zero minutes are rejected rather than truncated to a wrong window), and unreadable input warns and names the accepted formats.

**6. Smaller fixes:** dropped the Google providers (pi 0.84.4 registers none), fixed an arity bug that broke `/pool chain list`, and corrected the per-subscription action description, which still said login would "Show login instructions".

## Risk

The `set`/`logout` paths write `auth.json` directly, which is the file pi's own auth storage owns. Both do a read-modify-write of a single provider key and then ask the registry to refresh only that provider. Verified against a backup that a logout removes exactly one entry and leaves every other credential byte-identical.

Anyone relying on the Google providers loses them, but they could not have worked on 0.84.4 anyway.

Failover continuation relies on pi's automatic retry budget, enabled by default with three retries in pi 0.84.4. If every attempt exhausts that budget, failover stops rather than creating another user turn.

## Evidence

Type-clean (`npx tsc -p tsconfig.check.json`) and all 10 test scripts pass.

Verified in a live pi 0.84.4 TUI against real accounts, in a sandboxed agent directory (`PI_CODING_AGENT_DIR`) so the destructive paths ran against real data without risking a real config:

- `/subs list`, `status`, `limits` (including the per-account quota drill-down), `switch` - and a real completion on a switched cloned provider.
- `/subs add` -> `Login now?` reaches the genuine Anthropic OAuth flow with live PKCE and the manual-code fallback; cancelling leaves the subscription unauthenticated and writes no credential.
- `/subs logout` removed exactly the target credential; `/subs remove` also stripped the member from its pool.
- `/subs` rename, `/pool` create (incl. `quota-first` and `scheduled` strategies), list, inspect, members, strategy, rename, toggle, remove.
- `/pool chain` create, list, toggle, remove, status; `/pool project` restrict and info; `/mp-preset` create, list, activate (by name), toggle, remove.
- **Cross-provider turn-integrity regression:** fake Anthropic, Anthropic #2 and OpenAI Codex attempts rotate twice while preserving zero injected steering/follow-up messages.

The six pre-existing test scripts never load `extensions/multi-sub.ts` - they re-implement the logic locally - so they cannot see an API break at all: **all six pass with the `hasAuth` mapping deliberately inverted.** Two new scripts load the real file:

- `tests/auth-compat-check.mjs` - drives the real shim against a fake `ModelRegistry` and catches all 6 planted `authStorage` defects.
- `tests/schedule-and-restrict-check.mjs` - covers both editor bugs, including the call sites. Verified by planting all four reverts; an earlier draft passed when only the *call site* was reverted, which is why the call-site assertions are there.
- `tests/failover-turn-integrity-check.mjs` - loads the real extension with fake providers, reproduces Anthropic -> Anthropic #2 -> OpenAI Codex rotation, and requires zero injected user messages.

Also added `tsconfig.check.json` and `tests/stubs/` so the extension can be type-checked and imported outside a running pi.

## Open questions for the maintainer

1. **`engines` / `peerDependencies`** - worth declaring a pi range so npm refuses an incompatible install instead of failing at first command?
2. **Google providers** - dropped here because 0.84.4 registers none. Restore behind a capability check if they come back?
3. **`logout` via `auth.json`** - happy to switch to a public pi API if one is planned; `ModelRuntime.logout()` is not reachable from `ExtensionContext` today.
4. **Version bump** - left alone; tell me what you want and I will add it.

