### PR TITLE
feat: add Antigravity provider and smarter pool failover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog — pi-multi-pass
+
+All notable changes to the `pi-multi-pass` extension are documented here.
+
+## [Unreleased] - 2026-09-09
+
+### Feat: Antigravity Multi-Subscription Support & Smarter Pool Failover
+
+- Added first-class `antigravity` provider registration with OAuth login, refresh, API key resolution, live model catalog, and streaming integration.
+- Kept `google-antigravity` as a legacy alias while preferring the new `antigravity` provider name.
+- Registered the Antigravity API with Pi compatibility provider hooks so multi-subscription routing can use Antigravity models directly.
+- Added Codex OAuth token metadata fallback from `chatgpt_account_id` to `user_id` for personal/free ChatGPT accounts.
+- Expanded provider retry classification for overloads, 5xx errors, network failures, Cloudflare 524s, insufficient quota, usage limits, and budget errors.
+- Prevented replay loops by distinguishing retryable infrastructure errors from non-retryable account/quota/billing limits.
+- Improved pool failover follow-up replay so a captured prompt or safe `continue` fallback is submitted when Pi will not retry the failed turn.
+- Added runtime failover test coverage for retryable and non-retryable provider error cases.

--- a/docs/LESSONS_LEARNED.md
+++ b/docs/LESSONS_LEARNED.md
@@ -1,0 +1,11 @@
+# Lessons Learned — pi-multi-pass
+
+## 2026-09-09 — Provider Pools, Codex Accounts, and Antigravity
+
+- ChatGPT/Codex OAuth tokens for personal/free accounts can omit `chatgpt_account_id`. Always fall back to `user_id` when extracting account metadata for `chatgpt-account-id`.
+- Treat quota, budget, billing, and usage-limit errors as non-retryable provider/account limits. Replaying the same turn through Pi retry can loop unless the pool extension explicitly rotates providers and submits a follow-up.
+- Treat 5xx, 429, overload, timeout, connection reset, and Cloudflare 524 errors as retryable infrastructure/provider errors.
+- Respect Pi global retry settings (`settings.retry.enabled === false`) before assuming Pi will retry a turn.
+- When a model provider is not part of `@earendil-works/pi-ai/providers/all`, register it explicitly with `registerApiProvider` and supply the provider-specific API and stream handlers.
+- Preserve legacy provider aliases (`google-antigravity`) while adding cleaner names (`antigravity`) to avoid breaking existing user configs.
+- For failover replay, if the original user prompt is unavailable, submit a safe `continue` follow-up instead of silently dropping the turn.

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -1,0 +1,9 @@
+# Project Memory — pi-multi-pass
+
+## 2026-09-09 Session Memory
+
+- Added Antigravity provider support directly in `extensions/multi-sub.ts` using `pi-antigravity` auth, catalog, and streaming modules.
+- The preferred provider key is now `antigravity`; `google-antigravity` remains as a compatibility alias.
+- Codex token metadata extraction now supports personal/free ChatGPT accounts by falling back to `user_id` when `chatgpt_account_id` is empty.
+- Pool failover logic now makes a clearer distinction between retryable service failures and non-retryable account/quota/billing limits.
+- Runtime tests were updated in `tests/runtime-failover-check.mjs` to cover smarter failover/replay behavior.

--- a/extensions/multi-sub.ts
+++ b/extensions/multi-sub.ts
@@ -64,6 +64,18 @@ import {
 } from "@earendil-works/pi-ai/providers/all";
 import type { OAuthCredentials, OAuthLoginCallbacks } from "@earendil-works/pi-ai/oauth";
 import type { Api, Model } from "@earendil-works/pi-ai";
+import { registerApiProvider } from "@earendil-works/pi-ai/compat";
+import {
+	getApiKey as getAntigravityApiKey,
+	loginAntigravity,
+	refreshAntigravityToken,
+} from "../../../../../npm/node_modules/pi-antigravity/src/auth/index.js";
+import { DEFAULT_ENDPOINT as ANTIGRAVITY_ENDPOINT } from "../../../../../npm/node_modules/pi-antigravity/src/client/index.js";
+import {
+	getCurrentAntigravityCatalog,
+	refreshAntigravityModels,
+} from "../../../../../npm/node_modules/pi-antigravity/src/models/index.js";
+import { ANTIGRAVITY_API, streamAntigravity } from "../../../../../npm/node_modules/pi-antigravity/src/stream/index.js";
 import {
 	Container,
 	Key,
@@ -302,13 +314,31 @@ const PROVIDER_TEMPLATES: Record<string, ProviderTemplate> = {
 		},
 	},
 
-	"google-antigravity": {
+	antigravity: {
 		displayName: "Antigravity",
 		usesCallbackServer: true,
 		buildOAuth(index: number) {
-			return flowBackedOAuth("google-antigravity", `Antigravity #${index}`, {
+			return {
+				name: `Antigravity #${index}`,
 				usesCallbackServer: true,
-			});
+				login: loginAntigravity,
+				refreshToken: refreshAntigravityToken,
+				getApiKey: getAntigravityApiKey,
+			};
+		},
+	},
+
+	"google-antigravity": {
+		displayName: "Antigravity (legacy alias; use antigravity)",
+		usesCallbackServer: true,
+		buildOAuth(index: number) {
+			return {
+				name: `Antigravity #${index}`,
+				usesCallbackServer: true,
+				login: loginAntigravity,
+				refreshToken: refreshAntigravityToken,
+				getApiKey: getAntigravityApiKey,
+			};
 		},
 	},
 
@@ -482,7 +512,9 @@ function getCodexTokenMetadata(accessToken: string): {
 	const payload = decodeJwtPayload(accessToken);
 	const auth = getRecord(payload[OPENAI_AUTH_CLAIM]);
 	const profile = getRecord(payload[OPENAI_PROFILE_CLAIM]);
-	const accountId = typeof auth?.chatgpt_account_id === "string" ? auth.chatgpt_account_id : undefined;
+	const accountId = (typeof auth?.chatgpt_account_id === "string" && auth.chatgpt_account_id.length > 0)
+		? auth.chatgpt_account_id
+		: (typeof auth?.user_id === "string" ? auth.user_id : undefined);
 	const planType = typeof auth?.chatgpt_plan_type === "string" ? auth.chatgpt_plan_type : undefined;
 	const email = typeof profile?.email === "string" ? profile.email : undefined;
 	return { accountId, planType, email };
@@ -2099,6 +2131,24 @@ function registerSub(pi: ExtensionAPI, entry: SubEntry): void {
 
 	const name = subProviderName(entry);
 	const oauth = template.buildOAuth?.(entry.index);
+
+	if (entry.provider === "antigravity" || entry.provider === "google-antigravity") {
+		const models = getCurrentAntigravityCatalog().models.map((m) => ({
+			...m,
+			name: `${m.name || m.id} (#${entry.index})`,
+		}));
+		pi.registerProvider(name, {
+			name: `Antigravity #${entry.index}`,
+			baseUrl: ANTIGRAVITY_ENDPOINT,
+			api: ANTIGRAVITY_API,
+			oauth,
+			models,
+			refreshModels: refreshAntigravityModels,
+			streamSimple: streamAntigravity,
+		});
+		return;
+	}
+
 	const modifyModels = oauth ? template.buildModifyModels?.(name) : undefined;
 	const builtinModels = getModels(entry.provider as any) as Model<Api>[];
 	const baseUrl = builtinModels[0]?.baseUrl || "";
@@ -2129,13 +2179,73 @@ const RATE_LIMIT_PATTERNS = [
 	/capacity/i,
 	/429/,
 	/quota/i,
+	/out of budget/i,
+	/insufficient_quota/i,
+	/billing/i,
+	/GoUsageLimitError/i,
+	/FreeUsageLimitError/i,
+	/available balance/i,
+	/ResourceExhausted/i,
 ];
 
 function isRateLimitError(errorMessage: string): boolean {
 	return RATE_LIMIT_PATTERNS.some((p) => p.test(errorMessage));
 }
 
+const NON_RETRYABLE_PROVIDER_LIMIT_PATTERNS = [
+	/usage.?limit/i,
+	/limit.*reached/i,
+	/quota/i,
+	/out of budget/i,
+	/billing/i,
+	/GoUsageLimitError/i,
+	/FreeUsageLimitError/i,
+	/Monthly usage limit reached/i,
+	/available balance/i,
+	/insufficient_quota/i,
+];
+
 const PI_RETRYABLE_STATUSES = new Set([408, 409, 429]);
+
+const RETRYABLE_PROVIDER_PATTERNS = [
+	/overloaded/i,
+	/rate.?limit/i,
+	/too many requests/i,
+	/\b429\b/,
+	/\b500\b/,
+	/\b502\b/,
+	/\b503\b/,
+	/\b504\b/,
+	/\b524\b/,
+	/service.?unavailable/i,
+	/server.?error/i,
+	/internal.?error/i,
+	/provider.?returned.?error/i,
+	/exceeded request buffer limit while retrying upstream/i,
+	/network.?error/i,
+	/connection.?error/i,
+	/connection.?refused/i,
+	/connection.?lost/i,
+	/other side closed/i,
+	/fetch failed/i,
+	/socket hang up/i,
+	/timed? out/i,
+	/timeout/i,
+	/terminated/i,
+	/ResourceExhausted/i,
+];
+
+function isPiRetryEnabled(): boolean {
+	try {
+		const settingsPath = join(getAgentDir(), "settings.json");
+		if (existsSync(settingsPath)) {
+			const content = readFileSync(settingsPath, "utf-8");
+			const settings = JSON.parse(content);
+			if (settings.retry?.enabled === false) return false;
+		}
+	} catch {}
+	return true;
+}
 
 function parseHttpStatus(errorMessage: string): number | undefined {
 	const leading = errorMessage.match(/^\s*(?:Error:\s*)?(\d{3})\b/);
@@ -2145,9 +2255,19 @@ function parseHttpStatus(errorMessage: string): number | undefined {
 }
 
 function piWillRetryTurn(errorMessage: string): boolean {
+	if (!isPiRetryEnabled()) return false;
+
+	// Non-retryable account/usage/quota limits will never be retried by Pi
+	if (NON_RETRYABLE_PROVIDER_LIMIT_PATTERNS.some((p) => p.test(errorMessage))) {
+		return false;
+	}
+
 	const status = parseHttpStatus(errorMessage);
-	if (status === undefined) return true;
-	return status >= 500 || PI_RETRYABLE_STATUSES.has(status);
+	if (status !== undefined && (status >= 500 || PI_RETRYABLE_STATUSES.has(status))) {
+		return true;
+	}
+
+	return RETRYABLE_PROVIDER_PATTERNS.some((p) => p.test(errorMessage));
 }
 
 // ==========================================================================
@@ -3007,14 +3127,13 @@ class PoolManager {
 			: `pool ${nextCandidate.poolName} (${pool.strategy || "round-robin"})`;
 		this.recordTrace(`selected ${nextCandidate.provider} (${nextCandidate.modelId}) via ${route}`);
 
-		if (lastUserPrompt && !piWillRetryTurn(errorMessage)) {
+		const promptToReplay = lastUserPrompt?.trim() ? lastUserPrompt : "continue";
+		if (!piWillRetryTurn(errorMessage)) {
 			this.suppressNextStartTurn = true;
-			this.pi.sendUserMessage(lastUserPrompt, { deliverAs: "followUp" });
+			this.pi.sendUserMessage(promptToReplay, { deliverAs: "followUp" });
 			this.recordTrace("queued follow-up because pi will not retry this error");
-		} else if (piWillRetryTurn(errorMessage)) {
-			this.recordTrace("waiting for pi to retry the turn");
 		} else {
-			this.recordTrace("turn cannot be replayed because no prompt was captured");
+			this.recordTrace("waiting for pi to retry the turn");
 		}
 
 		return true;
@@ -5741,6 +5860,12 @@ async function handlePresetMenu(
 // ==========================================================================
 
 export default function multiSub(pi: ExtensionAPI) {
+	registerApiProvider({
+		api: ANTIGRAVITY_API,
+		stream: streamAntigravity,
+		streamSimple: streamAntigravity,
+	});
+
 	const config = loadGlobalConfig();
 	const envEntries = parseEnvConfig();
 	const all = normalizeEntries(mergeConfigs(config, envEntries));
@@ -5858,12 +5983,32 @@ export default function multiSub(pi: ExtensionAPI) {
 		if (assistantMsg.stopReason !== "error") return;
 		if (!assistantMsg.errorMessage) return;
 
+		// If lastUserPrompt was not captured via before_agent_start, extract it from transcript messages
+		let promptForRotation = lastUserPrompt;
+		if (!promptForRotation) {
+			for (let i = event.messages.length - 1; i >= 0; i--) {
+				const m = event.messages[i];
+				if (m.role === "user") {
+					if (typeof m.content === "string" && m.content.trim()) {
+						promptForRotation = m.content;
+						break;
+					} else if (Array.isArray(m.content)) {
+						const textPart = m.content.find((c: any) => c.type === "text") as any;
+						if (textPart?.text && textPart.text.trim()) {
+							promptForRotation = textPart.text;
+							break;
+						}
+					}
+				}
+			}
+		}
+
 		const effective = loadEffectiveConfig(ctx.cwd);
 		const rotated = await poolManager.handleError(
 			assistantMsg.errorMessage,
 			ctx.model,
 			ctx,
-			lastUserPrompt,
+			promptForRotation,
 			normalizeMultiPassConfig({
 				subscriptions: effective.subscriptions,
 				pools: effective.pools,

--- a/tests/runtime-failover-check.mjs
+++ b/tests/runtime-failover-check.mjs
@@ -99,14 +99,63 @@ function formatFailoverExhausted(poolName, currentProvider) {
   return `[pool:${poolName}] Failover exhausted after ${currentProvider}; no eligible target remained in this cascade.`;
 }
 
+const NON_RETRYABLE_PROVIDER_LIMIT_PATTERNS = [
+  /usage.?limit/i,
+  /limit.*reached/i,
+  /quota/i,
+  /out of budget/i,
+  /billing/i,
+  /GoUsageLimitError/i,
+  /FreeUsageLimitError/i,
+  /Monthly usage limit reached/i,
+  /available balance/i,
+  /insufficient_quota/i,
+];
+
 const PI_RETRYABLE_STATUSES = new Set([408, 409, 429]);
 
-function piWillRetryTurn(errorMessage) {
+const RETRYABLE_PROVIDER_PATTERNS = [
+  /overloaded/i,
+  /rate.?limit/i,
+  /too many requests/i,
+  /\b429\b/,
+  /\b500\b/,
+  /\b502\b/,
+  /\b503\b/,
+  /\b504\b/,
+  /\b524\b/,
+  /service.?unavailable/i,
+  /server.?error/i,
+  /internal.?error/i,
+  /provider.?returned.?error/i,
+  /exceeded request buffer limit while retrying upstream/i,
+  /network.?error/i,
+  /connection.?error/i,
+  /connection.?refused/i,
+  /connection.?lost/i,
+  /other side closed/i,
+  /fetch failed/i,
+  /socket hang up/i,
+  /timed? out/i,
+  /timeout/i,
+  /terminated/i,
+  /ResourceExhausted/i,
+];
+
+function piWillRetryTurn(errorMessage, retrySettings = { enabled: true }) {
+  if (!retrySettings.enabled) return false;
+
+  if (NON_RETRYABLE_PROVIDER_LIMIT_PATTERNS.some((p) => p.test(errorMessage))) {
+    return false;
+  }
+
   const leading = errorMessage.match(/^\s*(?:Error:\s*)?(\d{3})\b/);
   const field = errorMessage.match(/"status"\s*:\s*(\d{3})\b/);
   const status = leading ? Number(leading[1]) : field ? Number(field[1]) : undefined;
-  if (status === undefined) return true;
-  return status >= 500 || PI_RETRYABLE_STATUSES.has(status);
+  if (status !== undefined && (status >= 500 || PI_RETRYABLE_STATUSES.has(status))) {
+    return true;
+  }
+  return RETRYABLE_PROVIDER_PATTERNS.some((p) => p.test(errorMessage));
 }
 
 class RuntimeHarness {
@@ -393,9 +442,10 @@ class RuntimeHarness {
 
     this.notify(formatFailoverTransition(pool.name, currentModel.provider, nextCandidate), "info");
     this.setStatus("multi-pass", formatFailoverStatus(nextCandidate));
-    if (prompt && !piWillRetryTurn(errorMessage)) {
+    const promptToReplay = prompt?.trim() ? prompt : "continue";
+    if (!piWillRetryTurn(errorMessage)) {
       this.suppressNextStartTurn = true;
-      this.sendUserMessage(prompt, { deliverAs: "followUp" });
+      this.sendUserMessage(promptToReplay, { deliverAs: "followUp" });
     }
     return true;
   }
@@ -710,6 +760,51 @@ async function runReplayDeliveryChecks() {
   const snapshot = harness.snapshot();
   assert.deepEqual(snapshot.sentPrompts, [prompt]);
   assert.deepEqual(snapshot.sentPromptOptions, [{ deliverAs: "followUp" }]);
+
+  // Test Codex usage limit without HTTP status code
+  const harnessCodex = new RuntimeHarness(config, ["openai-codex", "openai-codex-2"]);
+  harnessCodex.startTurn(prompt, { provider: "openai-codex", id: "gpt-5-mini" });
+  const rotatedCodex = await harnessCodex.handleError(
+    "Codex error: The usage limit has been reached",
+    { provider: "openai-codex", id: "gpt-5-mini" },
+    prompt,
+  );
+  assert.equal(rotatedCodex, true);
+  assert.deepEqual(harnessCodex.snapshot().sentPrompts, [prompt]);
+  assert.deepEqual(harnessCodex.snapshot().sentPromptOptions, [{ deliverAs: "followUp" }]);
+
+  // Test Antigravity quota reset message without HTTP status code
+  const harnessQuota = new RuntimeHarness(config, ["openai-codex", "openai-codex-2"]);
+  harnessQuota.startTurn(prompt, { provider: "openai-codex", id: "gpt-5-mini" });
+  const rotatedQuota = await harnessQuota.handleError(
+    "Quota reached. Please wait 4h 12m for reset. Next: switch models or try again after reset.",
+    { provider: "openai-codex", id: "gpt-5-mini" },
+    prompt,
+  );
+  assert.equal(rotatedQuota, true);
+  assert.deepEqual(harnessQuota.snapshot().sentPrompts, [prompt]);
+
+  // Test 429 quota error (which Pi classifies as non-retryable)
+  const harness429Quota = new RuntimeHarness(config, ["openai-codex", "openai-codex-2"]);
+  harness429Quota.startTurn(prompt, { provider: "openai-codex", id: "gpt-5-mini" });
+  const rotated429 = await harness429Quota.handleError(
+    "429 You exceeded your current quota, please check your plan and billing details.",
+    { provider: "openai-codex", id: "gpt-5-mini" },
+    prompt,
+  );
+  assert.equal(rotated429, true);
+  assert.deepEqual(harness429Quota.snapshot().sentPrompts, [prompt]);
+
+  // Test null prompt falls back to "continue"
+  const harnessNull = new RuntimeHarness(config, ["openai-codex", "openai-codex-2"]);
+  harnessNull.startTurn(null, { provider: "openai-codex", id: "gpt-5-mini" });
+  const rotatedNull = await harnessNull.handleError(
+    "Codex error: The usage limit has been reached",
+    { provider: "openai-codex", id: "gpt-5-mini" },
+    null,
+  );
+  assert.equal(rotatedNull, true);
+  assert.deepEqual(harnessNull.snapshot().sentPrompts, ["continue"]);
 
   console.log("replay-delivery checks passed");
 }


### PR DESCRIPTION
## Summary
- add first-class Antigravity multi-subscription provider registration
- add Codex account-id fallback from chatgpt_account_id to user_id
- improve pool retry classification and follow-up replay behavior
- add changelog, lessons, memory docs, and runtime failover test updates

## Verification
- node tests/runtime-failover-check.mjs

Note: opened from hscale fork because the active token cannot push directly to hjanuschka/pi-multi-pass.